### PR TITLE
runfix: Load correct string for website menu item

### DIFF
--- a/electron/src/interfaces/locale.ts
+++ b/electron/src/interfaces/locale.ts
@@ -80,7 +80,7 @@ export type i18nLanguageIdentifier =
   | 'menuVideoCall'
   | 'menuView'
   | 'menuWindow'
-  | 'menuWebsiteURL'
+  | 'menuWireURL'
   | 'restartLater'
   | 'restartLocale'
   | 'restartNeeded'

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -262,7 +262,7 @@ const helpTemplate: ElectronMenuItemWithI18n = {
     },
     {
       click: () => shell.openExternal(EnvironmentUtil.web.getWebsiteUrl()),
-      i18n: 'menuWebsiteURL',
+      i18n: 'menuWireURL',
     },
   ],
 };


### PR DESCRIPTION
See [en-US.json#L62](https://github.com/wireapp/wire-web-config-wire/blob/master/wire-desktop/content/translation/en-US.json#L62).