### PR TITLE
chore: Remove 32-bit support for Linux

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -254,7 +254,7 @@ module.exports = function(grunt) {
 
       linux_other: {
         options: {
-          arch: grunt.option('arch') || process.arch,
+          arch: 'x64',
           linux: {
             artifactName: '${productName}-${version}_${arch}.${ext}',
             category: LINUX_SETTINGS.category,
@@ -286,7 +286,7 @@ module.exports = function(grunt) {
       },
 
       options: {
-        arch: 'all',
+        arch: 'x64',
         asar: false,
         publish: null,
       },
@@ -412,19 +412,6 @@ module.exports = function(grunt) {
     delete options.arch;
 
     const done = this.async();
-
-    if (arch === 'all') {
-      return electronBuilder
-        .build({
-          config: options,
-          targets: electronBuilder.Platform.LINUX.createTarget(
-            targets,
-            electronBuilder.Arch.ia32,
-            electronBuilder.Arch.x64
-          ),
-        })
-        .then(done, done);
-    }
 
     electronBuilder
       .build({

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ yarn build:win
 yarn build:linux
 ```
 
-### Other Linux targets or architectures
+### Other Linux targets
 
-If you would like to build for another Linux target or architecture, run the following command:
+If you would like to build for another Linux target, run the following command:
 
 ```shell
-grunt --arch=<arch> --target=<target> linux-other
+grunt --target=<target> linux-other
 ```
 
-Replace `<arch>` and `<target>` with your desired architecture (e.g. `"ia32"`) and target (e.g. `"rpm"`). Have a look at the [documentation for `electron-builder`](https://github.com/electron-userland/electron-builder/wiki/Options) for the available options. Note that we cannot offer support for uncommon architectures or targets.
+Replace `<target>` with your desired target (e.g. `"rpm"`). Have a look at the [documentation for `electron-builder`](https://www.electron.build/configuration/linux) for the available options. Note that we cannot offer support for uncommon targets.
 
 ### Troubleshooting
 

--- a/bin/linux-prod-s3.py
+++ b/bin/linux-prod-s3.py
@@ -46,31 +46,17 @@ def upload_file(source, dest):
 if __name__ == '__main__':
   files = [
     'sha256sum.txt.asc',
-    'Wire-%s-i386.AppImage' % VERSION,
     'Wire-%s-x86_64.AppImage' % VERSION,
     'debian/pool/main/Wire-%s-amd64.deb' % VERSION,
-    'debian/pool/main/Wire-%s-i386.deb' % VERSION,
-    'debian/dists/stable/Contents-all',
-    'debian/dists/stable/Contents-all.bz2',
-    'debian/dists/stable/Contents-all.gz',
     'debian/dists/stable/Contents-amd64',
     'debian/dists/stable/Contents-amd64.bz2',
     'debian/dists/stable/Contents-amd64.gz',
-    'debian/dists/stable/Contents-i386',
-    'debian/dists/stable/Contents-i386.bz2',
-    'debian/dists/stable/Contents-i386.gz',
     'debian/dists/stable/InRelease',
     'debian/dists/stable/Release',
     'debian/dists/stable/Release.gpg',
-    'debian/dists/stable/main/binary-all/Packages',
-    'debian/dists/stable/main/binary-all/Packages.bz2',
-    'debian/dists/stable/main/binary-all/Packages.gz',
     'debian/dists/stable/main/binary-amd64/Packages',
     'debian/dists/stable/main/binary-amd64/Packages.bz2',
     'debian/dists/stable/main/binary-amd64/Packages.gz',
-    'debian/dists/stable/main/binary-i386/Packages',
-    'debian/dists/stable/main/binary-i386/Packages.bz2',
-    'debian/dists/stable/main/binary-i386/Packages.gz',
   ]
 
   for filename in files:

--- a/bin/repo/conf/apt-ftparchive.conf
+++ b/bin/repo/conf/apt-ftparchive.conf
@@ -16,5 +16,5 @@ TreeDefault {
 };
 Tree "dists/stable" {
     Sections "main";
-    Architectures "i386 amd64 all";
+    Architectures "amd64";
 }

--- a/bin/repo/conf/stable.conf
+++ b/bin/repo/conf/stable.conf
@@ -1,4 +1,4 @@
-APT::FTPArchive::Release::Architectures "i386 amd64 all";
+APT::FTPArchive::Release::Architectures "amd64";
 APT::FTPArchive::Release::Codename "stable";
 APT::FTPArchive::Release::Components "main";
 APT::FTPArchive::Release::Description "Cross platform desktop app, wrapping the Wire Webapp. Based on Electron.";

--- a/bin/repo/linux-prod-repo.sh
+++ b/bin/repo/linux-prod-repo.sh
@@ -40,7 +40,7 @@ _error_exit() {
   exit 1
 }
 
-mkdir -p "${BINARY_DIR}" "${STABLE_DIR}/main/binary-"{all,i386,amd64} "${CONF_DIR}" "${CACHE_DIR}"
+mkdir -p "${BINARY_DIR}" "${STABLE_DIR}/main/binary-amd64" "${CONF_DIR}" "${CACHE_DIR}"
 
 if ! _command_exist "gpg2"; then
   _error_exit "Could not find gpg2. Please install package 'gnupg2' version 2.0.x."

--- a/jenkins/linux.groovy
+++ b/jenkins/linux.groovy
@@ -70,10 +70,8 @@ node('node180') {
     stage('Test packaging') {
         if (production) {
           sh 'dpkg-deb --info wrap/dist/debian/pool/main/*amd64.deb'
-          sh 'dpkg-deb --info wrap/dist/debian/pool/main/*i386.deb'
         } else {
           sh 'dpkg-deb --info wrap/dist/*amd64.deb'
-          sh 'dpkg-deb --info wrap/dist/*i386.deb'
         }
     }
 


### PR DESCRIPTION
See the official announcement from Electron: [Discontinuing support for 32-bit Linux](https://electronjs.org/blog/linux-32bit-support).