### PR TITLE
Update deb deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "afterInstall" : "bin/deb/after-install.tpl",
       "afterRemove" : "bin/deb/after-remove.tpl",
       "category": "Network",
-      "depends": ["libappindicator1", "libnotify-bin", "libxss1", "libgconf-2-4", "libnss3", "libasound2"],
+      "depends": ["libappindicator1", "libasound2", "libgconf-2-4", "libnotify-bin", "libnss3", "libxss1"],
       "target": ["AppImage", "deb"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "afterInstall" : "bin/deb/after-install.tpl",
       "afterRemove" : "bin/deb/after-remove.tpl",
       "category": "Network",
+      "depends": ["libappindicator1", "libnotify-bin", "libxss1", "libgconf-2-4", "libnss3", "libasound2"],
       "target": ["AppImage", "deb"]
     }
   },


### PR DESCRIPTION
While these may not be missing from a typical Ubuntu install, Wire refuses to launch without at least these dependencies. This list generated from a the official Ubuntu Docker image (very minimal) in which I installed Wire. See #171 for the particular shared library `.so` files that were missing. 