### PR TITLE
fix: Change app language (WEBAPP-5451)

### DIFF
--- a/electron/js/settings/SchemaUpdater.js
+++ b/electron/js/settings/SchemaUpdater.js
@@ -60,12 +60,12 @@ class SchemaUpdater {
           }
         });
       }
-    }
 
-    try {
-      fs.writeJsonSync(configFileV1, config, {spaces: 2});
-    } catch (error) {
-      debugLogger(`Failed to write config to "${configFileV1}": ${error.message}`, error);
+      try {
+        fs.writeJsonSync(configFileV1, config, {spaces: 2});
+      } catch (error) {
+        debugLogger(`Failed to write config to "${configFileV1}": ${error.message}`, error);
+      }
     }
 
     return configFileV1;

--- a/electron/main.js
+++ b/electron/main.js
@@ -308,7 +308,11 @@ const renameLogFile = () => {
       })
       .forEach(file => {
         if (file.endsWith('.log')) {
-          fs.renameSync(file, file.replace('.log', '.old'));
+          try {
+            fs.renameSync(file, file.replace('.log', '.old'));
+          } catch (error) {
+            console.error(`Failed to rename log file: ${error.message}`);
+          }
         }
       });
   });


### PR DESCRIPTION
## What was wrong?

We always run the config schema updates on app start (similar to IndexedDB schema updates on webapp). When there is an old config (`./init.json`), then we update that config and save it to its new place (`./config/init.json`).

The problem here was, that no config change was detected (because wrapper was already running on latest config) and thus the config update was skipped BUT the config save wasn't skipped so a properly updated config was overwritten on the harddisk with a config template which includes nothing except:

```json
{
  "configVersion": 1
}
```

That's why the `locale` property got overwritten.

## Bonus

During testing I realized that it can happen that log file renaming fails (because log file is opened in Notepad++ or still written into). This can cause a JavaScript error and crash of our app so it put this in a try-catch block to not crash the app.