### PR TITLE
Reset identity when logging out without deleting data (WEBAPP-5921)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,6 +160,7 @@ module.exports = function(grunt) {
           extendInfo: 'resources/macos/custom.plist',
           helperBundleId: 'com.wearezeta.zclient.mac.helper',
           icon: 'resources/macos/wire.icns',
+          out: 'wrap/dist',
           platform: 'mas',
         },
       },

--- a/electron/renderer/src/actions/index.js
+++ b/electron/renderer/src/actions/index.js
@@ -24,6 +24,7 @@ import {MAXIMUM_ACCOUNTS} from '../../../dist/js/config';
 
 export const ADD_ACCOUNT = 'ADD_ACCOUNT';
 export const DELETE_ACCOUNT = 'DELETE_ACCOUNT';
+export const RESET_IDENTITY = 'RESET_IDENTITY';
 export const SWITCH_ACCOUNT = 'SWITCH_ACCOUNT';
 export const UPDATE_ACCOUNT = 'UPDATE_ACCOUNT';
 export const UPDATE_ACCOUNT_BADGE = 'UPDATE_ACCOUNT_BADGE';
@@ -37,6 +38,12 @@ export const addAccount = (withSession = true) => ({
 export const deleteAccount = id => ({
   id,
   type: DELETE_ACCOUNT,
+});
+
+export const resetIdentity = (id = true, isAdding = false) => ({
+  id,
+  isAdding,
+  type: RESET_IDENTITY,
 });
 
 export const switchAccount = id => ({

--- a/electron/renderer/src/actions/index.js
+++ b/electron/renderer/src/actions/index.js
@@ -40,9 +40,8 @@ export const deleteAccount = id => ({
   type: DELETE_ACCOUNT,
 });
 
-export const resetIdentity = (id = true, isAdding = false) => ({
+export const resetIdentity = (id = true) => ({
   id,
-  isAdding,
   type: RESET_IDENTITY,
 });
 

--- a/electron/renderer/src/components/Webviews.jsx
+++ b/electron/renderer/src/components/Webviews.jsx
@@ -106,7 +106,12 @@ class Webviews extends Component {
       }
 
       case EVENT_TYPE.LIFECYCLE.SIGNED_OUT: {
-        this._deleteWebview(account);
+        const [clearData] = args;
+        if (clearData) {
+          this._deleteWebview(account);
+        } else {
+          this.props.resetIdentity(account.id);
+        }
         break;
       }
 

--- a/electron/renderer/src/containers/WebviewsContainer.js
+++ b/electron/renderer/src/containers/WebviewsContainer.js
@@ -21,6 +21,7 @@ import {connect} from 'react-redux';
 
 import {
   abortAccountCreation,
+  resetIdentity,
   switchAccount,
   updateAccountBadgeCount,
   updateAccountData,
@@ -32,6 +33,7 @@ const WebviewsContainer = connect(
   state => ({accounts: state.accounts}),
   {
     abortAccountCreation,
+    resetIdentity,
     switchAccount,
     updateAccountBadgeCount,
     updateAccountData,

--- a/electron/renderer/src/reducers/accountReducer.js
+++ b/electron/renderer/src/reducers/accountReducer.js
@@ -46,6 +46,13 @@ const accountReducer = (state = [createAccount()], action) => {
       return state.filter(account => account.id !== action.id);
     }
 
+    case ActionCreator.RESET_IDENTITY: {
+      return state.map(account => {
+        const isMatchingAccount = account.id === action.id;
+        return isMatchingAccount ? {...account, isAdding: true, teamID: undefined, userID: undefined} : account;
+      });
+    }
+
     case ActionCreator.SWITCH_ACCOUNT: {
       return state.map(account => {
         const isMatchingAccount = account.id === action.id;
@@ -71,13 +78,6 @@ const accountReducer = (state = [createAccount()], action) => {
       return state.map(account => {
         const isMatchingAccount = account.id === action.id;
         return isMatchingAccount ? {...account, lifecycle: action.data} : account;
-      });
-    }
-
-    case ActionCreator.RESET_IDENTITY: {
-      return state.map(account => {
-        const isMatchingAccount = account.id === action.id;
-        return isMatchingAccount ? {...account, isAdding: true, teamID: undefined, userID: undefined} : account;
       });
     }
 

--- a/electron/renderer/src/reducers/accountReducer.js
+++ b/electron/renderer/src/reducers/accountReducer.js
@@ -74,6 +74,13 @@ const accountReducer = (state = [createAccount()], action) => {
       });
     }
 
+    case ActionCreator.RESET_IDENTITY: {
+      return state.map(account => {
+        const isMatchingAccount = account.id === action.id;
+        return isMatchingAccount ? {...account, isAdding: true, teamID: undefined, userID: undefined} : account;
+      });
+    }
+
     default:
       return state;
   }

--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -55,9 +55,7 @@ const subscribeToWebappEvents = () => {
   });
 
   amplify.subscribe(z.event.WebApp.LIFECYCLE.SIGNED_OUT, clearData => {
-    if (clearData) {
-      ipcRenderer.sendToHost(EVENT_TYPE.LIFECYCLE.SIGNED_OUT);
-    }
+    ipcRenderer.sendToHost(EVENT_TYPE.LIFECYCLE.SIGNED_OUT, clearData);
   });
 
   amplify.subscribe(z.event.WebApp.LIFECYCLE.UNREAD_COUNT, count => {


### PR DESCRIPTION
Reset identity (userId, teamId and isAdding on true) when logging out without deleting data. This allows SSO link to work properly when there is three accounts and one of them is logged out.