### PR TITLE
chore: Split other Linux build tasks as well

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -585,11 +585,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('linux-custom', ['linux-custom-package', 'electronbuilder:linux_prod']);
 
-  grunt.registerTask('linux-other-internal-package', ['linux-package']);
+  grunt.registerTask('linux-other-internal', ['linux-package', 'electronbuilder:linux_other']);
 
-  grunt.registerTask('linux-other-internal', ['linux-other-internal-package', 'electronbuilder:linux_other']);
-
-  grunt.registerTask('linux-other-package', ['linux-prod-package']);
-
-  grunt.registerTask('linux-other', ['linux-other-package', 'electronbuilder:linux_other']);
+  grunt.registerTask('linux-other', ['linux-prod-package', 'electronbuilder:linux_other']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -561,8 +561,6 @@ module.exports = function(grunt) {
     'bundle',
   ]);
 
-  grunt.registerTask('linux', ['linux-package', 'electronbuilder:linux_internal']);
-
   grunt.registerTask('linux-prod-package', [
     'clean:wrap',
     'update-keys',
@@ -572,8 +570,6 @@ module.exports = function(grunt) {
     'bundle',
   ]);
 
-  grunt.registerTask('linux-prod', ['linux-prod-package', 'electronbuilder:linux_prod']);
-
   grunt.registerTask('linux-custom-package', [
     'clean:wrap',
     'update-keys',
@@ -582,6 +578,10 @@ module.exports = function(grunt) {
     'release-custom',
     'bundle',
   ]);
+
+  grunt.registerTask('linux', ['linux-package', 'electronbuilder:linux_internal']);
+
+  grunt.registerTask('linux-prod', ['linux-prod-package', 'electronbuilder:linux_prod']);
 
   grunt.registerTask('linux-custom', ['linux-custom-package', 'electronbuilder:linux_prod']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -585,25 +585,11 @@ module.exports = function(grunt) {
 
   grunt.registerTask('linux-custom', ['linux-custom-package', 'electronbuilder:linux_prod']);
 
-  grunt.registerTask('linux-other-internal-package', [
-    'clean:wrap',
-    'update-keys',
-    'gitinfo',
-    'set-custom-data',
-    'release-internal',
-    'bundle',
-  ]);
+  grunt.registerTask('linux-other-internal-package', ['linux-package']);
 
   grunt.registerTask('linux-other-internal', ['linux-other-internal-package', 'electronbuilder:linux_other']);
 
-  grunt.registerTask('linux-other-package', [
-    'clean:wrap',
-    'update-keys',
-    'gitinfo',
-    'set-custom-data',
-    'release-prod',
-    'bundle',
-  ]);
+  grunt.registerTask('linux-other-package', ['linux-prod-package']);
 
   grunt.registerTask('linux-other', ['linux-other-package', 'electronbuilder:linux_other']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -552,15 +552,16 @@ module.exports = function(grunt) {
     'create-windows-installer:custom',
   ]);
 
-  grunt.registerTask('linux', [
+  grunt.registerTask('linux-package', [
     'clean:wrap',
     'update-keys',
     'gitinfo',
     'set-custom-data',
     'release-internal',
     'bundle',
-    'electronbuilder:linux_internal',
   ]);
+
+  grunt.registerTask('linux', ['linux-package', 'electronbuilder:linux_internal']);
 
   grunt.registerTask('linux-prod-package', [
     'clean:wrap',
@@ -573,33 +574,36 @@ module.exports = function(grunt) {
 
   grunt.registerTask('linux-prod', ['linux-prod-package', 'electronbuilder:linux_prod']);
 
-  grunt.registerTask('linux-custom', [
+  grunt.registerTask('linux-custom-package', [
     'clean:wrap',
     'update-keys',
     'gitinfo',
     'set-custom-data',
     'release-custom',
     'bundle',
-    'electronbuilder:linux_prod',
   ]);
 
-  grunt.registerTask('linux-other-internal', [
+  grunt.registerTask('linux-custom', ['linux-custom-package', 'electronbuilder:linux_prod']);
+
+  grunt.registerTask('linux-other-internal-package', [
     'clean:wrap',
     'update-keys',
     'gitinfo',
     'set-custom-data',
     'release-internal',
     'bundle',
-    'electronbuilder:linux_other',
   ]);
 
-  grunt.registerTask('linux-other', [
+  grunt.registerTask('linux-other-internal', ['linux-other-internal-package', 'electronbuilder:linux_other']);
+
+  grunt.registerTask('linux-other-package', [
     'clean:wrap',
     'update-keys',
     'gitinfo',
     'set-custom-data',
     'release-prod',
     'bundle',
-    'electronbuilder:linux_other',
   ]);
+
+  grunt.registerTask('linux-other', ['linux-other-package', 'electronbuilder:linux_other']);
 };


### PR DESCRIPTION
No functional changes, repeating #2228 for other linux tasks. I only need it for internal (for wire-desktop-beta), but thought why not align all linux tasks at once while I'm at it.

