### PR TITLE
Make the preference to hide the menu sticky

### DIFF
--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -223,6 +223,8 @@ let showWireTemplate = {
 
 let toggleMenuTemplate = {
   i18n: 'menuShowHide',
+  type: 'checkbox',
+  checked: !init.restore('hideMenu', false),
   click: function() {
     let mainBrowserWindow = getPrimaryWindow();
     if (mainBrowserWindow.isMenuBarAutoHide()) {

--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -227,9 +227,11 @@ let toggleMenuTemplate = {
     let mainBrowserWindow = getPrimaryWindow();
     if (mainBrowserWindow.isMenuBarAutoHide()) {
       mainBrowserWindow.setAutoHideMenuBar(false);
+      init.save('hideMenu', false);
     } else {
       mainBrowserWindow.setAutoHideMenuBar(true);
       mainBrowserWindow.setMenuBarVisibility(false);
+      init.save('hideMenu', true);
     }
   },
 };

--- a/electron/js/menu/system.js
+++ b/electron/js/menu/system.js
@@ -224,16 +224,16 @@ let showWireTemplate = {
 let toggleMenuTemplate = {
   i18n: 'menuShowHide',
   type: 'checkbox',
-  checked: !init.restore('hideMenu', false),
+  checked: init.restore('showMenu', true),
   click: function() {
     let mainBrowserWindow = getPrimaryWindow();
     if (mainBrowserWindow.isMenuBarAutoHide()) {
       mainBrowserWindow.setAutoHideMenuBar(false);
-      init.save('hideMenu', false);
+      init.save('showMenu', true);
     } else {
       mainBrowserWindow.setAutoHideMenuBar(true);
       mainBrowserWindow.setMenuBarVisibility(false);
-      init.save('hideMenu', true);
+      init.save('showMenu', false);
     }
   },
 };

--- a/electron/locale/strings-en.js
+++ b/electron/locale/strings-en.js
@@ -48,7 +48,7 @@ string.menuHideOthers = 'Hide Others';
 string.menuShowAll = 'Show All';
 string.menuSettings = 'Settings';
 string.menuQuit = 'Quit Wire';
-string.menuShowHide = 'Show/Hide Menu';
+string.menuShowHide = 'Show Menu';
 string.menuSavePictureAs = 'Save Picture As...';
 string.menuNoSuggestions = 'No Suggestions';
 

--- a/electron/locale/strings.js
+++ b/electron/locale/strings.js
@@ -46,7 +46,7 @@ string.menuHideOthers = 'Hide Others';
 string.menuShowAll = 'Show All';
 string.menuSettings = 'Settings';
 string.menuQuit = 'Quit Wire';
-string.menuShowHide = 'Show/Hide Menu';
+string.menuShowHide = 'Show Menu';
 string.menuSavePictureAs = 'Save Picture As...';
 string.menuNoSuggestions = 'No Suggestions';
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -165,7 +165,7 @@ function showMainWindow() {
     'height': config.DEFAULT_HEIGHT_MAIN,
     'minWidth': config.MIN_WIDTH_MAIN,
     'minHeight': config.MIN_HEIGHT_MAIN,
-    'autoHideMenuBar': init.restore('hideMenu', false),
+    'autoHideMenuBar': !init.restore('showMenu', true),
     'icon': ICON_PATH,
     'show': false,
     'webPreferences': {

--- a/electron/main.js
+++ b/electron/main.js
@@ -165,7 +165,7 @@ function showMainWindow() {
     'height': config.DEFAULT_HEIGHT_MAIN,
     'minWidth': config.MIN_WIDTH_MAIN,
     'minHeight': config.MIN_HEIGHT_MAIN,
-    'autoHideMenuBar': false,
+    'autoHideMenuBar': init.restore('hideMenu', false),
     'icon': ICON_PATH,
     'show': false,
     'webPreferences': {


### PR DESCRIPTION
A couple of questions here: 

1. Should the menu item be a check box?
2. Should the menu item be changed to "Hide the menu bar by default"?

As it stands now, a user might choose to hide them menu bar. If that user hits 'Alt', the user *might* think that the menu bar will now remain visible, however it will disappear again on restart, unless the user remembers to click on the "Show/Hide Menu Bar" item again. Maybe this isn't intuitive. 