### PR TITLE
chore: Add additional config file for TS tests

### DIFF
--- a/electron/src/sso/SingleSignOn.test.main.ts
+++ b/electron/src/sso/SingleSignOn.test.main.ts
@@ -1,3 +1,21 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
 import * as assert from 'assert';
 import {SingleSignOn} from './SingleSignOn';
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-proposal-object-rest-spread": "7.4.0",
     "@babel/preset-env": "7.4.2",
     "@babel/preset-react": "7.0.0",
+    "@types/jest": "24.0.11",
     "@wireapp/copy-config": "0.5.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
@@ -59,8 +60,12 @@
       "eslint --fix",
       "git add"
     ],
-    "*.ts": [
-      "tslint --config tslint.json --project tsconfig.json --fix",
+    "**/!(*.test*).ts": [
+      "tslint --project tsconfig.json --fix",
+      "git add"
+    ],
+    "**/*.test*.ts": [
+      "tslint --project tsconfig.jest.json --fix",
       "git add"
     ],
     "*.{json,md,css}": [
@@ -92,12 +97,14 @@
     "fix:js": "yarn lint:js --fix",
     "fix:other": "yarn prettier --write",
     "fix:ts": "yarn lint:ts --fix",
-    "fix": "yarn fix:js && yarn fix:other && yarn fix:ts",
+    "fix:ts:tests": "yarn lint:ts:tests --fix",
+    "fix": "yarn fix:js && yarn fix:other && yarn fix:ts && yarn fix:ts:tests",
     "jest": "jest",
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx .",
     "lint:other": "yarn prettier --list-different",
-    "lint:ts": "tslint --config tslint.json --project tsconfig.json \"**/*.ts\"",
-    "lint": "yarn lint:js && yarn lint:other && yarn lint:ts",
+    "lint:ts": "tslint --project tsconfig.json",
+    "lint:ts:tests": "tslint --project tsconfig.jest.json",
+    "lint": "yarn lint:js && yarn lint:other && yarn lint:ts && yarn lint:ts:tests",
     "postinstall": "yarn configure && cd electron && yarn",
     "prestart": "yarn build:ts && yarn bundle:dev",
     "prettier": "prettier \"**/*.{json,md,css}\"",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "types": ["jest"]
+  },
+  "extends": "./tsconfig.json",
+  "exclude": [],
+  "include": ["electron/**/*.test*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,6 +914,18 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@24.0.11":
+  version "24.0.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
+  integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/node@*":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.10.5.tgz#fbaca34086bdc118011e1f05c47688d432f2d571"


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-desktop/pull/2417.

Without an additional `tsconfig.json` file it was not possible to lint the test files and my IDE was throwing errors because `lint-staged` was trying to lint them on commit.