### PR TITLE
Update windows deploy scripts

### DIFF
--- a/bin/win-prod-s3-deploy.py
+++ b/bin/win-prod-s3-deploy.py
@@ -40,7 +40,7 @@ NEW_EXE_KEY = S3_PATH + NEW_EXE
 OLD_RELEASE_KEY = S3_PATH + 'RELEASES'
 OLD_EXE_KEY = S3_PATH + 'WireSetup.exe'
 
-s3 = boto3.resource('s3');
+s3 = boto3.resource('s3')
 
 s3.Object(BUCKET, OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY

--- a/bin/win-prod-s3-deploy.py
+++ b/bin/win-prod-s3-deploy.py
@@ -42,14 +42,14 @@ OLD_EXE_KEY = S3_PATH + 'WireSetup.exe'
 
 s3 = boto3.resource('s3');
 
-s3.Object(BUCKET,OLD_RELEASE_KEY).delete()
+s3.Object(BUCKET, OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY
 
-s3.Object(BUCKET,OLD_EXE_KEY).delete()
+s3.Object(BUCKET, OLD_EXE_KEY).delete()
 print 'deleted %s' % OLD_EXE_KEY
 
-s3.Object(BUCKET,OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
+s3.Object(BUCKET, OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
 print 'copied %s to %s ' % (NEW_RELEASE_KEY, OLD_RELEASE_KEY)
 
-s3.Object(BUCKET,OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
+s3.Object(BUCKET, OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
 print 'copied %s to %s ' % (NEW_EXE_KEY, OLD_EXE_KEY)

--- a/bin/win-prod-s3-deploy.py
+++ b/bin/win-prod-s3-deploy.py
@@ -40,20 +40,16 @@ NEW_EXE_KEY = S3_PATH + NEW_EXE
 OLD_RELEASE_KEY = S3_PATH + 'RELEASES'
 OLD_EXE_KEY = S3_PATH + 'WireSetup.exe'
 
-client = boto3.client(
-  's3',
-  aws_access_key_id=os.environ.get('AWS_ACCESS_KEY'),
-  aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY')
-)
+s3 = boto3.resource('s3');
 
-client.delete_object(Bucket=BUCKET, Key=OLD_RELEASE_KEY)
+s3.Object(BUCKET,OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY
 
-client.delete_object(Bucket=BUCKET, Key=OLD_EXE_KEY)
+s3.Object(BUCKET,OLD_EXE_KEY).delete()
 print 'deleted %s' % OLD_EXE_KEY
 
-client.copy_object(Bucket=BUCKET, CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY), Key=OLD_RELEASE_KEY)
+s3.Object(BUCKET,OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
 print 'copied %s to %s ' % (NEW_RELEASE_KEY, OLD_RELEASE_KEY)
 
-client.copy_object(Bucket=BUCKET, CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY), Key=OLD_EXE_KEY)
+s3.Object(BUCKET,OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
 print 'copied %s to %s ' % (NEW_EXE_KEY, OLD_EXE_KEY)

--- a/bin/win-prod-s3.py
+++ b/bin/win-prod-s3.py
@@ -33,7 +33,7 @@ info_json = os.path.join(bin_root, '..', 'info.json')
 
 def upload_file(source, dest):
   if not os.path.isfile(source):
-    print '%s not found'
+    print '%s not found' % source
     return
 
   print 'Uploading %s to %s' % (os.path.basename(source), dest),

--- a/bin/win-s3-deploy.py
+++ b/bin/win-s3-deploy.py
@@ -40,7 +40,7 @@ NEW_EXE_KEY = S3_PATH + NEW_EXE
 OLD_RELEASE_KEY = S3_PATH + 'RELEASES'
 OLD_EXE_KEY = S3_PATH + 'WireInternalSetup.exe'
 
-s3 = boto3.resource('s3');
+s3 = boto3.resource('s3')
 
 s3.Object(BUCKET, OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY

--- a/bin/win-s3-deploy.py
+++ b/bin/win-s3-deploy.py
@@ -42,14 +42,14 @@ OLD_EXE_KEY = S3_PATH + 'WireInternalSetup.exe'
 
 s3 = boto3.resource('s3');
 
-s3.Object(BUCKET,OLD_RELEASE_KEY).delete()
+s3.Object(BUCKET, OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY
 
-s3.Object(BUCKET,OLD_EXE_KEY).delete()
+s3.Object(BUCKET, OLD_EXE_KEY).delete()
 print 'deleted %s' % OLD_EXE_KEY
 
-s3.Object(BUCKET,OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
+s3.Object(BUCKET, OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
 print 'copied %s to %s ' % (NEW_RELEASE_KEY, OLD_RELEASE_KEY)
 
-s3.Object(BUCKET,OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
+s3.Object(BUCKET, OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
 print 'copied %s to %s ' % (NEW_EXE_KEY, OLD_EXE_KEY)

--- a/bin/win-s3-deploy.py
+++ b/bin/win-s3-deploy.py
@@ -38,22 +38,19 @@ NEW_RELEASE_KEY = S3_PATH + NEW_RELEASE
 NEW_EXE_KEY = S3_PATH + NEW_EXE
 
 OLD_RELEASE_KEY = S3_PATH + 'RELEASES'
-OLD_EXE_KEY = S3_PATH + 'WireSetup.exe'
+OLD_EXE_KEY = S3_PATH + 'WireInternalSetup.exe'
 
-client = boto3.client(
-  's3',
-  aws_access_key_id=os.environ.get('AWS_ACCESS_KEY'),
-  aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY')
-)
+s3 = boto3.resource('s3');
 
-client.delete_object(Bucket=BUCKET, Key=OLD_RELEASE_KEY)
+s3.Object(BUCKET,OLD_RELEASE_KEY).delete()
 print 'deleted %s' % OLD_RELEASE_KEY
 
-client.delete_object(Bucket=BUCKET, Key=OLD_EXE_KEY)
+s3.Object(BUCKET,OLD_EXE_KEY).delete()
 print 'deleted %s' % OLD_EXE_KEY
 
+s3.Object(BUCKET,OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
 client.copy_object(Bucket=BUCKET, CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY), Key=OLD_RELEASE_KEY)
 print 'copied %s to %s ' % (NEW_RELEASE_KEY, OLD_RELEASE_KEY)
 
-client.copy_object(Bucket=BUCKET, CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY), Key=OLD_EXE_KEY)
+s3.Object(BUCKET,OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))
 print 'copied %s to %s ' % (NEW_EXE_KEY, OLD_EXE_KEY)

--- a/bin/win-s3-deploy.py
+++ b/bin/win-s3-deploy.py
@@ -49,7 +49,6 @@ s3.Object(BUCKET,OLD_EXE_KEY).delete()
 print 'deleted %s' % OLD_EXE_KEY
 
 s3.Object(BUCKET,OLD_RELEASE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY))
-client.copy_object(Bucket=BUCKET, CopySource='%s/%s' % (BUCKET, NEW_RELEASE_KEY), Key=OLD_RELEASE_KEY)
 print 'copied %s to %s ' % (NEW_RELEASE_KEY, OLD_RELEASE_KEY)
 
 s3.Object(BUCKET,OLD_EXE_KEY).copy_from(CopySource='%s/%s' % (BUCKET, NEW_EXE_KEY))

--- a/bin/win-s3.py
+++ b/bin/win-s3.py
@@ -52,13 +52,6 @@ if __name__ == '__main__':
   wire_nupkg_full = os.path.join(build_root, wire_nupkg)
   wire_exe_full = os.path.join(build_root, 'WireInternalSetup.exe')
 
-  with open(releases, 'r+') as f:
-    last = f.readlines()[-1]
-    f.seek(0)
-    f.write(last)
-    f.truncate()
-
   upload_file(wire_nupkg_full, '%s%s' % (S3_PATH, wire_nupkg))
   upload_file(wire_exe_full, '%swire-internal-%s.exe' % (S3_PATH, version))
-  upload_file(releases, '%sRELEASES' % S3_PATH)
   upload_file(releases, '%swire-internal-%s-RELEASES' % (S3_PATH, version))


### PR DESCRIPTION
* Both production and internal script now work the same. The s3 internal script does not upload RELEASES file directly. Instead this is now done by the deploy script (like on production).
* Fixed issue with environment variables when using client instead of resource client object on boto3 (tested with internal already)