### PR TITLE
app.exit() instead of return

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -118,7 +118,7 @@ if (environment.platform.IS_WINDOWS) {
 
   // Stop further execution on update to prevent second tray icon
   if (shouldQuit) {
-    return;
+    app.exit();
   }
 }
 


### PR DESCRIPTION
Not sure how can we test it.. but for sure `return` was doing nothing in that case.