### PR TITLE
Fix spelling checkbox state in system menu

### DIFF
--- a/electron/js/menu/context.js
+++ b/electron/js/menu/context.js
@@ -215,7 +215,7 @@ if (config.SPELL_SUPPORTED.indexOf(locale.getCurrent()) > -1) {
   const spellchecker = require('spellchecker');
   webFrame.setSpellCheckProvider(locale.getCurrent(), false, {
     spellCheck (text) {
-      if (!init.restore('spelling')) {
+      if (!init.restore('spelling', true)) {
         return true;
       }
       selection.isMisspelled = spellchecker.isMisspelled(text);


### PR DESCRIPTION
As of today, when spelling is not configured in init.json, the spell check is not working. 
However in this special case the checkbox "Check Spelling while typing" is enabled, implying that the spell check _should work_. But it doesn't.

The intention obviously was to make spell check enabled by default, but it never worked.

This pull request fixes the checkbox state, so that it isn't misleading anymore. This preserves the current behavior of the app.

If you want to enable spell check by default, it can be achieved with the code below. I didn't do it as it would be a breaking change, people will suddenly start seeing a spell check when it wasn't there before. 

If you still want me to do it, suggest me where to place this code better, and I will do update this pull request. Ideally it should happen some time before `systemMenu.createMenu()` is called, so that the first time the app is loaded the checkbox already has a correct state.

```
if (typeof init.restore('spelling') == 'undefined') {
    init.save('spelling', true);
}
```