### PR TITLE
fix: Don't send link previews without metadata, remove synchronous openGraph (WEBAPP-6508)

### DIFF
--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -148,11 +148,10 @@ const checkAvailability = callback => {
 const _clearImmediate = clearImmediate;
 const _setImmediate = setImmediate;
 process.once('loaded', () => {
-  const {getOpenGraphData, getOpenGraphDataAsync} = require('../../dist/lib/openGraph');
+  const {getOpenGraphDataAsync} = require('../../dist/lib/openGraph');
 
   global.clearImmediate = _clearImmediate;
   global.environment = environment;
-  global.openGraph = getOpenGraphData;
   global.openGraphAsync = getOpenGraphDataAsync;
   global.setImmediate = _setImmediate;
 });

--- a/electron/src/lib/openGraph.ts
+++ b/electron/src/lib/openGraph.ts
@@ -191,9 +191,16 @@ const updateMetaDataWithImage = (meta: OpenGraphResult, imageData?: string): Ope
   return meta;
 };
 
+/**
+ * @deprecated Use `getOpenGraphDataAsync()`
+ */
 export const getOpenGraphData = async (url: string, callback: GetDataCallback): Promise<void> => {
   try {
     let meta = await fetchOpenGraphData(url);
+
+    if (!meta.description && !meta.image && !meta.type && !meta.url) {
+      throw new Error('No openGraph data found');
+    }
 
     if (Array.isArray(meta.image)) {
       meta.image = meta.image[0];
@@ -222,6 +229,10 @@ export const getOpenGraphData = async (url: string, callback: GetDataCallback): 
 
 export const getOpenGraphDataAsync = async (url: string): Promise<OpenGraphResult> => {
   const metadata = await fetchOpenGraphData(url);
+
+  if (!metadata.description && !metadata.image && !metadata.type && !metadata.url) {
+    throw new Error('No openGraph data found');
+  }
 
   if (Array.isArray(metadata.image)) {
     metadata.image = metadata.image[0];

--- a/electron/src/lib/openGraph.ts
+++ b/electron/src/lib/openGraph.ts
@@ -28,8 +28,6 @@ import {parse as parseUrl} from 'url';
 import {getLogger} from '../logging/getLogger';
 import {config} from '../settings/config';
 
-type GetDataCallback = (error: Error | null, meta?: OpenGraphResult) => void;
-
 const logger = getLogger(path.basename(__filename));
 
 axios.defaults.adapter = require('axios/lib/adapters/http'); // always use Node.js adapter
@@ -189,42 +187,6 @@ const updateMetaDataWithImage = (meta: OpenGraphResult, imageData?: string): Ope
   }
 
   return meta;
-};
-
-/**
- * @deprecated Use `getOpenGraphDataAsync()`
- */
-export const getOpenGraphData = async (url: string, callback: GetDataCallback): Promise<void> => {
-  try {
-    let meta = await fetchOpenGraphData(url);
-
-    if (!meta.description && !meta.image && !meta.type && !meta.url) {
-      throw new Error('No openGraph data found');
-    }
-
-    if (Array.isArray(meta.image)) {
-      meta.image = meta.image[0];
-    }
-
-    if (typeof meta.image === 'object' && !Array.isArray(meta.image) && meta.image.url) {
-      const [imageUrl] = arrayify(meta.image.url);
-
-      const uri = await fetchImageAsBase64(imageUrl);
-      meta = updateMetaDataWithImage(meta, uri);
-    } else {
-      delete meta.image;
-    }
-
-    if (callback) {
-      callback(null, meta);
-    }
-  } catch (error) {
-    if (callback) {
-      callback(error);
-    } else {
-      logger.info(error);
-    }
-  }
 };
 
 export const getOpenGraphDataAsync = async (url: string): Promise<OpenGraphResult> => {


### PR DESCRIPTION
This removes `window.openGraph` which was in use by the WebApp but is already replaced by `window.openGraphAsync` for 8 months.