### PR TITLE
Compile linux for different architectures separately

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -259,5 +259,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'win',        ['clean:win', 'update-keys', 'release-internal', 'electron:win_internal', 'create-windows-installer:internal']
   grunt.registerTask 'win-prod',   ['clean:win', 'update-keys', 'release-prod', 'electron:win_prod', 'create-windows-installer:prod']
 
-  grunt.registerTask 'linux',      ['clean:linux', 'update-keys', 'release-internal', 'shell']
-  grunt.registerTask 'linux-prod', ['clean:linux', 'update-keys', 'release-prod', 'shell']
+  grunt.registerTask 'linux-32',      ['clean:linux', 'update-keys', 'release-internal', 'shell:linux32']
+  grunt.registerTask 'linux-64',      ['clean:linux', 'update-keys', 'release-internal', 'shell:linux64']
+  grunt.registerTask 'linux-32-prod', ['clean:linux', 'update-keys', 'release-prod', 'shell:linux32']
+  grunt.registerTask 'linux-64-prod', ['clean:linux', 'update-keys', 'release-prod', 'shell:linux64']

--- a/README.md
+++ b/README.md
@@ -25,16 +25,22 @@ Based on [Electron](http://electron.atom.io).
 
 1. Install [Node.js](https://nodejs.org/)
 2. Install [Yarn](https://yarnpkg.com) (`npm install -g yarn`)
+3. Install [Grunt](https://gruntjs.com) (`npm install -g grunt-cli`)
 
 ### Clone
 
 ```shell
 git clone https://github.com/wireapp/wire-desktop.git
 cd wire-desktop
+```
+
+### Compile
+
+```shell
 yarn
 ```
 
-### Start
+### Start for debugging/developing
 
 ```shell
 yarn start
@@ -46,7 +52,7 @@ yarn start
 yarn test
 ```
 
-### Tasks
+### Package
 
 ```shell
 # Build for macOS
@@ -55,6 +61,18 @@ grunt macos-prod
 # Build for Windows
 grunt win-prod
 
-# Build for Linux
-grunt linux-prod
+# Build for Windows 32-bit on a 64-bit system
+export npm_config_target_arch=ia32
+npm install
+grunt win-prod
+
+# Build for Linux 32-bit
+export npm_config_target_arch=ia32
+npm install
+grunt linux-prod-32
+
+# Build for Linux 64-bit
+export npm_config_target_arch=x64
+npm install
+grunt linux-prod-64
 ```

--- a/electron/package.json
+++ b/electron/package.json
@@ -21,10 +21,10 @@
     "open-graph": "0.2.1",
     "raygun": "0.9.0",
     "request": "2.76.0",
-    "winston": "https://github.com/wireapp/winston.git#2.2.0-e",
-    "spellchecker": "3.3.1"
+    "spellchecker": "3.3.1",
+    "winston": "https://github.com/wireapp/winston.git#2.2.0-e"
   },
   "optionalDependencies": {
-    "node-addressbook": "https://github.com/wireapp/node-addressbook.git#1.0.1",
+    "node-addressbook": "https://github.com/wireapp/node-addressbook.git#1.0.1"
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -21,10 +21,10 @@
     "open-graph": "0.2.1",
     "raygun": "0.9.0",
     "request": "2.76.0",
-    "winston": "https://github.com/wireapp/winston.git#2.2.0-e"
+    "winston": "https://github.com/wireapp/winston.git#2.2.0-e",
+    "spellchecker": "3.3.1"
   },
   "optionalDependencies": {
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#1.0.1",
-    "spellchecker": "3.3.1"
   }
 }


### PR DESCRIPTION
The node module that does the spellcheck needs to be compiled for the architecture it is run. Currently we only compile it for the architecture of the build server, but we need need to compile it for the specific architectures (ia32 and x64) now.

Example: When compiling the linux build on x64 architecture, we currently build the spellcheck module for x64 architecture and package it together with either ia32 electron or x64 electron into deb files for ia32 and x64. The deb package for ia32 contains the ia32 electron but the x64 node module. Electron will potentially throw an error when trying to load the module, because it is not an ia32 module.

The module is build at the time `npm install` is run, therefor I propose having two separate tasks for each architecture. Maybe there is a better way.