### PR TITLE
fix: Set alwaysStrict option in TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "alwaysStrict": true,
     "declaration": true,
     "downlevelIteration": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This will add `'use strict'` to transpiled JS files.

- [MDN identifies performance improvements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Securing_JavaScript) in avoiding boxing `this` in function calls, and the removal of the `function.caller` and `function.arguments` properties.

- Jeff Walden of Mozilla has also hinted at opportunities for performance gains in [this StackOverflow answer](https://stackoverflow.com/questions/3145966/is-strict-mode-more-performant/4642633#4642633).