### PR TITLE
fix: Speed up link preview generation (WEBAPP-6415)

### DIFF
--- a/electron/src/lib/openGraph.ts
+++ b/electron/src/lib/openGraph.ts
@@ -167,16 +167,7 @@ const fetchOpenGraphData = async (url: string): Promise<OpenGraphResult> => {
   };
 
   const body = await axiosWithContentLimit(axiosConfig, CONTENT_SIZE_LIMIT);
-  // For the regex, see https://regex101.com/r/U62pCH/2
-  const matches = body.match(/.*property=(["'])?og:.+?\1.*/gim) || [''];
-
-  if (!matches) {
-    throw new Error('No open graph tags found in website.');
-  }
-
-  const openGraphTags = matches.join(' ');
-
-  return openGraphParse(openGraphTags);
+  return openGraphParse(body);
 };
 
 const updateMetaDataWithImage = (meta: OpenGraphResult, imageData?: string): OpenGraphResult => {
@@ -200,7 +191,7 @@ export const getOpenGraphData = async (url: string, callback: GetDataCallback): 
       const [imageUrl] = arrayify(meta.image.url);
 
       const uri = await fetchImageAsBase64(imageUrl);
-      meta = await updateMetaDataWithImage(meta, uri);
+      meta = updateMetaDataWithImage(meta, uri);
     } else {
       throw new Error('OpenGraph metadata contains no image.');
     }


### PR DESCRIPTION
Finding a regex match in a large website is very costly and can take a long time. Since open-graph [uses cheerio](https://github.com/samholmes/node-open-graph/blob/master/index.js#L59) to parse the content, it's much faster. As a result we will just send the whole body to open-graph instead of trying to parse it ourselves.