### PR TITLE
Fix link after electron-builder changes

### DIFF
--- a/bin/deb/after-install.tpl
+++ b/bin/deb/after-install.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Link to the binary
-ln -sf '/opt/<%= executable %>/<%= executable %>' '/usr/bin/<%= executable %>'
+ln -sf '/opt/<%= productFilename %>/<%= executable %>' '/usr/local/bin/<%= executable %>'


### PR DESCRIPTION
Addresses issue raised in https://github.com/wireapp/wire-desktop/pull/163#issuecomment-270128240. 
Related electron-builder changes: https://github.com/electron-userland/electron-builder/commit/2906227d9cd41a3d2e131d5233ee897968c01b5b