### PR TITLE
feat: Remove urgency hint when messages are read on other device

### DIFF
--- a/electron/js/menu/tray.js
+++ b/electron/js/menu/tray.js
@@ -67,7 +67,7 @@ const updateBadgeIcon = (win, count) => {
     win.setOverlayIcon(count ? iconOverlayPath : null, locale.getText('unreadMessages'));
   }
 
-  if (win.isFocused() || count == 0) {
+  if (win.isFocused() || !count) {
     win.flashFrame(false);
   } else if (count > lastUnreadCount) {
     win.flashFrame(true);

--- a/electron/js/menu/tray.js
+++ b/electron/js/menu/tray.js
@@ -67,7 +67,7 @@ const updateBadgeIcon = (win, count) => {
     win.setOverlayIcon(count ? iconOverlayPath : null, locale.getText('unreadMessages'));
   }
 
-  if (win.isFocused()) {
+  if (win.isFocused() || count == 0) {
     win.flashFrame(false);
   } else if (count > lastUnreadCount) {
     win.flashFrame(true);


### PR DESCRIPTION
This is an improvement on top of #1610.

The logic in `master` is: once we get at least one unread conversation, mark Wire as "urgent" until Wire is focused again.

This PR extends the logic to: once we get at least one unread conversation, mark Wire as "urgent" until Wire is focused again _or all conversations are read on another device_.

The idea is: I might leave my laptop and continue discussion on the phone, once I get back to my laptop I don't want to see Wire marked as "urgent" in case I have already replied to all the messages from the phone. But if there are some messages that I haven't replied from the phone, I do want to see Wire marked as "urgent", so I can remember to reply to people.