### PR TITLE
Update libsodium-neon to 2.1.0

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -30,7 +30,7 @@
     "electron-build-env": "0.2.0"
   },
   "optionalDependencies": {
-    "libsodium-neon": "2.0.6",
+    "libsodium-neon": "2.1.0",
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#2.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This enables MSVC and updates `neon` in `libsodium-neon`.