### PR TITLE
fix: Don't send link previews without metadata, remove synchronous openGraph (WEBAPP-6508) (backport)

### DIFF
--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -149,12 +149,11 @@ const checkAvailability = callback => {
 const _clearImmediate = clearImmediate;
 const _setImmediate = setImmediate;
 process.once('loaded', () => {
-  const {getOpenGraphData, getOpenGraphDataAsync} = require('../../dist/lib/openGraph');
+  const {getOpenGraphDataAsync} = require('../../dist/lib/openGraph');
 
   global.clearImmediate = _clearImmediate;
   global.desktopCapturer = desktopCapturer;
   global.environment = environment;
-  global.openGraph = getOpenGraphData;
   global.openGraphAsync = getOpenGraphDataAsync;
   global.setImmediate = _setImmediate;
 });


### PR DESCRIPTION
Backported https://github.com/wireapp/wire-desktop/pull/3158 to Electron 4.