### PR TITLE
Remove 'Wire / Preferences' menu on Linux

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -346,11 +346,6 @@ const win32Template: ElectronMenuItemWithI18n = {
 const linuxTemplate: ElectronMenuItemWithI18n = {
   label: config.NAME,
   submenu: [
-    {
-      click: () => sendAction(EVENT_TYPE.PREFERENCES.SHOW),
-      i18n: 'menuPreferences',
-    },
-    separatorTemplate,
     toggleAutoLaunchTemplate,
     separatorTemplate,
     localeTemplate,


### PR DESCRIPTION
Because this is a duplicate of 'Edit / Preferences' which is the typical location for Linux apps.

Signed-off-by: Volker Theile <votdev@gmx.de>