### PR TITLE
Preferably retrieve BrowserWindow by ID

### DIFF
--- a/electron/js/menu/developer.js
+++ b/electron/js/menu/developer.js
@@ -19,47 +19,48 @@
 
 'use strict';
 
-const {BrowserWindow, MenuItem} = require('electron');
+const {MenuItem} = require('electron');
 const config = require('./../config');
+const windowManager = require('./../window-manager');
 
-function getBrowserWindow() {
-  return BrowserWindow.getFocusedWindow();
+function getPrimaryWindow() {
+  return windowManager.getPrimaryWindow();
 }
 
 var reloadTemplate = {
   label: 'Reload',
-  click: function() {getBrowserWindow().reload();},
+  click: function() {getPrimaryWindow().reload();},
 };
 
 var devToolsTemplate = {
   label: 'Toggle DevTools',
   accelerator: 'Alt+CmdOrCtrl+I',
-  click: function() {getBrowserWindow().toggleDevTools();},
+  click: function() {getPrimaryWindow().toggleDevTools();},
 };
 
 var devProductionTemplate = {
   label: 'Production',
-  click: function() {getBrowserWindow().loadURL(config.PRODUCTION_URL);},
+  click: function() {getPrimaryWindow().loadURL(config.PRODUCTION_URL);},
 };
 
 var devStagingTemplate = {
   label: 'Staging',
-  click: function() {getBrowserWindow().loadURL(config.STAGING_URL);},
+  click: function() {getPrimaryWindow().loadURL(config.STAGING_URL);},
 };
 
 var devDevTemplate = {
   label: 'Dev',
-  click: function() {getBrowserWindow().loadURL(config.DEV_URL);},
+  click: function() {getPrimaryWindow().loadURL(config.DEV_URL);},
 };
 
 var devEdgeTemplate = {
   label: 'Edge',
-  click: function() {getBrowserWindow().loadURL(config.EDGE_URL);},
+  click: function() {getPrimaryWindow().loadURL(config.EDGE_URL);},
 };
 
 var devLocalhostTemplate = {
   label: 'Localhost',
-  click: function() {getBrowserWindow().loadURL(config.LOCALHOST_URL);},
+  click: function() {getPrimaryWindow().loadURL(config.LOCALHOST_URL);},
 };
 
 var versionTemplate = {

--- a/electron/js/menu/developer.js
+++ b/electron/js/menu/developer.js
@@ -23,9 +23,11 @@ const {MenuItem} = require('electron');
 const config = require('./../config');
 const windowManager = require('./../window-manager');
 
+
 function getPrimaryWindow() {
   return windowManager.getPrimaryWindow();
 }
+
 
 var reloadTemplate = {
   label: 'Reload',

--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -26,6 +26,7 @@ var launchCmd = (process.env.APPIMAGE != null) ? process.env.APPIMAGE : process.
 const config = require('./../config');
 const init = require('./../lib/init');
 const locale = require('./../../locale/locale');
+const windowManager = require('./../window-manager');
 
 let menu;
 var menuTemplate;
@@ -36,15 +37,15 @@ const launcher = new autoLaunch({
   isHidden: true,
 });
 
-function getBrowserWindow() {
-  return BrowserWindow.getFocusedWindow();
+function getPrimaryWindow() {
+  return windowManager.getPrimaryWindow();
 }
 
 // TODO: disable menus when not in focus
 function sendAction(action) {
-  const window = getBrowserWindow();
+  const window = getPrimaryWindow();
   if (window) {
-    getBrowserWindow().webContents.send(action);
+    getPrimaryWindow().webContents.send(action);
   }
 }
 
@@ -222,11 +223,12 @@ var showWireTemplate = {
 var toggleMenuTemplate = {
   i18n: 'menuShowHide',
   click: function() {
-    if (getBrowserWindow().isMenuBarAutoHide()) {
-      getBrowserWindow().setAutoHideMenuBar(false);
+    mainBrowserWindow = getPrimaryWindow();
+    if (mainBrowserWindow.isMenuBarAutoHide()) {
+      mainBrowserWindow.setAutoHideMenuBar(false);
     } else {
-      getBrowserWindow().setAutoHideMenuBar(true);
-      getBrowserWindow().setMenuBarVisibility(false);
+      mainBrowserWindow.setAutoHideMenuBar(true);
+      mainBrowserWindow.setMenuBarVisibility(false);
     }
   },
 };
@@ -236,7 +238,8 @@ var toggleFullScreenTemplate = {
   type: 'checkbox',
   accelerator: process.platform === 'darwin' ? 'Alt+Command+F' : 'F11',
   click: function() {
-    getBrowserWindow().setFullScreen(!getBrowserWindow().isFullScreen());
+    mainBrowserWindow = getPrimaryWindow();
+    mainBrowserWindow.setFullScreen(!mainBrowserWindow.isFullScreen());
   },
 };
 

--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -37,9 +37,11 @@ const launcher = new autoLaunch({
   isHidden: true,
 });
 
+
 function getPrimaryWindow() {
   return windowManager.getPrimaryWindow();
 }
+
 
 // TODO: disable menus when not in focus
 function sendAction(action) {
@@ -48,6 +50,7 @@ function sendAction(action) {
     getPrimaryWindow().webContents.send(action);
   }
 }
+
 
 var separatorTemplate = {
   type: 'separator',
@@ -402,6 +405,7 @@ menuTemplate = [
   helpTemplate,
 ];
 
+
 function processMenu(template, language) {
   for (let item of template) {
     if (item.submenu != null) {
@@ -431,6 +435,7 @@ function changeLocale(language) {
     }
   });
 }
+
 
 module.exports = {
   createMenu: function() {

--- a/electron/js/window-manager.js
+++ b/electron/js/window-manager.js
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+'use strict';
+
+const {BrowserWindow} = require('electron');
+
+let primaryWindowId;
+
+function setPrimaryWindowId(newPrimaryWindowId) {
+  primaryWindowId = newPrimaryWindowId;
+};
+
+
+function getPrimaryWindow() {
+  if (primaryWindowId) {
+    return BrowserWindow.fromId(primaryWindowId);
+  }
+};
+
+module.exports = {
+  setPrimaryWindowId: setPrimaryWindowId,
+  getPrimaryWindow: getPrimaryWindow,
+};

--- a/electron/js/window-manager.js
+++ b/electron/js/window-manager.js
@@ -23,6 +23,7 @@ const {BrowserWindow} = require('electron');
 
 let primaryWindowId;
 
+
 function setPrimaryWindowId(newPrimaryWindowId) {
   primaryWindowId = newPrimaryWindowId;
 };
@@ -33,6 +34,7 @@ function getPrimaryWindow() {
     return BrowserWindow.fromId(primaryWindowId);
   }
 };
+
 
 module.exports = {
   setPrimaryWindowId: setPrimaryWindowId,

--- a/electron/main.js
+++ b/electron/main.js
@@ -166,6 +166,7 @@ function showMainWindow() {
       main.center();
     }
 
+    discloseWindowID(main);
     setTimeout(function() {
       main.show();
     }, 800);
@@ -252,6 +253,11 @@ function showAboutWindow() {
   }
   about.show();
 }
+
+function discloseWindowID(browserWindow) {
+  const windowManager = require('./js/window-manager');
+  windowManager.setPrimaryWindowId(browserWindow.id);
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 // APP Events


### PR DESCRIPTION
I have seen electron actions performed in the BrowserWindow fails because the currently we rely on the focussed window. Sometimes focus is on the about screen or devtools and actions thus fail resulting in errors.

This should be safe in the menu cases but I temporarly reused the code when making changes to the updater and came across this problem. This can be handled in a more robust way. I am thus disclosing the window ID of the main BrowserWindow and retrieve it based on the ID instead of focus.