### PR TITLE
Make tray icon a toggle

### DIFF
--- a/electron/js/menu/tray.js
+++ b/electron/js/menu/tray.js
@@ -51,7 +51,8 @@ module.exports = {
     appIcon.setToolTip(config.NAME);
     appIcon.setContextMenu(contextMenu);
     appIcon.on('click', function () {
-      BrowserWindow.getAllWindows()[0].show();
+      if (BrowserWindow.getAllWindows()[0].isFocused()) BrowserWindow.getAllWindows()[0].hide();
+      else BrowserWindow.getAllWindows()[0].show();
     });
   },
 


### PR DESCRIPTION
This one is a little more presumptive and could go against your own design spec. 

The push turns the tray icon into a toggle:

If Wire is hidden, it is shown. 
If Wire is shown, but does not have focus (under other windows) it is shown. 
If Wire is in focus, it is hidden.

This is good for my personal workflow, but I will understand if you folks aren't into it! 👍 