### PR TITLE
fix: Limit content length size when downloading link preview (WEBAPP-4422, WEBAPP-5341)

### DIFF
--- a/electron/js/lib/openGraph.js
+++ b/electron/js/lib/openGraph.js
@@ -47,11 +47,7 @@ const fetchOpenGraphData = url => {
   const normalizedUrl = parsedUrl.protocol ? parsedUrl : urlUtil.parse(`http://${url}`);
 
   const parseHead = body => {
-    const headMatches = body.match(/<head>[\s\S]*?<\/head>/);
-    if (!headMatches) {
-      throw new Error('No head found in the document');
-    }
-    const [head] = headMatches;
+    const [head] = body.match(/<head>[\s\S]*?<\/head>/) || [''];
     return openGraphParse(head);
   };
 

--- a/electron/js/lib/openGraph.js
+++ b/electron/js/lib/openGraph.js
@@ -52,7 +52,7 @@ const fetchImageAsBase64 = url => {
 };
 
 const fetchOpenGraphData = url => {
-  const CONTENT_SIZE_LIMIT = 1000000; // ~1MB
+  const CONTENT_SIZE_LIMIT = 1e6; // ~1MB
   const parsedUrl = urlUtil.parse(url);
   const normalizedUrl = parsedUrl.protocol ? parsedUrl : urlUtil.parse(`http://${url}`);
 

--- a/electron/js/lib/openGraph.js
+++ b/electron/js/lib/openGraph.js
@@ -42,7 +42,7 @@ const fetchImageAsBase64 = url => {
 };
 
 const fetchOpenGraphData = url => {
-  const CONTENT_TYPE_LIMIT = 1000000; // 1MB
+  const CONTENT_SIZE_LIMIT = 1000000; // ~1MB
   const parsedUrl = urlUtil.parse(url);
   const normalizedUrl = parsedUrl.protocol ? parsedUrl : urlUtil.parse(`http://${url}`);
 
@@ -70,13 +70,11 @@ const fetchOpenGraphData = url => {
       }
     });
 
-    let requestCurrentSize = 0;
     let partialBody = '';
     getContentRequest.on('data', buffer => {
       const chunk = buffer.toString();
-      requestCurrentSize += buffer.length;
       partialBody += chunk;
-      if (chunk.match('</head>') || requestCurrentSize > CONTENT_TYPE_LIMIT) {
+      if (chunk.match('</head>') || partialBody.length > CONTENT_SIZE_LIMIT) {
         getContentRequest.abort();
         resolve(partialBody);
       }


### PR DESCRIPTION
Previous strategy was:

- do HEAD request and read the content of the response ;
- if the content type doesn't match throw error ;
- else send another request via `openGraph`.

New strategy:

- do full request ;
- when the headers arrive (before any content is downloaded), check that `content-type` is of type `text/html` ;
- start counting downloaded bytes ;
- if the number of bytes exceed the limit, we fail ;
- if not we call the `parse` method of `openGraph` only on the `<head>` of the document.