### PR TITLE
Rebuild now works with yarn >= 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "output": "wrap/dist"
   },
   "build": {
-    "npmRebuild": false,
     "linux" : {
       "afterInstall" : "bin/deb/after-install.tpl",
       "afterRemove" : "bin/deb/after-remove.tpl",


### PR DESCRIPTION
``` shell
[conor@Sushi wire-desktop]$ yarn --version
0.18.0
[conor@Sushi wire-desktop]$ yarn
yarn install v0.18.0
$ cd electron && yarn
yarn install v0.18.0
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.90s.
[1/4] Resolving packages...
success Already up-to-date.
$ yarn run rebuild-native-modules
yarn run v0.18.0
$ electron-rebuild -m ./electron/node_modules -f 
Couldn't find electron-prebuilt and no --node-module-version parameter set, always rebuilding
Done in 32.12s.
Done in 35.02s.
[conor@Sushi wire-desktop]$ node_modules/.bin/build --linux --x64 --dir
Rebuilding native production dependencies for arch x64
Packaging for linux x64 using electron 1.4.10 to wrap/dist/linux-unpacked
[conor@Sushi wire-desktop]$ node_modules/.bin/build --linux --ia32 --dir
Rebuilding native production dependencies for arch ia32
Packaging for linux ia32 using electron 1.4.10 to wrap/dist/linux-ia32-unpacked
Downloading tmp-9090-0-electron-v1.4.10-linux-ia32.zip
[============================================>] 100.0% of 44.53 MB (1.84 MB/s)
```