### PR TITLE
fix: Remove invalid settings from Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ const LINUX_SETTINGS = {
   afterRemove: 'bin/deb/after-remove.tpl',
   category: 'Network',
   desktop: {
-    Version: '<%= info.version %>.<%= buildNumber %>',
+    Version: '1.1',
     Name: '<%= info.name %>',
     GenericName: '<%= info.description %>',
     Categories: 'Network;InstantMessaging;Chat;VideoConference',
@@ -200,9 +200,10 @@ module.exports = function(grunt) {
         options: {
           arch: grunt.option('arch') || process.arch,
           linux: {
-            ...LINUX_SETTINGS,
-            fpm: ['--name', 'wire-desktop'],
+            category: 'Network',
+            executableName: 'wire-desktop',
           },
+          productName: 'wire-desktop',
           targets: [grunt.option('target') || 'dir'],
         },
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,13 +17,13 @@
  *
  */
 
-const electronPackager = require('electron-packager');
 const {createWindowsInstaller} = require('electron-winstaller');
+const electronPackager = require('electron-packager');
 const electronBuilder = require('electron-builder');
 
 const ELECTRON_PACKAGE_JSON = 'electron/package.json';
-const PACKAGE_JSON = 'package.json';
 const INFO_JSON = 'info.json';
+const PACKAGE_JSON = 'package.json';
 
 const LINUX_DESKTOP = {
   Categories: 'Network;InstantMessaging;Chat;VideoConference',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,7 @@ module.exports = function(grunt) {
             fpm: ['--name', 'wire-desktop-internal'],
           },
           linux: {
-            category: 'Network',
+            category: LINUX_SETTINGS.category,
             executableName: 'wire-desktop-internal',
           },
           rpm: {
@@ -185,7 +185,7 @@ module.exports = function(grunt) {
         options: {
           arch: grunt.option('arch') || process.arch,
           linux: {
-            category: 'Network',
+            category: LINUX_SETTINGS.category,
             desktop: LINUX_DESKTOP,
             executableName: 'wire-desktop',
           },
@@ -201,7 +201,7 @@ module.exports = function(grunt) {
             depends: ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'],
           },
           linux: {
-            category: 'Network',
+            category: LINUX_SETTINGS.category,
             executableName: 'wire-desktop',
           },
           rpm: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,18 +27,20 @@ const ELECTRON_PACKAGE_JSON = 'electron/package.json';
 const PACKAGE_JSON = 'package.json';
 const INFO_JSON = 'info.json';
 
+const LINUX_DESKTOP = {
+  Version: '1.1',
+  Name: '<%= info.name %>',
+  GenericName: '<%= info.description %>',
+  Categories: 'Network;InstantMessaging;Chat;VideoConference',
+  Keywords: 'chat;encrypt;e2e;messenger;videocall',
+  StartupWMClass: '<%= info.name %>',
+};
+
 const LINUX_SETTINGS = {
   afterInstall: 'bin/deb/after-install.tpl',
   afterRemove: 'bin/deb/after-remove.tpl',
   category: 'Network',
-  desktop: {
-    Version: '1.1',
-    Name: '<%= info.name %>',
-    GenericName: '<%= info.description %>',
-    Categories: 'Network;InstantMessaging;Chat;VideoConference',
-    Keywords: 'chat;encrypt;e2e;messenger;videocall',
-    StartupWMClass: '<%= info.name %>',
-  },
+  desktop: LINUX_DESKTOP,
   fpm: ['--name', 'wire-desktop'],
 };
 
@@ -201,6 +203,7 @@ module.exports = function(grunt) {
           arch: grunt.option('arch') || process.arch,
           linux: {
             category: 'Network',
+            desktop: LINUX_DESKTOP,
             executableName: 'wire-desktop',
           },
           productName: 'wire-desktop',


### PR DESCRIPTION
* This fixes #1735 by removing keys from the `linux` settings which don't belong there.
* The `Version` entry in a Gnome desktop file actually specifies the version of the Desktop Entry Specification, not the product version, see https://developer.gnome.org/desktop-entry-spec/.