### PR TITLE
Move `directories` under `build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "type": "git",
     "url": "https://github.com/wireapp/wire-desktop.git"
   },
-  "directories": {
-    "buildResources": "resources",
-    "app": "electron",
-    "output": "wrap/dist"
-  },
   "build": {
+    "directories": {
+      "buildResources": "resources",
+      "app": "electron",
+      "output": "wrap/dist"
+    },
     "linux" : {
       "afterInstall" : "bin/deb/after-install.tpl",
       "afterRemove" : "bin/deb/after-remove.tpl",


### PR DESCRIPTION
Just doing as I'm told :wink: 

``` shell
$ node_modules/.bin/build --linux --x64 --dir

⚠️  "directories" in the root is deprecated, please specify in the "build"
Rebuilding native production dependencies for linux:x64
Packaging for linux x64 using electron 1.4.14 to wrap/dist/linux-unpacked
```