### PR TITLE
runfix: Update.exe is now Squirrel.exe

### DIFF
--- a/electron/src/js/squirrel.ts
+++ b/electron/src/js/squirrel.ts
@@ -32,7 +32,7 @@ app.setAppUserModelId(`com.squirrel.wire.${config.NAME.toLowerCase()}`);
 const logger = getLogger('squirrel');
 
 const rootFolder = path.resolve(process.execPath, '../../');
-const updateDotExe = path.join(rootFolder, 'Update.exe');
+const updateDotExe = path.join(rootFolder, 'Squirrel.exe');
 
 const exeName = `${config.NAME}.exe`;
 const linkName = `${config.NAME}.lnk`;

--- a/jenkins/windows.groovy
+++ b/jenkins/windows.groovy
@@ -55,13 +55,13 @@ node('node160') {
   stage('Sign build') {
     try {
       if (production) {
-        bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\Wire-win32-ia32\\Update.exe"'
+        bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\Wire-win32-ia32\\Squirrel.exe"'
         bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\Wire-win32-ia32\\Wire.exe"'
       } else if (custom) {
-        bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe\" sign /t http://timestamp.digicert.com /fd SHA256 /a \"wrap\\build\\${app_name}-win32-ia32\\Update.exe\""
+        bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe\" sign /t http://timestamp.digicert.com /fd SHA256 /a \"wrap\\build\\${app_name}-win32-ia32\\Squirrel.exe\""
         bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe\" sign /t http://timestamp.digicert.com /fd SHA256 /a \"wrap\\build\\${app_name}-win32-ia32\\${app_name}.exe\""
       } else {
-        bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\WireInternal-win32-ia32\\Update.exe"'
+        bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\WireInternal-win32-ia32\\Squirrel.exe"'
         bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" sign /t http://timestamp.digicert.com /fd SHA256 /a "wrap\\build\\WireInternal-win32-ia32\\WireInternal.exe"'
       }
     } catch(e) {


### PR DESCRIPTION
Squirrel's updater/installer was renamed from `Update.exe` to `Squirrel.exe`.

See https://github.com/electron/windows-installer/pull/288#issuecomment-468430461