### PR TITLE
Pop!_OS-indicator

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  *
  */
+ */Unity
 
 // Modules
 const debug = require('debug');


### PR DESCRIPTION
Added support for Pop!_OS indicator.
Requires user to have appindicator extenstion installed - extension install is not required prior to wire install