### PR TITLE
fix: Make Undo/Redo disappear on macOS

### DIFF
--- a/electron/src/js/menu/system.ts
+++ b/electron/src/js/menu/system.ts
@@ -190,7 +190,7 @@ const menuUndoRedo = [
 const editTemplate: ElectronMenuItemWithI18n = {
   i18n: 'menuEdit',
   submenu: [
-    ...(environment.platform.IS_MAC_OS === false ? <ElectronMenuItemWithI18n>menuUndoRedo : []),
+    ...(environment.platform.IS_MAC_OS ? [] : <ElectronMenuItemWithI18n>menuUndoRedo),
     {
       i18n: 'menuCut',
       role: 'cut',

--- a/electron/src/js/menu/system.ts
+++ b/electron/src/js/menu/system.ts
@@ -176,18 +176,21 @@ const toggleAutoLaunchTemplate: ElectronMenuItemWithI18n = {
 
 const supportsSpellCheck = config.SPELLCHECK.SUPPORTED_LANGUAGES.includes(locale.getCurrent());
 
+const menuUndoRedo = [
+  {
+    i18n: 'menuUndo',
+    role: 'undo',
+  },
+  {
+    i18n: 'menuRedo',
+    role: 'redo',
+  },
+  separatorTemplate,
+];
 const editTemplate: ElectronMenuItemWithI18n = {
   i18n: 'menuEdit',
   submenu: [
-    {
-      i18n: 'menuUndo',
-      role: 'undo',
-    },
-    {
-      i18n: 'menuRedo',
-      role: 'redo',
-    },
-    separatorTemplate,
+    ...(environment.platform.IS_MAC_OS === false ? <ElectronMenuItemWithI18n>menuUndoRedo : []),
     {
       i18n: 'menuCut',
       role: 'cut',


### PR DESCRIPTION
https://github.com/electron/electron/issues/15728