### PR TITLE
Add `linux-other-internal` Grunt task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -316,14 +316,15 @@ module.exports = (grunt) ->
     execSync = require('child_process').execSync
     execSync 'npm run bundle'
 
-  grunt.registerTask 'bump-version',  ['version-inc', 'gitcommit', 'gitpush']
+  grunt.registerTask 'bump-version',          ['version-inc', 'gitcommit', 'gitpush']
 
-  grunt.registerTask 'macos',         ['clean:macos', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:macos_internal']
-  grunt.registerTask 'macos-prod',    ['clean:macos', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
+  grunt.registerTask 'macos',                 ['clean:macos', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:macos_internal']
+  grunt.registerTask 'macos-prod',            ['clean:macos', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:macos_prod', 'productbuild']
 
-  grunt.registerTask 'win',           ['clean:win', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
-  grunt.registerTask 'win-prod',      ['clean:win', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
+  grunt.registerTask 'win',                   ['clean:win', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electron:win_internal', 'create-windows-installer:internal']
+  grunt.registerTask 'win-prod',              ['clean:win', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electron:win_prod', 'create-windows-installer:prod']
 
-  grunt.registerTask 'linux',         ['clean:linux', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
-  grunt.registerTask 'linux-prod',    ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
-  grunt.registerTask 'linux-other',   ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_other']
+  grunt.registerTask 'linux',                 ['clean:linux', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electronbuilder:linux_internal']
+  grunt.registerTask 'linux-prod',            ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_prod']
+  grunt.registerTask 'linux-other-internal',  ['clean:linux', 'update-keys', 'gitinfo', 'release-internal', 'bundle', 'electronbuilder:linux_other']
+  grunt.registerTask 'linux-other',           ['clean:linux', 'update-keys', 'gitinfo', 'release-prod', 'bundle', 'electronbuilder:linux_other']


### PR DESCRIPTION
Simplifies AUR package `wire-desktop-beta`.

Append `?w=1` to URL before reviewing the code: [click](https://github.com/wireapp/wire-desktop/pull/987/files?w=1)

Reference: #986 