### PR TITLE
chore: Remove unneeded dependencies

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -40,7 +40,6 @@
     "@types/open-graph": "0.2.0",
     "@types/raygun": "0.10.1",
     "@types/uuid": "3.4.4",
-    "cross-spawn": "6.0.5",
     "electron-mocha": "6.0.4",
     "electron-rebuild": "1.8.4",
     "istanbul": "1.1.0-alpha.1",

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -563,7 +563,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cross-spawn@6.0.5, cross-spawn@^6.0.0:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "24.5.0",
     "babel-loader": "8.0.5",
-    "commander": "2.19.0",
     "cross-env": "5.2.0",
     "css-loader": "2.1.1",
     "dotenv": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.19.0, commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0:
+commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==


### PR DESCRIPTION
This PR will
* remove `cross-spawn` and `commander` which are left over from old features and are not in use anymore.