### PR TITLE
fix: Permissions for Chrome sandbox on Linux

### DIFF
--- a/bin/deb/after-install.tpl
+++ b/bin/deb/after-install.tpl
@@ -20,3 +20,7 @@ fi
 
 # Link to the binary
 ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
+
+# Prepare Chrome sandbox
+chown root '/opt/${productFilename}/chrome-sandbox'
+chmod 4755 '/opt/${productFilename}/chrome-sandbox'


### PR DESCRIPTION
This helps with https://github.com/electron/electron/issues/17972 on Linux machines not being able to run Wire with Electron 5 after installation.