### PR TITLE
chore: Print actual error in Jenkins console

### DIFF
--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -72,6 +72,7 @@ node('master') {
         build job: 'Wrapper_macOS_Smoke_Tests', parameters: [run(description: '', name: 'WRAPPER_BUILD', runId: "Wrapper_macOS_Production#${BUILD_ID}"), string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-rc.zinfra.io/')], wait: false
       } catch(e) {
         wireSend secret: "${jenkinsbot_secret}", message: "🍏 **${JOB_NAME} Unable to trigger smoke tests for ${version}** see: ${JOB_URL}"
+        print e
       }
     }
   }

--- a/jenkins/windows.groovy
+++ b/jenkins/windows.groovy
@@ -75,6 +75,7 @@ node('node130') {
         build job: 'Wrapper_Windows_Smoke_Tests', parameters: [run(description: '', name: 'WRAPPER_BUILD', runId: "Wrapper_Windows_Production#${BUILD_ID}"), string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-rc.zinfra.io/')], wait: false
       } catch(e) {
         wireSend secret: "${jenkinsbot_secret}", message: "🏞 **${JOB_NAME} Unable to trigger smoke tests for ${version}** see: ${JOB_URL}"
+        print e
       }
     }
   }


### PR DESCRIPTION
We swallowed the error when the smoke run can not be triggered