### PR TITLE
fix: Enable asar packaging on Linux

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,7 +214,7 @@ module.exports = function(grunt) {
 
       options: {
         arch: 'all',
-        asar: false,
+        asarUnpack: 'node_modules/spellchecker/vendor',
         publish: null,
       },
     },


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-desktop/pull/335.

Tested this on Debian with `en_US` locale.

@lipis @maximbaz @ConorIA
Can you test this, too? :slightly_smiling_face: 