### PR TITLE
Use build id from Jenkins CI jobs in version number

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -31,7 +31,7 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON PACKAGE_JSON
     info: grunt.file.readJSON INFO_JSON
-    build_number: "#{process.env.BUILD_NUMBER or 'local'}"
+    build_number: "#{process.env.BUILD_NUMBER or '0'}"
 
     clean:
       wrap: 'wrap'
@@ -212,24 +212,32 @@ module.exports = (grunt) ->
   grunt.registerTask 'release-internal', ->
     info = grunt.config.get 'info'
     build_number = grunt.config.get 'build_number'
+    commit_id = grunt.config('gitinfo.local.branch.current.shortSHA')
     electron_pkg = grunt.file.readJSON ELECTRON_PACKAGE_JSON
     electron_pkg.updateWinUrl = info.updateWinUrlInternal
     electron_pkg.environment = 'internal'
     electron_pkg.name = info.nameInternal.toLowerCase()
     electron_pkg.productName = info.nameInternal
-    electron_pkg.version = "#{info.version}.#{build_number}-internal"
+    if(build_number == '0')
+      electron_pkg.version = "#{info.version}.0-#{commit_id}-internal"
+    else
+      electron_pkg.version = "#{info.version}.#{build_number}-internal"
     grunt.file.write ELECTRON_PACKAGE_JSON, "#{JSON.stringify electron_pkg, null, 2}\n"
     grunt.log.write("Releases URL points to #{electron_pkg.updateWinUrl} ").ok();
 
   grunt.registerTask 'release-prod', ->
     info = grunt.config.get 'info'
     build_number = grunt.config.get 'build_number'
+    commit_id = grunt.config('gitinfo.local.branch.current.shortSHA')
     electron_pkg = grunt.file.readJSON ELECTRON_PACKAGE_JSON
     electron_pkg.updateWinUrl = info.updateWinUrlProd
     electron_pkg.environment = 'production'
     electron_pkg.name = info.name.toLowerCase()
     electron_pkg.productName = info.name
-    electron_pkg.version = "#{info.version}.#{build_number}"
+    if(build_number == '0')
+      electron_pkg.version = "#{info.version}.0-#{commit_id}"
+    else
+      electron_pkg.version = "#{info.version}.#{build_number}"
     grunt.file.write ELECTRON_PACKAGE_JSON, "#{JSON.stringify electron_pkg, null, 2}\n"
     grunt.log.write("Releases URL points to #{electron_pkg.updateWinUrl} ").ok();
 
@@ -307,12 +315,12 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'bump-version',  ['version-inc', 'gitcommit', 'gitpush']
 
