### PR TITLE
Avoid building every arch on Linux

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -17,6 +17,7 @@
 #
 
 electron_packager = require 'electron-packager'
+os = require 'os'
 
 ELECTRON_PACKAGE_JSON = 'electron/package.json'
 PACKAGE_JSON = 'package.json'
@@ -114,6 +115,7 @@ module.exports = (grunt) ->
       linux:
         options:
           platform: 'linux'
+          arch: os.arch()
 
     'create-windows-installer':
       internal:


### PR DESCRIPTION
When building on Linux, the Gruntfile doesn't specify architecture, so we end up building on x64, i686 and ARM! 

Not sure if this will become redundant after the change to Electron-builder, but thought I'd send it your way any way. I've patched my PKGBUILD after a user complained about needing to download Electron four times. 😛 
