### PR TITLE
feat: Re-enable hardware acceleration on Linux

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -351,9 +351,6 @@ const addLinuxWorkarounds = () => {
     ) {
       process.env.XDG_CURRENT_DESKTOP = 'Unity';
     }
-
-    // https://github.com/electron/electron/issues/13415
-    app.disableHardwareAcceleration();
   }
 };
 


### PR DESCRIPTION
Seems like the hardware acceleration issue was fixed: https://github.com/electron/electron/issues/13415

This closes https://github.com/wireapp/wire-desktop/issues/2758.