### PR TITLE
fix: Add new husky precommit hook

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -29,19 +29,20 @@
   "devDependencies": {
     "cross-spawn": "6.0.5"
   },
-  "environment": "internal",
+  "environment": "production",
   "homepage": "https://wire.com",
   "license": "GPL-3.0",
   "main": "main.js",
-  "name": "wireinternal",
+  "name": "wire",
   "optionalDependencies": {
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#2.0.0"
   },
   "private": true,
-  "productName": "WireInternal",
+  "productName": "Wire",
   "repository": {
     "type": "git",
     "url": "https://github.com/wireapp/wire-desktop.git"
   },
-  "updateWinUrl": "https://wire-app.wire.com/win/internal/"
+  "updateWinUrl": "https://wire-app.wire.com/win/prod/",
+  "version": "3.3.0-bd4b185"
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -29,20 +29,19 @@
   "devDependencies": {
     "cross-spawn": "6.0.5"
   },
-  "environment": "production",
+  "environment": "internal",
   "homepage": "https://wire.com",
   "license": "GPL-3.0",
   "main": "main.js",
-  "name": "wire",
+  "name": "wireinternal",
   "optionalDependencies": {
     "node-addressbook": "https://github.com/wireapp/node-addressbook.git#2.0.0"
   },
   "private": true,
-  "productName": "Wire",
+  "productName": "WireInternal",
   "repository": {
     "type": "git",
     "url": "https://github.com/wireapp/wire-desktop.git"
   },
-  "updateWinUrl": "https://wire-app.wire.com/win/prod/",
-  "version": "3.3.0-bd4b185"
+  "updateWinUrl": "https://wire-app.wire.com/win/internal/"
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "webpack": "4.20.2",
     "webpack-cli": "3.1.1"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "license": "LicenseRef-LICENSE",
   "lint-staged": {
     "*.{js,jsx}": [
@@ -71,7 +76,6 @@
     "fix": "npm run fix:js && npm run fix:other",
     "jest": "jest",
     "localhost": "npm run prestart && electron electron --inspect --devtools --enable-logging --env=http://localhost:8080/app",
-    "precommit": "lint-staged",
     "postinstall": "cd electron && electron-builder install-app-deps",
     "prestart": "npm run bundle:dev",
     "prettier": "prettier \"**/*.{json,md,css}\"",


### PR DESCRIPTION
`husky` 1.0.0 has changed the way of adding precommit hooks. See https://github.com/typicode/husky#upgrading-from-014.

Follow-up to https://github.com/wireapp/wire-web-packages/pull/1162.