### PR TITLE
Linux autostart start minimized

### DIFF
--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -33,6 +33,7 @@ var menuTemplate;
 const launcher = new autoLaunch({
   name: config.NAME,
   path: launchCmd,
+  isHidden: true,
 });
 
 function getBrowserWindow() {

--- a/electron/main.js
+++ b/electron/main.js
@@ -156,7 +156,7 @@ function showMainWindow() {
     main.webContents.openDevTools();
   }
 
-  if (!argv.startup) {
+  if (!argv.startup && !argv.hidden) {
     if (!util.isInView(main)) {
       main.center();
     }


### PR DESCRIPTION
Sorry, this probably should have been included in #154, but when I wrote that PR, I had already implemented #146 locally, so I didn't think to implement this. Anyway, as of https://github.com/wireapp/wire-desktop/commit/891a5c5ae49245bd492b4047d9744cf43cf88d22, the app will launch with a window at startup. This PR will make the app start in the tray.

I thought about changing the windows argument from `--startup` to `--hidden`, but I wasn't sure where the argument is defined. We could also use the argument `--startup` on the Linux launcher, but only once https://github.com/Teamwork/node-auto-launch/pull/47 is merged.

EDIT: This PR replaces #146, or vice-versa.