### PR TITLE
fix: Right-click in sidebar (WEBAPP-6251)

### DIFF
--- a/electron/renderer/src/components/Sidebar.jsx
+++ b/electron/renderer/src/components/Sidebar.jsx
@@ -69,7 +69,9 @@ const _Sidebar = ({
           className={getClassName(account)}
           onClick={() => connected.switchAccount(account.id)}
           onContextMenu={preventFocus(event => {
-            const isAtLeastAdmin = [z.team.ROLE.OWNER, z.team.ROLE.ADMIN].includes(account.teamRole);
+            const isAtLeastAdmin = ['z.team.TeamRole.ROLE.OWNER', 'z.team.TeamRole.ROLE.ADMIN'].includes(
+              account.teamRole
+            );
             const {centerX, centerY} = centerOfEventTarget(event);
             connected.toggleEditAccountMenuVisibility(
               centerX,


### PR DESCRIPTION
`z` was not defined since the WebApp was not loaded yet. We switch to strings for the time being.

See [`UserPermission.js#L135`](https://github.com/wireapp/wire-webapp/blob/68a81692b7ecf1bd1e4b5339f72a65d65a06297a/src/script/user/UserPermission.js#L135)