### PR TITLE
runfix: Re-enable desktopCapturer

### DIFF
--- a/electron/renderer/static/webview-preload.js
+++ b/electron/renderer/static/webview-preload.js
@@ -20,7 +20,7 @@
 const environment = require('../../dist/runtime/EnvironmentUtil');
 const {EVENT_TYPE} = require('../../dist/lib/eventType');
 
-const {ipcRenderer, remote, webFrame} = require('electron');
+const {desktopCapturer, ipcRenderer, remote, webFrame} = require('electron');
 const {systemPreferences} = remote;
 
 // Note: Until appearance-changed event is available in a future
@@ -152,6 +152,7 @@ process.once('loaded', () => {
 
   global.clearImmediate = _clearImmediate;
   global.environment = environment;
+  global.desktopCapturer = desktopCapturer;
   global.openGraphAsync = getOpenGraphDataAsync;
   global.setImmediate = _setImmediate;
 });


### PR DESCRIPTION
Re-enabling `desktopCapturer` because of https://github.com/electron/electron/issues/16513 and https://github.com/electron/electron/issues/19017.