### PR TITLE
Create a better .desktop file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,14 @@ const ELECTRON_PACKAGE_JSON = 'electron/package.json';
 const PACKAGE_JSON = 'package.json';
 const INFO_JSON = 'info.json';
 
+const DESKTOP_SPEC = {
+  "Version": "1.1",
+  "Name": "Wire",
+  "GenericName": "Privacy-Oriented Messenger",
+  "Keywords": "chat;encrypt;e2e;messenger;videocall",
+  "StartupWMClass": "Wire"
+};
+
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt, {pattern: ['grunt-*']});
   const path = require('path');
@@ -146,10 +154,8 @@ module.exports = function(grunt) {
             executableName: 'wire-desktop',
             afterInstall: 'bin/deb/after-install.tpl',
             afterRemove: 'bin/deb/after-remove.tpl',
-            desktop: {
-              "StartupWMClass": "Wire"
-            },
-            category: 'Network',
+            desktop: DESKTOP_SPEC,
+            category: 'Network;InstantMessaging;Chat;VideoConference',
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
           },
         },
@@ -164,10 +170,8 @@ module.exports = function(grunt) {
             executableName: 'wire-desktop-internal',
             afterInstall: 'bin/deb/after-install.tpl',
             afterRemove: 'bin/deb/after-remove.tpl',
-            desktop: {
-              "StartupWMClass": "Wire"
-            },
-            category: 'Network',
+            desktop: DESKTOP_SPEC,
+            category: 'Network;InstantMessaging;Chat;VideoConference',
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
           },
         },
@@ -181,9 +185,8 @@ module.exports = function(grunt) {
           linux: {
             fpm: ['--name', 'wire-desktop'],
             executableName: 'wire-desktop',
-            desktop: {
-              "StartupWMClass": "Wire"
-            },
+            desktop: DESKTOP_SPEC,
+            category: 'Network;InstantMessaging;Chat;VideoConference',
           },
         },
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,10 +25,11 @@ const ELECTRON_PACKAGE_JSON = 'electron/package.json';
 const PACKAGE_JSON = 'package.json';
 const INFO_JSON = 'info.json';
 
-const DESKTOP_SPEC = {
+const LINUX_DESKTOP = {
   "Version": "1.1",
   "Name": "Wire",
-  "GenericName": "Privacy-Oriented Messenger",
+  "GenericName": "Secure messenger",
+  "Categories": "Network;InstantMessaging;Chat;VideoConference",
   "Keywords": "chat;encrypt;e2e;messenger;videocall",
   "StartupWMClass": "Wire"
 };
@@ -154,8 +155,7 @@ module.exports = function(grunt) {
             executableName: 'wire-desktop',
             afterInstall: 'bin/deb/after-install.tpl',
             afterRemove: 'bin/deb/after-remove.tpl',
-            desktop: DESKTOP_SPEC,
-            category: 'Network;InstantMessaging;Chat;VideoConference',
+            desktop: LINUX_DESKTOP,
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
           },
         },
@@ -170,8 +170,7 @@ module.exports = function(grunt) {
             executableName: 'wire-desktop-internal',
             afterInstall: 'bin/deb/after-install.tpl',
             afterRemove: 'bin/deb/after-remove.tpl',
-            desktop: DESKTOP_SPEC,
-            category: 'Network;InstantMessaging;Chat;VideoConference',
+            desktop: LINUX_DESKTOP,
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
           },
         },
@@ -185,8 +184,7 @@ module.exports = function(grunt) {
           linux: {
             fpm: ['--name', 'wire-desktop'],
             executableName: 'wire-desktop',
-            desktop: DESKTOP_SPEC,
-            category: 'Network;InstantMessaging;Chat;VideoConference',
+            desktop: LINUX_DESKTOP,
           },
         },
       },


### PR DESCRIPTION
### Rationale

- `.desktop` spec is updated to version 1.1
- adds keywords and generic name
- uses standard category names
- uses "Wire" as application menu name, not `wire-desktop`

### Result: 

```
[Desktop Entry]
Name=Wire
Comment=Secure messenger for everyone.
Exec="/opt/wire-desktop/wire-desktop" %U
Terminal=false
Type=Application
Icon=wire-desktop
Version=1.1
GenericName=Privacy-Oriented Messenger
Keywords=chat;encrypt;e2e;messenger;videocall
StartupWMClass=Wire
Categories=Network;InstantMessaging;Chat;VideoConference;
```

Edit: I would like developer input re: [keywords, GenericName](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html), and [Categories](https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry) [+](https://specifications.freedesktop.org/menu-spec/latest/apas02.html).