### PR TITLE
fix: locale replacement, productName, Record (WEBAPP-6106)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -54,6 +54,7 @@
     "@wireapp/node-addressbook": "3.0.2"
   },
   "private": true,
+  "productName": "WireInternal",
   "repository": {
     "type": "git",
     "url": "https://github.com/wireapp/wire-desktop.git"

--- a/electron/src/interfaces/global.ts
+++ b/electron/src/interfaces/global.ts
@@ -17,13 +17,13 @@
  *
  */
 
-import {Supportedi18nStrings} from './locale';
+import {i18nStrings} from './locale';
 
 declare global {
   interface Window {
     isMac: boolean;
-    locStrings: Supportedi18nStrings;
-    locStringsDefault: Supportedi18nStrings;
+    locStrings: i18nStrings;
+    locStringsDefault: i18nStrings;
     sendBadgeCount: (count: number) => void;
     sendDeleteAccount: (accountId: string, sessionId?: string) => Promise<void>;
     sendLogoutAccount: (accountId: string) => void;

--- a/electron/src/interfaces/locale.ts
+++ b/electron/src/interfaces/locale.ts
@@ -98,10 +98,8 @@ export type i18nLanguageIdentifier =
   | 'wrapperManageTeam'
   | 'wrapperRemoveAccount';
 
-export type i18nStrings = {[identifier in i18nLanguageIdentifier]: string};
-
-export type Supportedi18nStrings = Partial<i18nStrings>;
+export type i18nStrings = Record<i18nLanguageIdentifier, string>;
 
 export type Supportedi18nLanguage = keyof typeof SupportedLanguages;
 
-export type Supportedi18nLanguageObject = {[id in Supportedi18nLanguage]: Supportedi18nStrings};
+export type Supportedi18nLanguageObject = Record<Supportedi18nLanguage, i18nStrings>;

--- a/electron/src/interfaces/main.ts
+++ b/electron/src/interfaces/main.ts
@@ -43,9 +43,7 @@ export interface PinningResult {
   verifiedPublicKeyInfo?: boolean;
 }
 
-export interface Schemata {
-  [version: string]: any;
-}
+export type Schemata = {[version: string]: any};
 
 export type Point = [number, number];
 

--- a/electron/src/interfaces/polyfills.ts
+++ b/electron/src/interfaces/polyfills.ts
@@ -28,9 +28,7 @@ export interface jsRsaSignPublicKey {
 }
 
 export interface OnHeadersReceivedDetails {
-  responseHeaders: {
-    [key: string]: string[];
-  };
+  responseHeaders: Record<string, string[]>;
 }
 
 export type OnHeadersReceivedCallback = (config: OnHeadersReceivedDetails & {cancel?: boolean}) => void;

--- a/electron/src/locale/locale.ts
+++ b/electron/src/locale/locale.ts
@@ -18,7 +18,6 @@
  */
 
 import * as Electron from 'electron';
-import * as config from '../settings/config';
 import {settings} from '../settings/ConfigurationPersistence';
 import {SettingsType} from '../settings/SettingsType';
 
@@ -120,25 +119,9 @@ const parseLocale = (locale: string): Supportedi18nLanguage => {
   return languageKeys.find(languageKey => languageKey === locale) || languageKeys[0];
 };
 
-const customReplacements: {[key: string]: string} = {
-  appName: config.NAME,
-  maximumAccounts: config.MAXIMUM_ACCOUNTS.toString(),
-};
-
 const getText = (stringIdentifier: i18nLanguageIdentifier): string => {
   const strings = getCurrent();
-  let str = LANGUAGES[strings][stringIdentifier] || LANGUAGES.en[stringIdentifier] || '';
-
-  if (str) {
-    for (const replacement of Object.keys(customReplacements)) {
-      const regex = new RegExp(`{{${replacement}}}`, 'g');
-      if (str.match(regex)) {
-        str = str.replace(regex, customReplacements[replacement]);
-      }
-    }
-  }
-
-  return str;
+  return LANGUAGES[strings][stringIdentifier] || LANGUAGES.en[stringIdentifier];
 };
 
 const setLocale = (locale: string): void => {

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -104,7 +104,7 @@ const showWindow = () => {
       if (aboutWindow) {
         const isExpected = event.sender.id === aboutWindow.webContents.id;
         if (isExpected) {
-          const resultLabels: {[index: string]: string} = {};
+          const resultLabels: Record<string, string> = {};
           labels.forEach(label => (resultLabels[label] = locale.getText(label)));
           event.sender.send(EVENT_TYPE.ABOUT.LOCALE_RENDER, resultLabels);
         }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/preset-env": "7.4.3",
     "@babel/preset-react": "7.0.0",
     "@types/mocha": "5.2.6",
-    "@wireapp/build-tools": "0.1.4",
+    "@wireapp/build-tools": "0.1.5",
     "@wireapp/copy-config": "0.5.4",
     "@wireapp/deploy-tools": "0.1.2",
     "babel-core": "7.0.0-bridge.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,10 +1117,10 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@wireapp/build-tools@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@wireapp/build-tools/-/build-tools-0.1.4.tgz#32b4736188374dd5a089bea3f37412ab51e54d0a"
-  integrity sha512-lXpj7B9dwc6AyAWuQfqMKhsQ1EXr1L9zduvHCuoItpuV6Mjt9cpOlGlpEu8XgOXbGl8ONeMOeuxkZ+ca9qBSSw==
+"@wireapp/build-tools@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@wireapp/build-tools/-/build-tools-0.1.5.tgz#fc5ffa91abbd9fb29f939695d7ecbe5df009446d"
+  integrity sha512-X9wSEALfFdSNHQxitcgzy+gvx8j6fWOm0M3LPA2McwpopkxlTIEbdn6IVg0Rt5GFt1WGZrTdzC9xzymPL3BpkA==
   dependencies:
     commander "2.20.0"
     dotenv "7.0.0"


### PR DESCRIPTION
This PR will
* add `productName` to `electron/package.json` following https://github.com/wireapp/wire-desktop-packages/pull/450
* replace `{[key: string]: string}`-like interfaces with TypeScript's built-in `Record` type
* remove locale string replacements (which were used to replace e.g. `{{appName}}` in locale strings, but we never used that)
* set all object keys to required in locale objects as there are no missing keys anymore due to automatic synchronizing in our config repositories