### PR TITLE
fix: Compile libsodium-neon with correct x86 linker and module version on Windows

### DIFF
--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\VsDevCmd.bat" & npm install'
+        bat 'set "VSCMD_START_DIR=%CD%" & "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\VsDevCmd.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vsvars32.bat" & npm install'
+        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat" & npm install'
+        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\vsvars32.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\vsvars32.bat" & npm install'
+        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vsvars32.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\vcvars32.bat" & npm install'
+        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvars32.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -27,7 +27,7 @@ node('Windows_Node') {
   stage('Build') {
     try {
       bat 'pip install -r requirements.txt'
-      def NODE = tool name: 'node-v8.7.0', type: 'nodejs'
+      def NODE = tool name: 'node-v8.7.0-windows-x86', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}",'npm_config_target_arch=ia32','wire_target_arch=ia32']) {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat 'npm install'
+        bat '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -32,7 +32,7 @@ node('Windows_Node') {
         bat 'node -v'
         bat returnStatus: true, script: 'rustc --version'
         bat 'npm install -g grunt-cli'
-        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvars32.bat" & npm install'
+        bat '"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\VsDevCmd.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             bat 'grunt win-prod'


### PR DESCRIPTION
Most linker issues in the rust compilation were fixed by setting the Visual Studio development environment with VsDevCmd.bat.

The remaining conflict between the node module machine type and the target machine type was solved by using the x86 version of node.