### PR TITLE
Add license info to app package.json

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -7,6 +7,7 @@
   "updateWinUrl": "https://wire-app.wire.com/win/prod/",
   "environment": "production",
   "homepage": "https://wire.com",
+  "license": "GPL-3.0",
   "author": "Wire Swiss <wireapp@wire.com>",
   "private": true,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "wire-desktop",
+  "license": "LicenseRef-LICENSE",
   "private": true,
   "scripts": {
     "preinstall": "cd electron && yarn",


### PR DESCRIPTION
This will also define the license for the built apps.
Currently, the deb shows an 'unknown' license.

The LICENSE.md file from the repository root (which specifies GNU GPLv3) is not included in the final packages; it really should be. Instead, the Github license is included.