### PR TITLE
runfix: Don't copy config files from node_modules

### DIFF
--- a/.copyconfigrc.js
+++ b/.copyconfigrc.js
@@ -14,7 +14,6 @@ const repositoryUrl = pkg.devDependencies[configurationEntry];
 
 /** @type {CopyConfigOptions} */
 const options = {
-  externalDir: `node_modules/${configurationEntry}`,
   files: {
     [`${imageSource}/**`]: 'electron/img/',
     [`${macOsSource}/**`]: 'resources/macos/',


### PR DESCRIPTION
Otherwise builds with completely different config repos set via [`WIRE_CONFIGURATION_REPOSITORY`](https://github.com/wireapp/wire-web-packages/blob/master/packages/copy-config/README.md#environment-variables) will never copy the correct files but always the default files.

This partly reverts https://github.com/wireapp/wire-desktop/pull/2512.