### PR TITLE
Get user's locale on first run

### DIFF
--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -365,12 +365,12 @@ menuTemplate = [
 ];
 
 function processMenu(template, language) {
-  var strings = locale[language];
+  let strings = locale[language];
   for (let item of template) {
     if (item.submenu != null) {
       processMenu(item.submenu, language);
     }
-    if (locale.label[locale.getCurrent()] === item.label) {
+    if (locale.label[language] === item.label) {
       item.checked = true;
     }
     if (item.i18n != null && strings[item.i18n] != null) {

--- a/electron/js/squirrel.js
+++ b/electron/js/squirrel.js
@@ -25,7 +25,6 @@ const {app} = require('electron');
 
 const config = require('./config');
 const cp = require('child_process');
-const locale = require('./../../locale/locale');
 const fs = require('fs');
 const path = require('path');
 
@@ -176,7 +175,6 @@ function handleSquirrelEvent(shouldQuit, callback) {
       createStartShortcut(function() {
         createDesktopShortcut(function() {
           createStartupShortcut(function() {
-            locale.setLocale(app.getLocale());
             app.quit();
           });
         });

--- a/electron/main.js
+++ b/electron/main.js
@@ -94,16 +94,12 @@ if (process.platform !== 'darwin') {
 ///////////////////////////////////////////////////////////////////////////////
 ipcMain.once('load-webapp', function(event, online) {
   enteredWebapp = true;
-  if (baseURL.includes('?')) {
-    baseURL += '&hl=' + locale.getCurrent();
-  } else {
-    baseURL += '?hl=' + locale.getCurrent();
-  }
+  baseURL += (baseURL.includes('?') ? '&' : '?') + 'hl=' + locale.getCurrent();
   main.loadURL(baseURL);
 });
 
 ipcMain.on('loaded', function() {
-  var size = main.getSize();
+  let size = main.getSize();
   if (size[0] < config.MIN_WIDTH_MAIN || size[1] < config.MIN_HEIGHT_MAIN) {
     util.resizeToBig(main);
   }


### PR DESCRIPTION
No need for the #229.. it works because of this line: https://github.com/wireapp/wire-desktop/blob/master/electron/locale/locale.js#L64

Test it by deleting the `init.json` file.

(macOS: `~/Library/Application Support/Wire/init.json`)