### PR TITLE
fix: Linux executable name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,7 @@ const LINUX_SETTINGS = {
     Keywords: 'chat;encrypt;e2e;messenger;videocall',
     StartupWMClass: '<%= info.name %>',
   },
+  fpm: ['--name', 'wire-desktop'],
 };
 
 module.exports = function(grunt) {
@@ -162,11 +163,9 @@ module.exports = function(grunt) {
           linux: {
             category: 'Network',
           },
-          productName: 'wire-desktop',
           rpm: {
             ...LINUX_SETTINGS,
             depends: ['alsa-lib', 'GConf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
-            fpm: ['--name', 'wire-desktop'],
           },
           targets: ['deb', 'rpm', 'AppImage'],
         },
@@ -181,11 +180,11 @@ module.exports = function(grunt) {
               Name: '<%= info.nameInternal %>',
             },
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
+            fpm: ['--name', 'wire-desktop-internal'],
           },
           linux: {
             category: 'Network',
           },
-          productName: 'wire-desktop-internal',
           rpm: {
             ...LINUX_SETTINGS,
             depends: ['alsa-lib', 'GConf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'],
@@ -202,7 +201,6 @@ module.exports = function(grunt) {
             ...LINUX_SETTINGS,
             fpm: ['--name', 'wire-desktop'],
           },
-          productName: 'wire-desktop',
           targets: [grunt.option('target') || 'dir'],
         },
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,7 @@ module.exports = function(grunt) {
           },
           linux: {
             category: 'Network',
+            executableName: 'wire-desktop',
           },
           rpm: {
             ...LINUX_SETTINGS,
@@ -184,6 +185,7 @@ module.exports = function(grunt) {
           },
           linux: {
             category: 'Network',
+            executableName: 'wire-desktop-internal',
           },
           rpm: {
             ...LINUX_SETTINGS,


### PR DESCRIPTION
This PR will
* partly revert https://github.com/wireapp/wire-desktop/commit/49feee08bc3882d0b47308c6393897ecb5bfad50 where `fpm` settings were moved to the wrong part of the Gruntfile. Now the Debian package names are "wire-desktop" and "wire-desktop-internal".
(e.g.: a user can run `sudo apt-get install wire-desktop`)
* set `executableName` to "wire-desktop" and "wire-desktop-internal" instead of "wire" and "wireinternal".
(e.g.: a user can run `/opt/wire-desktop/wire-desktop`).

