### PR TITLE
feat: UX improvements to Sidebar component.

### DIFF
--- a/electron/renderer/src/components/Sidebar.css
+++ b/electron/renderer/src/components/Sidebar.css
@@ -67,10 +67,6 @@
   border-radius: 50%;
 }
 
-.Sidebar-icon-cursor {
-  cursor: pointer;
-}
-
 .Sidebar-account-add {
   width: 28px;
   height: 28px;

--- a/electron/renderer/src/components/Sidebar.css
+++ b/electron/renderer/src/components/Sidebar.css
@@ -19,16 +19,27 @@
 
 .Sidebar {
   background-color: var(--sidebar-color);
-  width: 78px;
+  width: 48px;
   padding-top: 40px;
   display: flex;
   align-items: center;
   flex-direction: column;
   flex: 0 0 auto;
+
+  transition: width;
+  transition-timing-function: var(--ease-out-quart);
+  transition-duration: var(--animation-timing-slow);
+  transition-delay: var(--animation-timing-slow);
+}
+
+.Sidebar:hover {
+  width: 78px;
+  transition-delay: 0ms;
 }
 
 .Sidebar:hover .ContextMenuTrigger {
   opacity: 1;
+  transition-delay: 0ms;
 }
 
 .Sidebar-cell {

--- a/electron/renderer/src/components/Sidebar.js
+++ b/electron/renderer/src/components/Sidebar.js
@@ -41,8 +41,7 @@ const centerOfEventTarget = event => {
 
 const getClassName = account => {
   const showIconBadge = account.badgeCount > 0 ? ' Sidebar-icon-badge' : '';
-  const showIconCursor = account.visible ? '' : ' Sidebar-icon-cursor';
-  return `Sidebar-icon${showIconBadge}${showIconCursor}`;
+  return `Sidebar-icon${showIconBadge}`;
 };
 
 const Sidebar = ({
@@ -61,25 +60,25 @@ const Sidebar = ({
     onClick={connected.setAccountContextHidden}
   >
     {accounts.map(account => (
-      <div className="Sidebar-cell" key={account.id}>
-        <div
-          style={{color: colorFromId(currentAccentID)}}
-          className={getClassName(account)}
-          onClick={() => connected.switchAccount(account.id)}
-          onContextMenu={preventFocus(event => {
-            const isAtLeastAdmin = ['z.team.TeamRole.ROLE.OWNER', 'z.team.TeamRole.ROLE.ADMIN'].includes(
-              account.teamRole
-            );
-            connected.toggleEditAccountMenuVisibility(
-              ...centerOfEventTarget(event),
-              account.id,
-              account.sessionID,
-              account.lifecycle,
-              isAtLeastAdmin
-            );
-          })}
-          onMouseDown={preventFocus()}
-        >
+      <div
+        className="Sidebar-cell"
+        key={account.id}
+        onClick={() => connected.switchAccount(account.id)}
+        onContextMenu={preventFocus(event => {
+          const isAtLeastAdmin = ['z.team.TeamRole.ROLE.OWNER', 'z.team.TeamRole.ROLE.ADMIN'].includes(
+            account.teamRole
+          );
+          connected.toggleEditAccountMenuVisibility(
+            ...centerOfEventTarget(event),
+            account.id,
+            account.sessionID,
+            account.lifecycle,
+            isAtLeastAdmin
+          );
+        })}
+        onMouseDown={preventFocus()}
+      >
+        <div style={{color: colorFromId(currentAccentID)}} className={getClassName(account)}>
           {account.teamID ? (
             <TeamIcon account={account} accentID={currentAccentID} />
           ) : (

--- a/electron/renderer/src/components/context/ContextMenu.css
+++ b/electron/renderer/src/components/context/ContextMenu.css
@@ -43,6 +43,7 @@
   transition: opacity;
   transition-timing-function: var(--ease-out-quart);
   transition-duration: var(--animation-timing-slow);
+  transition-delay: var(--animation-timing-slow);
 }
 
 .ContextMenu-item:hover,


### PR DESCRIPTION
### Changes
 - Reduce sidebar width to 48px
 - Expand sidebar width to 78px on hover
 - Retract sidebar width to 48px delayed when not hovering
 - Make sidebar cells interactive instead of the icons in the cells.
 - Remove unnecessary `Sidebar-icon-cursor` class, as all cells have a pointer-cursor by default.

![Preview GIF](https://x.scrumplex.net/img/wire.gif)