### PR TITLE
fix: option to hide title bar was changed to camel case in electron 2.0.0

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -137,7 +137,7 @@ const showMainWindow = () => {
     minWidth: config.WINDOW.MAIN.MIN_WIDTH,
     show: false,
     title: config.NAME,
-    titleBarStyle: 'hidden-inset',
+    titleBarStyle: 'hiddenInset',
     webPreferences: {
       backgroundThrottling: false,
       nodeIntegration: false,


### PR DESCRIPTION
See https://github.com/electron/electron/commit/594302fcff2311c95a576bd6ac432987aadbcb1e#diff-b0dbfed07f681b0f2ecb1eb01f0ed85b