### PR TITLE
Fix debian pre/post-install scripts

### DIFF
--- a/bin/deb/after-install.tpl
+++ b/bin/deb/after-install.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Link to the binary
-ln -sf '/opt/<%= productFilename %>/<%= executable %>' '/usr/local/bin/<%= executable %>'
+ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'

--- a/bin/deb/after-install.tpl
+++ b/bin/deb/after-install.tpl
@@ -1,4 +1,22 @@
 #!/bin/bash
 
+old_exec="/opt/Wire/wire";
+
+# Warn if old package is still installed
+if test -e "${old_exec}"; then
+  echo "WARNING: It seems that there are files from the old Wire package on"
+  echo "your machine. We highly recommend that you remove the old version"
+  echo "and then reinstall this package. You can remove the old package with"
+  echo "the following command:"
+  echo "sudo apt-get remove wire"
+fi
+
+# Clean up old invalid links
+if [ -L '/usr/local/bin/wire' ] || [ -L '/usr/local/bin/<%= executable %>' ]; then
+  echo "Removing old invalid symlinks"
+  if [ -L '/usr/local/bin/wire' ] && [ "$(readlink '/usr/local/bin/wire')" = "${old_exec}" ]; then rm -f /usr/local/bin/wire; fi
+  if [ -L '/usr/local/bin/<%= executable %>' ] && [ "$(readlink '/usr/local/bin/<%= executable %>')" = '/opt/<% productFilename %>/<%= executable %>' ]; then rm -f '/usr/local/bin/<%= executable %>'; fi
+fi
+
 # Link to the binary
 ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'

--- a/bin/deb/after-remove.tpl
+++ b/bin/deb/after-remove.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Delete the link to the binary
-rm -f '/usr/bin/<%= executable %>'
+rm -f '/usr/bin/${executable}'


### PR DESCRIPTION
A [change on the `electron-builder` side](https://github.com/electron-userland/electron-builder/commit/fe137fc221f46683433cc7dc86984caeab281d84) broke the `after-install.tpl` and `after-remove.tpl` scripts. This resolves #602, but the bad links might still exist for some users.