### PR TITLE
Disable asar for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "linux" : {
       "afterInstall" : "bin/deb/after-install.tpl",
       "afterRemove" : "bin/deb/after-remove.tpl",
+      "asar": false,
       "category": "Network",
       "depends": ["libappindicator1", "libasound2", "libgconf-2-4", "libnotify-bin", "libnss3", "libxss1"],
       "target": ["AppImage", "deb"]


### PR DESCRIPTION
This is a temporary workaround for atom/node-spellchecker#49, as suggested by @ConorIA in #334. 

I confirm that it does fix the issue.

Disabling only for Linux since the original bug describes this as a Linux-only issue, though I didn't verify this.