### PR TITLE
Fix premature unset of urgency hint

### DIFF
--- a/electron/js/menu/tray.js
+++ b/electron/js/menu/tray.js
@@ -67,7 +67,11 @@ const updateBadgeIcon = (win, count) => {
     win.setOverlayIcon(count ? iconOverlayPath : null, locale.getText('unreadMessages'));
   }
 
-  win.flashFrame(!win.isFocused() && count > lastUnreadCount);
+  if (win.isFocused()) {
+    win.flashFrame(false);
+  } else if (count > lastUnreadCount) {
+    win.flashFrame(true);
+  }
   app.setBadgeCount(count);
   lastUnreadCount = count;
 };


### PR DESCRIPTION
I looked into why #1599 happens. The code is set to enable the urgency hint if the "unread" count is greater than the previously known count:

https://github.com/wireapp/wire-desktop/blob/baaf586911d044e3a23990d43b41e8a129cbcc7a/electron/js/menu/tray.js#L70

However, the `count` here is **not** the number of unread messages, instead it equals to the [number of _conversations_ that have unread messages](https://github.com/wireapp/wire-webapp/blob/d6ce31b0c39760291d56042dafd52e19b80fd6ba/app/script/view_model/WindowTitleViewModel.js#L65).

So, if one person sends you the first message while Wire is unfocused, you have 1 conversation with unread messages, `lastUnreadCount` is 0, 1 is greater than 0 so the urgency hint is set, and `lastUnreadCount` is now 1. When the same person sends you another message, the number of unread conversations is still 1, but since `lastUnreadCount` is also 1, the condition becomes false and the urgency hint becomes unset.

I'm confused how come it got broken after the update of desktop app, this seems to be quite an old code, I'm not sure what exactly changed in the process. Maybe there's something about how different electron versions handle the "false" argument to the `flashFrame`, I don't know.

To fix the issue I just make sure the urgency hint is not being unset until the window becomes focused again.

Fixes #1599.