### PR TITLE
chore(deps-dev): bump electron to 4.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "core-js": "2.6.5",
     "cross-env": "5.2.0",
     "css-loader": "2.1.1",
-    "electron": "4.1.4",
+    "electron": "4.1.5",
     "electron-mocha": "8.0.1",
     "electron-rebuild": "1.8.4",
     "eslint": "5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,10 +3367,10 @@ electron-winstaller@2.7.0:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-4.1.4.tgz#41ba9e041f38c25c62a7db806884410654df058f"
-  integrity sha512-MelOjntJvd33izEjR6H4N/Uii7y535z/b2BuYXJGLNSHL6o1IlyhUQmfiT87kWABayERgeuYERgvsyf956OOFw==
+electron@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-4.1.5.tgz#d1873147d5be36ab0c8bb9db3a54297a82ee8fef"
+  integrity sha512-0VZzUd4vZaUeSLdxJI/XMrMnPN7AROjPFZOiNgZZkYRUUEjGHfaSAbCJyxuXtii52KGhzGL0JgW0q5QmQ3ykKQ==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"


### PR DESCRIPTION
This one was not caught by dependabot since it wanted to update to 5.0.0 directly.