### PR TITLE
[WEBAPP-4491] fix: Strip mailto: from copied links

### DIFF
--- a/electron/js/menu/context.js
+++ b/electron/js/menu/context.js
@@ -119,7 +119,7 @@ window.addEventListener('contextmenu', (event) => {
     imageMenu.popup(remote.getCurrentWindow());
   } else if (element.nodeName === 'A') {
     event.preventDefault();
-    copyContext = element.href;
+    copyContext = element.href.replace(/^mailto:/, '');
     defaultMenu.popup(remote.getCurrentWindow());
   } else if (element.classList.contains('text')) {
     event.preventDefault();


### PR DESCRIPTION
In addition to https://github.com/wireapp/wire-webapp/pull/1957.