### PR TITLE
Bump electron version

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -179,7 +179,7 @@ function showMainWindow() {
     if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {
       cb(-2);
     } else {
-      cb(0);
+      cb(-3);
     }
   });
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -172,7 +172,7 @@ function showMainWindow() {
   main.webContents.session.setCertificateVerifyProc(({hostname = '', certificate = {}}, cb) => {
     const {data: cert = ''} = certificate;
 
-    if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, certificate.data))) {
+    if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {
       cb(-2);
     } else {
       cb(0);

--- a/electron/main.js
+++ b/electron/main.js
@@ -169,13 +169,13 @@ function showMainWindow() {
     main.setBounds(init.restore('bounds', main.getBounds()));
   }
 
-  main.webContents.session.setCertificateVerifyProc((hostname = '', certificate = {}, cb) => {
+  main.webContents.session.setCertificateVerifyProc(({hostname = '', certificate = {}}, cb) => {
     const {data: cert = ''} = certificate;
 
-    if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {
-      cb(false);
+    if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, certificate.data))) {
+      cb(-2);
     } else {
-      cb(true);
+      cb(0);
     }
   });
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -173,7 +173,7 @@ function showMainWindow() {
     const { hostname = '', certificate: { data: cert = '' } = {}, error } = request;
 
     if (error !== undefined) {
-      return cb(0);
+      return cb(-2);
     }
 
     if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -173,7 +173,7 @@ function showMainWindow() {
     const { hostname = '', certificate: { data: cert = '' } = {}, error } = request;
 
     if (error !== undefined) {
-      return cb(0)
+      return cb(0);
     }
 
     if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -169,8 +169,12 @@ function showMainWindow() {
     main.setBounds(init.restore('bounds', main.getBounds()));
   }
 
-  main.webContents.session.setCertificateVerifyProc(({hostname = '', certificate = {}}, cb) => {
-    const {data: cert = ''} = certificate;
+  main.webContents.session.setCertificateVerifyProc((request, cb) => {
+    const { hostname = '', certificate: { data: cert = '' } = {}, error } = request;
+
+    if (error !== undefined) {
+      return cb(0)
+    }
 
     if (certutils.hostnameShouldBePinned(hostname) && !(certutils.verifyPinning(hostname, cert))) {
       cb(-2);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "devDependencies": {
-    "electron": "1.4.15",
+    "electron": "1.6.1",
     "electron-builder": "13.11.1",
     "electron-mocha": "3.3.0",
     "electron-packager": "8.5.2",


### PR DESCRIPTION
electron recently changed the the `setCertificateVerifyProc`api. so in order to update to 1.6.1 we need update the certificate verification code on our side.

see: https://github.com/electron/electron/blob/master/docs/api/session.md#sessetcertificateverifyprocproc

