### PR TITLE
fix: Log with filename only

### DIFF
--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -17,6 +17,8 @@
  *
  */
 
+const path = require('path');
+
 const environment = require('../../dist/runtime/EnvironmentUtil');
 const {getLogger} = require('../../dist/logging/getLogger');
 const {EVENT_TYPE} = require('../../dist/lib/eventType');
@@ -24,7 +26,7 @@ const {EVENT_TYPE} = require('../../dist/lib/eventType');
 const {ipcRenderer, remote, webFrame} = require('electron');
 const {systemPreferences} = remote;
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 // Note: Until appearance-changed event is available in a future
 // version of Electron... use AppleInterfaceThemeChangedNotification event

--- a/electron/src/lib/CertificateVerifyProcManager.ts
+++ b/electron/src/lib/CertificateVerifyProcManager.ts
@@ -20,12 +20,13 @@
 import * as certificateUtils from '@wireapp/certificate-check';
 import {dialog} from 'electron';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 
 import {getText} from '../locale/locale';
 import {getLogger} from '../logging/getLogger';
 import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 interface DisplayCertificateErrorOptions {
   bypassDialogLock: boolean;

--- a/electron/src/lib/CoreProtocol.ts
+++ b/electron/src/lib/CoreProtocol.ts
@@ -18,6 +18,7 @@
  */
 
 import {app} from 'electron';
+import * as path from 'path';
 import {URL} from 'url';
 
 import {getLogger} from '../logging/getLogger';
@@ -26,7 +27,7 @@ import {config} from '../settings/config';
 import {WindowManager} from '../window/WindowManager';
 import {EVENT_TYPE} from './eventType';
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 const CORE_PROTOCOL_PREFIX = `${config.customProtocolName}://`;
 const CORE_PROTOCOL_POSITION = 1;

--- a/electron/src/lib/LocalAccountDeletion.ts
+++ b/electron/src/lib/LocalAccountDeletion.ts
@@ -27,7 +27,7 @@ import {getLogger} from '../logging/getLogger';
 const USER_DATA_DIR = app.getPath('userData');
 const LOG_DIR = path.join(USER_DATA_DIR, 'logs');
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 const clearStorage = (session: Electron.Session): Promise<void> => {
   return new Promise(resolve =>

--- a/electron/src/lib/openGraph.ts
+++ b/electron/src/lib/openGraph.ts
@@ -22,6 +22,7 @@ import {parse as parseContentType} from 'content-type';
 import {IncomingMessage} from 'http';
 import {decode as iconvDecode} from 'iconv-lite';
 import {Data as OpenGraphResult, parse as openGraphParse} from 'open-graph';
+import * as path from 'path';
 import {parse as parseUrl} from 'url';
 
 import {getLogger} from '../logging/getLogger';
@@ -29,7 +30,7 @@ import {config} from '../settings/config';
 
 type GetDataCallback = (error: Error | null, meta?: OpenGraphResult) => void;
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 axios.defaults.adapter = require('axios/lib/adapters/http'); // always use Node.js adapter
 

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -78,7 +78,7 @@ if (argv.version) {
   process.exit();
 }
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 // Icon
 const ICON = `wire.${EnvironmentUtil.platform.IS_WINDOWS ? 'ico' : 'png'}`;

--- a/electron/src/renderer/preload.ts
+++ b/electron/src/renderer/preload.ts
@@ -18,6 +18,7 @@
  */
 
 import {IpcMessageEvent, WebviewTag, ipcRenderer, webFrame} from 'electron';
+import * as path from 'path';
 
 import {EVENT_TYPE} from '../lib/eventType';
 import * as locale from '../locale/locale';
@@ -25,7 +26,7 @@ import {getLogger} from '../logging/getLogger';
 import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
 import {AutomatedSingleSignOn} from '../sso/AutomatedSingleSignOn';
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 webFrame.setZoomFactor(1.0);
 webFrame.setVisualZoomLevelLimits(1, 1);

--- a/electron/src/settings/SchemaUpdater.ts
+++ b/electron/src/settings/SchemaUpdater.ts
@@ -27,7 +27,7 @@ import {SettingsType} from './SettingsType';
 
 const app = Electron.app || Electron.remote.app;
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 const defaultPathV0 = path.join(app.getPath('userData'), 'init.json');
 const defaultPathV1 = path.join(app.getPath('userData'), 'config/init.json');
 

--- a/electron/src/update/Squirrel.ts
+++ b/electron/src/update/Squirrel.ts
@@ -19,9 +19,8 @@
 
 // https://github.com/atom/atom/blob/ce18e1b7d65808c42df5b612d124935ab5c06490/src/main-process/squirrel-update.js
 
-import {app} from 'electron';
-
 import * as cp from 'child_process';
+import {app} from 'electron';
 import * as fs from 'fs';
 import * as moment from 'moment';
 import * as path from 'path';
@@ -36,7 +35,7 @@ type SpawnError = Error & {code?: number | null; stdout?: string | null};
 
 app.setAppUserModelId(`com.squirrel.wire.${config.name.toLowerCase()}`);
 
-const logger = getLogger(__filename);
+const logger = getLogger(path.basename(__filename));
 
 const appFolder = path.resolve(process.execPath, '..');
 const rootFolder = path.resolve(appFolder, '..');


### PR DESCRIPTION
Currently the logs look like this:
```
@wireapp/desktop//Users/<username>/git/wire-desktop/electron/renderer/static/webview-preload.js [2019-09-10 15:42:31] <some message>
```

But they should look like this:
```
@wireapp/desktop/webview-preload.js [2019-09-10 15:42:31] <some message>
```