-  grunt.registerTask 'macos',         ['clean:macos', 'update-keys', 'release-internal', 'bundle', 'electron:macos_internal']
-  grunt.registerTask 'macos-prod',    ['clean:macos', 'update-keys', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
+  grunt.registerTask 'macos',         ['clean:macos', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:macos_internal']
+  grunt.registerTask 'macos-prod',    ['clean:macos', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
 
-  grunt.registerTask 'win',           ['clean:win', 'update-keys', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
-  grunt.registerTask 'win-prod',      ['clean:win', 'update-keys', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
+  grunt.registerTask 'win',           ['clean:win', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
+  grunt.registerTask 'win-prod',      ['clean:win', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
 
-  grunt.registerTask 'linux',         ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
-  grunt.registerTask 'linux-prod',    ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
-  grunt.registerTask 'linux-other',   ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_other']
+  grunt.registerTask 'linux',         ['clean:linux', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
+  grunt.registerTask 'linux-prod',    ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
+  grunt.registerTask 'linux-other',   ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_other']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -221,6 +221,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'release-prod', ->
     info = grunt.config.get 'info'
+    build_number = grunt.config.get 'build_number'
     electron_pkg = grunt.file.readJSON ELECTRON_PACKAGE_JSON
     electron_pkg.updateWinUrl = info.updateWinUrlProd
     electron_pkg.environment = 'production'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -31,6 +31,7 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON PACKAGE_JSON
     info: grunt.file.readJSON INFO_JSON
+    build_number: "#{process.env.BUILD_NUMBER or 'local'}"
 
     clean:
       wrap: 'wrap'
@@ -65,7 +66,7 @@ module.exports = (grunt) ->
         asar: true
         appCopyright: '<%= info.copyright %>'
         appVersion: '<%= info.version %>'
-        buildVersion: '<%= info.build %>'
+        buildVersion: '<%= build_number %>'
         ignore: 'electron/renderer/src'
         protocols: [
           {name: '', schemes: ['wire']}
@@ -149,7 +150,7 @@ module.exports = (grunt) ->
       internal:
         title: '<%= info.nameInternal %>'
         description: '<%= info.description %>'
-        version: '<%= info.version %>.<%= info.build %>'
+        version: '<%= info.version %>.<%= build_number %>'
         appDirectory: 'wrap/build/<%= info.nameInternal %>-win32-ia32'
         outputDirectory: 'wrap/internal/<%= info.nameInternal %>-win32-ia32'
         authors: '<%= info.nameInternal %>'
@@ -161,7 +162,7 @@ module.exports = (grunt) ->
       prod:
         title: '<%= info.name %>'
         description: '<%= info.description %>'
-        version: '<%= info.version %>.<%= info.build %>'
+        version: '<%= info.version %>.<%= build_number %>'
         appDirectory: 'wrap/build/<%= info.name %>-win32-ia32'
         outputDirectory: 'wrap/prod/<%= info.name %>-win32-ia32'
         authors: '<%= info.name %>'
@@ -174,15 +175,9 @@ module.exports = (grunt) ->
     gitcommit:
       release:
         options:
-          message: 'Release <%= info.version %>.<%= info.build %>'
+          message: 'Bump version to <%= info.version %>'
         files:
           src: [INFO_JSON, ELECTRON_PACKAGE_JSON]
-
-    gittag:
-      release:
-        options:
-          tag: 'release/<%= info.version %>.<%= info.build %>'
-          message: 'Release <%= info.version %>.<%= info.build %>'
 
     gitpush:
       task:
@@ -202,17 +197,17 @@ module.exports = (grunt) ->
 ###############################################################################
 # Tasks
 ###############################################################################
-  grunt.registerTask 'build-inc', ->
+  grunt.registerTask 'version-inc', ->
     info = grunt.config.get 'info'
-    info.build = "#{parseInt(info.build, 10) + 1}"
+    info.version = "#{parseInt(info.version, 10) + 1}"
     grunt.config.set 'info', info
     grunt.file.write INFO_JSON, "#{JSON.stringify info, null, 2}\n"
 
     electron_pkg = grunt.file.readJSON ELECTRON_PACKAGE_JSON
-    electron_pkg.version = "#{info.version}.#{info.build}"
+    electron_pkg.version = "#{info.version}"
     grunt.file.write ELECTRON_PACKAGE_JSON, "#{JSON.stringify electron_pkg, null, 2}\n"
 
-    grunt.log.write("Build number increased to #{info.build} ").ok();
+    grunt.log.write("Version number increased to #{info.version} ").ok();
 
   grunt.registerTask 'release-internal', ->
     info = grunt.config.get 'info'
@@ -306,14 +301,14 @@ module.exports = (grunt) ->
     execSync = require('child_process').execSync
     execSync 'npm run bundle'
 
-  grunt.registerTask 'release',     ['build-inc', 'gitcommit', 'gittag', 'gitpush']
+  grunt.registerTask 'bump-version',  ['version-inc', 'gitcommit', 'gitpush']
 
-  grunt.registerTask 'macos',       ['clean:macos', 'update-keys', 'release-internal', 'bundle', 'electron:macos_internal']
-  grunt.registerTask 'macos-prod',  ['clean:macos', 'update-keys', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
+  grunt.registerTask 'macos',         ['clean:macos', 'update-keys', 'release-internal', 'bundle', 'electron:macos_internal']
+  grunt.registerTask 'macos-prod',    ['clean:macos', 'update-keys', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
 
-  grunt.registerTask 'win',         ['clean:win', 'update-keys', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
-  grunt.registerTask 'win-prod',    ['clean:win', 'update-keys', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
+  grunt.registerTask 'win',           ['clean:win', 'update-keys', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
+  grunt.registerTask 'win-prod',      ['clean:win', 'update-keys', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
 
-  grunt.registerTask 'linux',       ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
-  grunt.registerTask 'linux-prod',  ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
-  grunt.registerTask 'linux-other', ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_other']
+  grunt.registerTask 'linux',         ['clean:linux', 'update-keys', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
+  grunt.registerTask 'linux-prod',    ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
+  grunt.registerTask 'linux-other',   ['clean:linux', 'update-keys', 'release-prod', 'bundle', 'electronbuilder:linux_other']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -226,6 +226,7 @@ module.exports = (grunt) ->
     electron_pkg.environment = 'production'
     electron_pkg.name = info.name.toLowerCase()
     electron_pkg.productName = info.name
+    electron_pkg.version = "#{info.version}.#{build_number}"
     grunt.file.write ELECTRON_PACKAGE_JSON, "#{JSON.stringify electron_pkg, null, 2}\n"
     grunt.log.write("Releases URL points to #{electron_pkg.updateWinUrl} ").ok();
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -211,11 +211,13 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'release-internal', ->
     info = grunt.config.get 'info'
+    build_number = grunt.config.get 'build_number'
     electron_pkg = grunt.file.readJSON ELECTRON_PACKAGE_JSON
     electron_pkg.updateWinUrl = info.updateWinUrlInternal
     electron_pkg.environment = 'internal'
     electron_pkg.name = info.nameInternal.toLowerCase()
     electron_pkg.productName = info.nameInternal
+    electron_pkg.version = "#{info.version}.#{build_number}-internal"
     grunt.file.write ELECTRON_PACKAGE_JSON, "#{JSON.stringify electron_pkg, null, 2}\n"
     grunt.log.write("Releases URL points to #{electron_pkg.updateWinUrl} ").ok();
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,6 @@
   "name": "wireinternal",
   "productName": "WireInternal",
   "description": "Modern communication, full privacy.",
-  "version": "2.15",
   "main": "main.js",
   "updateWinUrl": "https://wire-app.wire.com/win/internal/",
   "environment": "internal",

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "wireinternal",
   "productName": "WireInternal",
   "description": "Modern communication, full privacy.",
-  "version": "2.15.2751",
+  "version": "2.15",
   "main": "main.js",
   "updateWinUrl": "https://wire-app.wire.com/win/internal/",
   "environment": "internal",

--- a/info.json
+++ b/info.json
@@ -3,7 +3,6 @@
   "nameInternal": "WireInternal",
   "description": "Wire",
   "version": "2.15",
-  "build": "2751",
   "copyright": "© Wire Swiss GmbH",
   "updateWinUrlInternal": "https://wire-app.wire.com/win/internal/",
   "updateWinUrlProd": "https://wire-app.wire.com/win/prod/",

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -17,7 +17,7 @@ node('Linux_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
+  def version = buildInfo.version + '.' + currentBuild.id
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -16,8 +16,8 @@ node('Linux_Node') {
   }
 
   def text = readFile('info.json')
-  def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
+  def buildInfo = parseJson(text)
+  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -17,7 +17,7 @@ node('Linux_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + '.' + currentBuild.id
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -17,8 +17,8 @@ node('Linux_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + buildInfo.build;
-  currentBuild.displayName = version + ' #' + currentBuild.id
+  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  currentBuild.displayName = version;
 
   stage('Install rust') {
     withEnv(['PATH+RUST=/home/jenkins/.cargo/bin']) {

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -17,7 +17,7 @@ node('Linux_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -19,7 +19,7 @@ node('master') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
+  def version = buildInfo.version + '.' + currentBuild.id
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -19,7 +19,7 @@ node('master') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -19,8 +19,8 @@ node('master') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + buildInfo.build;
-  currentBuild.displayName = version + ' #' + currentBuild.id
+  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  currentBuild.displayName = version;
 
   stage('Install rust') {
     withEnv(['PATH+RUST=/Users/jenkins/.cargo/bin']) {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -19,7 +19,7 @@ node('master') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + '.' + currentBuild.id
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -18,8 +18,8 @@ node('master') {
   }
 
   def text = readFile('info.json')
-  def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
+  def buildInfo = parseJson(text)
+  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
   currentBuild.displayName = version;
 
   stage('Install rust') {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "grunt-contrib-clean": "1.1.0",
     "grunt-git": "1.0.4",
     "grunt-github-changes": "0.1.0",
+    "grunt-gitinfo": "0.1.8",
     "jest": "20.0.4",
     "load-grunt-tasks": "3.5.2",
     "style-loader": "0.18.2",

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -21,8 +21,8 @@ node('Windows_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + buildInfo.build;
-  currentBuild.displayName = version + ' #' + currentBuild.id
+  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  currentBuild.displayName = version;
 
   stage('Build') {
     try {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -20,8 +20,8 @@ node('Windows_Node') {
   }
 
   def text = readFile('info.json')
-  def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
+  def buildInfo = parseJson(text)
+  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
   currentBuild.displayName = version;
 
   stage('Build') {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -21,7 +21,7 @@ node('Windows_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text);
-  def version = buildInfo.version + '.' + params.BUILD_NUMBER;
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER;
   currentBuild.displayName = version;
 
   stage('Build') {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -21,7 +21,7 @@ node('Windows_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + ".${env.BUILD_NUMBER}"
+  def version = buildInfo.version + '.' + currentBuild.id
   currentBuild.displayName = version;
 
   stage('Build') {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -21,7 +21,7 @@ node('Windows_Node') {
 
   def text = readFile('info.json')
   def buildInfo = parseJson(text)
-  def version = buildInfo.version + '.' + currentBuild.id
+  def version = buildInfo.version + '.' + env.BUILD_NUMBER
   currentBuild.displayName = version;
 
   stage('Build') {


### PR DESCRIPTION
This PR will use the build number of the job and include it into the version number. The version number will now also tell us when a build was compiled for internal or manually

**Production builds** will look like this:
`2.15.2801`

**Internal builds** will look like this:
`2.15.2801-internal`

**Manually compiled builds** will include the commit id (short SHA) of the last commit (the build number will be always 0 because no CI was used):
`2.15.0-5df6b7c`
or
`2.15.0-5df6b7c-internal`

To bump the major.minor part of the version number, you can use the grunt task:
`grunt bump-version`

In this case it would bump the version from `2.15` to `2.16`.