### PR TITLE
fix: Set appropriate zoom levels

### DIFF
--- a/electron/js/preload.js
+++ b/electron/js/preload.js
@@ -22,8 +22,9 @@ const environment = require('./environment');
 const locale = require('../locale/locale');
 const EVENT_TYPE = require('./lib/eventType');
 
-webFrame.setVisualZoomLevelLimits(1, 1);
-webFrame.setLayoutZoomLevelLimits(1, 1);
+webFrame.setZoomLevel(0);
+webFrame.setVisualZoomLevelLimits(0, 0);
+webFrame.setLayoutZoomLevelLimits(0, 0);
 
 window.locStrings = locale[locale.getCurrent()];
 window.locStringsDefault = locale.en;

--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -27,8 +27,9 @@ const EVENT_TYPE = require('../../js/lib/eventType');
 const {desktopCapturer, ipcRenderer, remote, webFrame} = require('electron');
 const {app} = remote;
 
-webFrame.setVisualZoomLevelLimits(1, 1);
-webFrame.setLayoutZoomLevelLimits(1, 1);
+webFrame.setZoomLevel(0);
+webFrame.setVisualZoomLevelLimits(0, 0);
+webFrame.setLayoutZoomLevelLimits(0, 0);
 webFrame.registerURLSchemeAsBypassingCSP('file');
 
 const subscribeToWebappEvents = () => {


### PR DESCRIPTION
Default zoom level is 0 not 1. Since we added boundaries for both visual and layout values, these have to be 0. Also disables zooming by pinch.

https://electronjs.org/docs/api/web-frame#webframesetzoomlevellevel