### PR TITLE
Make custom Linux builds easier

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -316,4 +316,4 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'linux',       ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
   grunt.registerTask 'linux-prod',  ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
-  grunt.registerTask 'linux-other', ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_other']
+  grunt.registerTask 'linux-other', ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_other']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -306,13 +306,14 @@ module.exports = (grunt) ->
     execSync = require('child_process').execSync
     execSync 'npm run bundle'
 
-  grunt.registerTask 'release',    ['build-inc', 'gitcommit', 'gittag', 'gitpush']
+  grunt.registerTask 'release',     ['build-inc', 'gitcommit', 'gittag', 'gitpush']
 
-  grunt.registerTask 'macos',      ['clean:macos', 'update-keys', 'release-internal', 'bundle', 'electron:macos_internal']
-  grunt.registerTask 'macos-prod', ['clean:macos', 'update-keys', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
+  grunt.registerTask 'macos',       ['clean:macos', 'update-keys', 'release-internal', 'bundle', 'electron:macos_internal']
+  grunt.registerTask 'macos-prod',  ['clean:macos', 'update-keys', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
 
-  grunt.registerTask 'win',        ['clean:win', 'update-keys', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
-  grunt.registerTask 'win-prod',   ['clean:win', 'update-keys', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
+  grunt.registerTask 'win',         ['clean:win', 'update-keys', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
+  grunt.registerTask 'win-prod',    ['clean:win', 'update-keys', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
 
-  grunt.registerTask 'linux',      ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
-  grunt.registerTask 'linux-prod', ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
+  grunt.registerTask 'linux',       ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
+  grunt.registerTask 'linux-prod',  ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
+  grunt.registerTask 'linux-other', ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_other']

--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ npm run build:linux
 
 ### Other Linux targets or architectures
 
-If you would like to build for another Linux target or architecture, run the following commands:
+If you would like to build for another Linux target or architecture, run the following command:
 
-```bash
-grunt 'clean:linux' 'update-keys' 'release-prod'
-grunt --arch=<arch> --target=<target> 'electronbuilder:linux_other'
+```shell
+grunt --arch=<arch> --target=<target> linux-other
 ```
 
 Replace `<arch>` and `<target>` with your desired architecture (e.g. `"ia32"`) and target (e.g. `"rpm"`). Have a look at the [documentation for `electron-builder`](https://github.com/electron-userland/electron-builder/wiki/Options) for the available options. Note that we cannot offer support for uncommon architectures or targets.


### PR DESCRIPTION
Currently, the 'bundle' task is missing from the README. 
I thought to send a PR to update the README, but it occurred to me that this might be easier for end-users to get their heads around. 