### PR TITLE
fix: Building with TypeScript

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,7 +258,7 @@ module.exports = function(grunt) {
 
     'update-keys': {
       options: {
-        config: 'electron/js/config.js',
+        config: 'electron/dist/js/config.js',
       },
     },
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "strict": true,
     "target": "es5"
   },
-  "exclude": ["electron/dist", "node_modules", "electron/node_modules"]
+  "exclude": ["electron/dist", "node_modules", "electron/node_modules", "wrap"]
 }


### PR DESCRIPTION
This PR will
* set the correct path for the config file used by Grunt
* ignore the `wrap` folder when building