### PR TITLE
chore: Update Node.js to 8.11.3

### DIFF
--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -23,13 +23,14 @@ node('Linux_Node') {
   stage('Build') {
     try {
       sh 'pip install -r requirements.txt'
-      def NODE = tool name: 'node-v8.9.4', type: 'nodejs'
+      def NODE = tool name: 'node-v8.11.3', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'
-        sh 'npm install -g grunt-cli'
+        sh 'npm install -g npm'
+        sh 'npm -v'
         sh 'npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
-          sh 'grunt linux-prod'
+          sh 'npx grunt linux-prod'
         }
       }
     } catch(e) {

--- a/linux.Jenkinsfile
+++ b/linux.Jenkinsfile
@@ -26,7 +26,7 @@ node('Linux_Node') {
       def NODE = tool name: 'node-v8.11.3', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'
-        sh 'npm install -g npm'
+        sh 'npm update -g npm'
         sh 'npm -v'
         sh 'npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -29,7 +29,7 @@ node('master') {
       def NODE = tool name: 'node-v8.11.3', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'
-        sh 'npm install -g npm'
+        sh 'npm update -g npm'
         sh 'npm -v'
         sh 'npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {

--- a/macOS.Jenkinsfile
+++ b/macOS.Jenkinsfile
@@ -26,17 +26,19 @@ node('master') {
     try {
       sh 'security unlock-keychain -p 123456 /Users/jenkins/Library/Keychains/login.keychain'
       sh 'pip install -r requirements.txt'
-      def NODE = tool name: 'node-v8.7.0', type: 'nodejs'
+      def NODE = tool name: 'node-v8.11.3', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'
+        sh 'npm install -g npm'
+        sh 'npm -v'
         sh 'npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
             // Production
-            sh 'grunt macos-prod'
+            sh 'npx grunt macos-prod'
           } else {
             // Internal
-            sh 'grunt macos'
+            sh 'npx grunt macos'
           }
         }
       }

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -27,16 +27,17 @@ node('Windows_Node') {
   stage('Build') {
     try {
       bat 'pip install -r requirements.txt'
-      def NODE = tool name: 'node-v8.7.0-windows-x86', type: 'nodejs'
+      def NODE = tool name: 'node-v8.11.3-windows-x86', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}",'npm_config_target_arch=ia32','wire_target_arch=ia32']) {
         bat 'node -v'
-        bat 'npm install -g grunt-cli'
+        bat 'npm install -g npm'
+        bat 'npm -v'
         bat 'set "VSCMD_START_DIR=%CD%" & "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\VsDevCmd.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {
           if(production) {
-            bat 'grunt win-prod'
+            bat 'npx grunt win-prod'
           } else {
-            bat 'grunt win'
+            bat 'npx grunt win'
           }
         }
       }
@@ -65,12 +66,12 @@ node('Windows_Node') {
 
   stage('Build installer') {
     try {
-      def NODE = tool name: 'node-v8.7.0', type: 'nodejs'
+      def NODE = tool name: 'node-v8.11.3', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}",'npm_config_target_arch=ia32','wire_target_arch=ia32']) {
         if(production) {
-          bat 'grunt create-windows-installer:prod'
+          bat 'npx grunt create-windows-installer:prod'
         } else {
-          bat 'grunt create-windows-installer:internal'
+          bat 'npx grunt create-windows-installer:internal'
         }
       }
     } catch(e) {

--- a/windows.Jenkinsfile
+++ b/windows.Jenkinsfile
@@ -30,7 +30,7 @@ node('Windows_Node') {
       def NODE = tool name: 'node-v8.11.3-windows-x86', type: 'nodejs'
       withEnv(["PATH+NODE=${NODE}",'npm_config_target_arch=ia32','wire_target_arch=ia32']) {
         bat 'node -v'
-        bat 'npm install -g npm'
+        bat 'npm update -g npm'
         bat 'npm -v'
         bat 'set "VSCMD_START_DIR=%CD%" & "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\VsDevCmd.bat" & npm install'
         withCredentials([string(credentialsId: 'GOOGLE_CLIENT_ID', variable: 'GOOGLE_CLIENT_ID'), string(credentialsId: 'GOOGLE_CLIENT_SECRET', variable: 'GOOGLE_CLIENT_SECRET'), string(credentialsId: 'RAYGUN_API_KEY', variable: 'RAYGUN_API_KEY')]) {


### PR DESCRIPTION
This PR will
* let Jenkins use Node.js 8.11.3
* use `npx` instead of installing `grunt` globally.
* always use the latest version of `npm`.