### PR TITLE
fix incorrect spelling of dependency for rpm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
           productName: 'wire-desktop',
           rpm: {
             ...LINUX_SETTINGS,
-            depends: ['alsa-lib', 'Gconf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
+            depends: ['alsa-lib', 'GConf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
             fpm: ['--name', 'wire-desktop'],
           },
           targets: ['deb', 'rpm', 'AppImage'],
@@ -188,7 +188,7 @@ module.exports = function(grunt) {
           productName: 'wire-desktop-internal',
           rpm: {
             ...LINUX_SETTINGS,
-            depends: ['alsa-lib', 'Gconf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
+            depends: ['alsa-lib', 'GConf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
             fpm: ['--name', 'wire-desktop-internal'],
           },
           targets: ['deb', 'rpm', 'AppImage'],


### PR DESCRIPTION
Package installation fails on Fedora 28:
- nothing provides Gconf2 needed by wire-desktop-3.2.0_511072-1.i386

Correct package name:
- GConf2