### PR TITLE
Use yarn with Electron-Builder too

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -167,9 +167,9 @@ module.exports = (grunt) ->
 
     shell:
       linux64:
-        command: 'npm run linux64'
+        command: 'yarn run linux64'
       linux32:
-        command: 'npm run linux32'
+        command: 'yarn run linux32'
 
 
 ###############################################################################

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "output": "wrap/dist"
   },
   "build": {
+    "npmRebuild": false,
     "linux" : {
       "category": "Network",
       "target": ["AppImage", "deb"]


### PR DESCRIPTION
With this commit, NPM can be removed as a dependency in favour of yarn. 

How important is the `npm rebuild` command before building? 

If it is imperative to rebuild the modules before packaging, a possible solution would be to add `yarn install --force` to the shell task in the Gruntfile. 