### PR TITLE
chore: Start without sandbox, reuse variable

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -444,7 +444,7 @@ class ElectronWrapperInit {
             contents.on('console-message', async (event, level, message) => {
               const webViewId = getWebViewId(contents);
               if (webViewId) {
-                const logFilePath = path.join(app.getPath('userData'), 'logs', webViewId, config.logFileName);
+                const logFilePath = path.join(LOG_DIR, webViewId, config.logFileName);
                 try {
                   await LogFactory.writeMessage(message, logFilePath);
                 } catch (error) {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "prestart": "yarn build:ts && yarn bundle:dev",
     "prettier": "prettier \"**/*.{json,md,css,yml}\"",
     "rebuild": "electron-rebuild -f -w @wireapp/node-addressbook",
-    "start": "cross-env NODE_DEBUG=@wireapp* electron . --inspect --devtools --enable-logging",
+    "start": "cross-env NODE_DEBUG=@wireapp* electron . --no-sandbox --inspect --devtools --enable-logging",
     "start:dev": "yarn start --env=https://wire-webapp-dev.zinfra.io",
     "start:edge": "yarn start --env=https://wire-webapp-edge.zinfra.io",
     "start:internal": "yarn start --env=https://wire-webapp-staging.wire.com",


### PR DESCRIPTION
Because of https://github.com/electron/electron/issues/17972 starting the app on Linux machines always returns the error "The SUID sandbox helper binary was found, but is not configured correctly. [...]".