### PR TITLE
Call 'app.quit()' after 'app.relaunch()'

### DIFF
--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -428,8 +428,8 @@ function changeLocale(language) {
     buttons: [locale[language].restartLater, locale[language].restartNow],
   }, function(response) {
     if (response == 1) {
-      app.quit();
       app.relaunch();
+      app.quit();
     }
   });
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -145,8 +145,8 @@ ipcMain.on('google-auth-request', function(event) {
 });
 
 ipcMain.on('wrapper-reload', function() {
-  app.quit();
   app.relaunch();
+  app.quit();
 });
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
https://electron.atom.io/docs/api/app/#apprelaunchoptions

According to electron docs 'app.quit' should be called AFTER 'app.relaunch'