### PR TITLE
Easier rebuild of native modules

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -27,13 +27,16 @@
     "winston": "https://github.com/wireapp/winston.git#2.2.0-e"
   },
   "devDependencies": {
-    "electron-build-env": "0.2.0"
+    "cross-spawn": "5.1.0",
+    "electron-build-env": "0.2.0",
+    "electron-rebuild": "1.5.11"
   },
   "optionalDependencies": {
     "libsodium-neon": "2.1.0",
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#2.0.0"
   },
   "scripts": {
-    "rebuild-neon": "electron-build-env neon build libsodium-neon"
+    "rebuild-native-modules": "node ./rebuild-native-modules.js \"electron-rebuild\" \"-f -m ./\" && npm run rebuild-neon",
+    "rebuild-neon": "node ./rebuild-native-modules.js \"electron-build-env\" \"neon build libsodium-neon\""
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -36,7 +36,7 @@
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#2.0.0"
   },
   "scripts": {
-    "rebuild-native-modules": "node ./rebuild-native-modules.js \"electron-rebuild\" \"-f -m ./\" && npm run rebuild-neon",
+    "rebuild-native-modules": "node ./rebuild-native-modules.js \"electron-rebuild\" \"-f -m ./\"",
     "rebuild-neon": "node ./rebuild-native-modules.js \"electron-build-env\" \"neon build libsodium-neon\""
   }
 }

--- a/electron/rebuild-native-modules.js
+++ b/electron/rebuild-native-modules.js
@@ -39,7 +39,7 @@ if (args.length === 1) {
   const [command] = normalize(args);
   const proc = exec(command, (error, stdout, stderr) => {
     if (error) {
-      console.error('Execution error: ', error);
+      console.error('Execution error:', error);
       return;
     }
     process.stdout.write(stdout);

--- a/electron/rebuild-native-modules.js
+++ b/electron/rebuild-native-modules.js
@@ -27,8 +27,8 @@ const arch = process.env.wire_target_arch ? process.env.wire_target_arch : proce
 const normalize = (args) => {
   return args.map((arg) => {
     Object.keys(process.env).forEach((key) => {
-      const regex = new RegExp(`\\$${key}|%${key}%`, 'i');
-      arg = arg.replace(regex, process.env[key]);
+      const variableRegex = new RegExp(`\\$${key}|%${key}%`, 'i');
+      arg = arg.replace(variableRegex, process.env[key]);
     });
     return arg;
   });
@@ -39,7 +39,7 @@ if (args.length === 1) {
   const [command] = normalize(args);
   const proc = exec(command, (error, stdout, stderr) => {
     if (error) {
-      console.error(`exec error: ${error}`);
+      console.error('Execution error: ', error);
       return;
     }
     process.stdout.write(stdout);

--- a/electron/rebuild-native-modules.js
+++ b/electron/rebuild-native-modules.js
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
-
 /*
-   This is elijahmanor's cross-var (v1.0.3) with a few modifications.
-   https://github.com/elijahmanor/cross-var
-*/
+ * Wire
+ * Copyright (C) 2017 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
 
 'use strict';
 
@@ -13,8 +26,8 @@ const arch = process.env.wire_target_arch ? process.env.wire_target_arch : proce
 
 const normalize = (args) => {
   return args.map((arg) => {
-    Object.keys(process.env).forEach(key => {
-      const regex = new RegExp(`\\$${key }|%${key }%`, 'i');
+    Object.keys(process.env).forEach((key) => {
+      const regex = new RegExp(`\\$${key}|%${key}%`, 'i');
       arg = arg.replace(regex, process.env[key]);
     });
     return arg;

--- a/electron/rebuild-native-modules.js
+++ b/electron/rebuild-native-modules.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/*
+   This is elijahmanor's cross-var (v1.0.3) with a few modifications.
+   https://github.com/elijahmanor/cross-var
+*/
+
+'use strict';
+
+const spawn = require('cross-spawn');
+const exec = require('child_process').exec;
+const arch = process.env.wire_target_arch ? process.env.wire_target_arch : process.arch;
+
+const normalize = (args) => {
+  return args.map((arg) => {
+    Object.keys(process.env).forEach(key => {
+      const regex = new RegExp(`\\$${key }|%${key }%`, 'i');
+      arg = arg.replace(regex, process.env[key]);
+    });
+    return arg;
+  });
+};
+
+let args = process.argv.slice(2);
+if (args.length === 1) {
+  const [command] = normalize(args);
+  const proc = exec(command, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    process.stdout.write(stdout);
+    process.stderr.write(stderr);
+    process.exit(proc.code);
+  });
+} else {
+  args = normalize(args);
+  const command = args.shift();
+  args.unshift('--arch', arch, '--');
+  const proc = spawn.sync(command, args, {stdio: 'inherit'});
+  process.exit(proc.status);
+}

--- a/package.json
+++ b/package.json
@@ -4,14 +4,12 @@
   "private": true,
   "scripts": {
     "preinstall": "cd electron && npm install",
-    "install": "npm run rebuild-native-modules",
-    "postinstall": "cd electron && npm run rebuild-neon",
+    "install": "cd electron && npm run rebuild-native-modules",
     "start": "electron electron --inspect --devtools --enable-logging",
     "staging": "electron electron --inspect --devtools --enable-logging --env=https://wire-webapp-staging.zinfra.io",
     "prod": "electron electron --inspect --devtools --enable-logging --env=https://app.wire.com",
     "localhost": "electron electron --inspect --devtools --enable-logging --env=http://localhost:8888",
     "test": "eslint electron && electron-mocha tests",
-    "rebuild-native-modules": "electron-rebuild -f -m ./electron/node_modules",
     "build:macos": "grunt macos-prod",
     "build:win": "grunt win-prod",
     "build:linux": "grunt linux-prod"
@@ -32,7 +30,6 @@
     "electron-builder": "12.3.1",
     "electron-mocha": "3.4.0",
     "electron-packager": "8.6.0",
-    "electron-rebuild": "1.4.0",
     "electron-winstaller": "2.5.2",
     "eslint": "3.19.0",
     "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "preinstall": "cd electron && npm install",
     "install": "cd electron && npm run rebuild-native-modules",
+    "postinstall": "cd electron && npm run rebuild-neon",
     "start": "electron electron --inspect --devtools --enable-logging",
     "staging": "electron electron --inspect --devtools --enable-logging --env=https://wire-webapp-staging.zinfra.io",
     "prod": "electron electron --inspect --devtools --enable-logging --env=https://app.wire.com",


### PR DESCRIPTION
* When we rebuild native modules, we can now set the target architecture with the environment variable `wire_target_arch`.
* Updated `electron-rebuild`.