### PR TITLE
Use electron-builder's portable env.

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -93,9 +93,16 @@ if (config.DEVELOPMENT) {
   app.commandLine.appendSwitch('ignore-certificate-errors', 'true');
 }
 
-if (argv.portable) {
-  const EXEC_PATH = process.env.APPIMAGE || process.execPath;
-  const USER_PATH = path.join(EXEC_PATH, '..', 'Data');
+///////////////////////////////////////////////////////////////////////////////
+// Set data path for portable versions
+///////////////////////////////////////////////////////////////////////////////
+if (process.env.PORTABLE_EXECUTABLE_DIR || argv.portable) {
+  const EXEC_PATH = process.env.PORTABLE_EXECUTABLE_DIR || process.env.APPIMAGE || process.execPath;
+  if (process.env.PORTABLE_EXECUTABLE_DIR || process.env.APPIMAGE ) {
+    const USER_PATH = path.join(EXEC_PATH, '..', 'WireData');
+  } else {
+    const USER_PATH = path.join(EXEC_PATH, '..', 'Data');
+  }
   app.setPath('userData', USER_PATH);
 }
 


### PR DESCRIPTION
Electron builder adds a `PORTABLE_EXECUTABLE_DIR` environment var when building a portable target. I did not have any luck when I tried to add a portable target to the Gruntfile (it kept building for Linux, instead!). However, I can produce a nice portable binary by `$(npm bin)/build --win portable` in the `electronuserland/builder:wine` Docker image. If this could be implemented properly, it would solve #397 and #649 properly.