### PR TITLE
fix: macOS quit shortcut (WEBAPP-6358)

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -301,6 +301,7 @@ const darwinTemplate: MenuItemConstructorOptions = {
     signOutTemplate,
     {
       accelerator: 'Command+Q',
+      click: () => lifecycle.quit(),
       label: locale.getText('menuQuit'),
     },
   ],


### PR DESCRIPTION
This got lost during the refactor in https://github.com/wireapp/wire-desktop/pull/2846.