### PR TITLE
Do not hide window when closing on Gnome (#957)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -149,7 +149,7 @@ if (process.platform === 'linux') {
 ///////////////////////////////////////////////////////////////////////////////
 // Make sure not to close the window to the tray on Gnome
 ///////////////////////////////////////////////////////////////////////////////
-function closeButton() {
+function onCloseMain() {
   if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP && process.env.XDG_CURRENT_DESKTOP.includes('GNOME')) {
     main.minimize();
   } else {
@@ -310,11 +310,11 @@ function showMainWindow() {
 
       if (isFullScreen) {
         main.once('leave-full-screen', () => {
-          closeButton();
+          onCloseMain();
         });
         main.setFullScreen(false);
       } else {
-        closeButton();
+        onCloseMain();
       }
     }
   });

--- a/electron/main.js
+++ b/electron/main.js
@@ -147,6 +147,17 @@ if (process.platform === 'linux') {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Make sure not to close the window to the tray on Gnome
+///////////////////////////////////////////////////////////////////////////////
+function closeButton() {
+  if (process.platform === 'linux' && process.env.XDG_CURRENT_DESKTOP && process.env.XDG_CURRENT_DESKTOP.includes('GNOME')) {
+    main.minimize();
+  } else {
+    main.hide();
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // IPC events
 ///////////////////////////////////////////////////////////////////////////////
 ipcMain.once('webapp-version', (event, version) => {
@@ -299,11 +310,11 @@ function showMainWindow() {
 
       if (isFullScreen) {
         main.once('leave-full-screen', () => {
-          main.hide();
+          closeButton();
         });
         main.setFullScreen(false);
       } else {
-        main.hide();
+        closeButton();
       }
     }
   });


### PR DESCRIPTION
Ideally the function could check whether Gnome was >= 3.26, but I am not sure if there is an environment variable for that. Maybe @HeritageRD wouldn't mind checking whether there is anything apparent when they run `set` from a terminal.