### PR TITLE
fix: Add missing debug dependency

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -6,6 +6,7 @@
     "ansi-regex": "4.1.0",
     "auto-launch": "5.0.5",
     "axios": "0.18.0",
+    "debug": "4.1.1",
     "electron-window-state": "5.0.3",
     "file-url": "2.0.2",
     "fs-extra": "7.0.1",

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -590,6 +590,13 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4.1.1, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^2.5.1, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -601,13 +608,6 @@ debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 


### PR DESCRIPTION
`debug` is still used in [`ConfigurationPersistence.ts`](https://github.com/wireapp/wire-desktop/blob/6233186a5df75c4708bb2b8c8bb790f4f779d58c/electron/src/settings/ConfigurationPersistence.ts) and [`SchemaUpdater.ts`](https://github.com/wireapp/wire-desktop/blob/6233186a5df75c4708bb2b8c8bb790f4f779d58c/electron/src/settings/SchemaUpdater.ts).