### PR TITLE
fix: Portable path (backport)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -424,11 +424,12 @@ const addLinuxWorkarounds = () => {
 };
 
 const handlePortableFlags = () => {
-  if (argv.portable || argv.user_data_dir) {
-    const USER_PATH =
-      path.resolve(argv.user_data_dir) || path.join(process.env.APPIMAGE || process.execPath, '../Data');
+  if (argv.user_data_dir || argv.portable) {
+    const USER_PATH = argv.user_data_dir
+      ? path.resolve(argv.user_data_dir)
+      : path.join(process.env.APPIMAGE || process.execPath, '../Data');
 
-    console.log(`Saving user data to ${USER_PATH}`);
+    logger.log(`Saving user data to "${USER_PATH}".`);
     app.setPath('userData', USER_PATH);
   }
 };


### PR DESCRIPTION
Backported https://github.com/wireapp/wire-desktop/pull/3094 to Electron 4.