### PR TITLE
Add electron-window-state to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "yarn": "false"
   },
   "dependencies": {
-    "debug": "4.0.1"
+    "debug": "4.0.1",
+    "electron-window-state": "5.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.0.1",


### PR DESCRIPTION
The module "electron-window-state" is required to launch the Wire app,
but was not listed in the package.json file and is not pulled in as a
dependency by any other package. I have added the module to
package.json.

For reference, the error that I saw when running "npm start" was:

Error: Cannot find module 'electron-window-state'
    at Module._resolveFilename (module.js:485:15)
    at Function.Module._resolveFilename (/home/kechpaja/dev/wire/wire-desktop/node_modules/electron/dist/resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/kechpaja/dev/wire/wire-desktop/electron/main.js:26:27)
    at Object.<anonymous> (/home/kechpaja/dev/wire/wire-desktop/electron/main.js:424:3)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)