### PR TITLE
fix: Use Gnome icon only on X11

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -347,7 +347,7 @@ const addLinuxWorkarounds = () => {
     if (
       EnvironmentUtil.linuxDesktop.isUbuntuUnity ||
       EnvironmentUtil.linuxDesktop.isPopOS ||
-      EnvironmentUtil.linuxDesktop.isGnome
+      EnvironmentUtil.linuxDesktop.isGnomeX11
     ) {
       process.env.XDG_CURRENT_DESKTOP = 'Unity';
     }

--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -21,8 +21,8 @@ import {Menu, Tray, app, nativeImage} from 'electron';
 import * as path from 'path';
 
 import * as locale from '../locale/locale';
-import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
-import * as lifecycle from '../runtime/lifecycle';
+import {linuxDesktop, platform} from '../runtime/EnvironmentUtil';
+import {quit as lifecycleQuit} from '../runtime/lifecycle';
 import {config} from '../settings/config';
 import {WindowManager} from '../window/WindowManager';
 
@@ -45,9 +45,9 @@ export class TrayHandler {
     let trayPng = 'tray.png';
     let trayBadgePng = 'tray.badge.png';
 
-    if (EnvironmentUtil.platform.IS_LINUX) {
-      trayPng = `tray${EnvironmentUtil.linuxDesktop.isGnome ? '.gnome' : '@3x'}.png`;
-      trayBadgePng = `tray.badge${EnvironmentUtil.linuxDesktop.isGnome ? '.gnome' : '@3x'}.png`;
+    if (platform.IS_LINUX) {
+      trayPng = `tray${linuxDesktop.isGnomeX11 ? '.gnome' : '@3x'}.png`;
+      trayBadgePng = `tray.badge${linuxDesktop.isGnomeX11 ? '.gnome' : '@3x'}.png`;
     }
 
     const iconPaths = {
@@ -81,7 +81,7 @@ export class TrayHandler {
         label: locale.getText('trayOpen'),
       },
       {
-        click: () => lifecycle.quit(),
+        click: () => lifecycleQuit(),
         label: locale.getText('trayQuit'),
       },
     ]);

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -70,9 +70,15 @@ const isProdEnvironment = (): boolean => {
   );
 };
 
-const isLinuxDesktop = (identifier: string): boolean => {
-  const xdgDesktop = process.env.XDG_CURRENT_DESKTOP;
-  return !!xdgDesktop && xdgDesktop.includes(identifier);
+const isEnvVar = (envVar: string, value: string, caseSensitive = false): boolean => {
+  let envVarContent = process.env[envVar] || '';
+
+  if (!caseSensitive) {
+    envVar = envVar.toLowerCase();
+    envVarContent = envVarContent.toLowerCase();
+  }
+
+  return envVarContent.includes(value);
 };
 
 export const platform = {
@@ -82,9 +88,9 @@ export const platform = {
 };
 
 export const linuxDesktop = {
-  isGnome: isLinuxDesktop('GNOME'),
-  isPopOS: isLinuxDesktop('pop'),
-  isUbuntuUnity: isLinuxDesktop('Unity'),
+  isGnomeX11: isEnvVar('XDG_CURRENT_DESKTOP', 'gnome') && isEnvVar('XDG_SESSION_TYPE', 'x11'),
+  isPopOS: isEnvVar('XDG_CURRENT_DESKTOP', 'pop'),
+  isUbuntuUnity: isEnvVar('XDG_CURRENT_DESKTOP', 'Unity'),
 };
 
 const restoreEnvironment = (): BackendTypeLabelKey => {


### PR DESCRIPTION
Probable fix for https://github.com/wireapp/wire-desktop/issues/957.