### PR TITLE
fix: Re-enable PageDown/Up buttons

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -445,10 +445,6 @@ const registerShortcuts = (): void => {
   // Global mute shortcut
   globalShortcut.register('CmdOrCtrl+Alt+M', () => sendAction(EVENT_TYPE.CONVERSATION.TOGGLE_MUTE));
 
-  // fix the main window scrolling issues
-  globalShortcut.register('PageDown', () => undefined);
-  globalShortcut.register('PageUp', () => undefined);
-
   // Global account switching shortcut
   const switchAccountShortcut = ['CmdOrCtrl', 'Super'];
   const accountLimit = 3;


### PR DESCRIPTION
After https://github.com/wireapp/wire-webapp/pull/5574 is released, we can enable the PageDown/Up buttons again.