### PR TITLE
fix: Avoid global shortcuts

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -248,11 +248,8 @@ const showMainWindow = async (mainWindowState: WindowStateKeeper.State) => {
   });
 
   main.on('focus', () => {
-    systemMenu.registerShortcuts();
     main.flashFrame(false);
   });
-
-  main.on('blur', () => systemMenu.unregisterGlobalShortcuts());
 
   main.on('page-title-updated', () => tray.showUnreadCount(main));
 
@@ -269,7 +266,6 @@ const showMainWindow = async (mainWindowState: WindowStateKeeper.State) => {
         main.hide();
       }
     }
-    systemMenu.unregisterGlobalShortcuts();
   });
 
   main.webContents.on('crashed', event => {

--- a/electron/src/menu/developer.ts
+++ b/electron/src/menu/developer.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {MenuItem, app, dialog} from 'electron';
+import {MenuItem, MenuItemConstructorOptions, app, dialog} from 'electron';
 import * as openExternal from 'open';
 import * as path from 'path';
 
@@ -31,7 +31,7 @@ import * as WindowManager from '../window/WindowManager';
 const currentEnvironment = EnvironmentUtil.getEnvironment();
 const logger = getLogger(path.basename(__filename));
 
-const reloadTemplate: Electron.MenuItemConstructorOptions = {
+const reloadTemplate: MenuItemConstructorOptions = {
   click: () => {
     const primaryWindow = WindowManager.getPrimaryWindow();
     if (primaryWindow) {
@@ -41,7 +41,7 @@ const reloadTemplate: Electron.MenuItemConstructorOptions = {
   label: 'Reload',
 };
 
-const sendLogTemplate: Electron.MenuItemConstructorOptions = {
+const sendLogTemplate: MenuItemConstructorOptions = {
   click: async () => {
     const logText = await gatherLogs();
     const subject = encodeURIComponent('Wire Desktop Log');
@@ -71,7 +71,7 @@ const sendLogTemplate: Electron.MenuItemConstructorOptions = {
   label: 'Send Debug Logs',
 };
 
-const devToolsTemplate: Electron.MenuItemConstructorOptions = {
+const devToolsTemplate: MenuItemConstructorOptions = {
   label: 'Toggle DevTools',
   submenu: [
     {
@@ -118,7 +118,7 @@ const devToolsTemplate: Electron.MenuItemConstructorOptions = {
 };
 
 const createEnvironmentTemplates = () => {
-  const environmentTemplate: Electron.MenuItemConstructorOptions[] = [];
+  const environmentTemplate: MenuItemConstructorOptions[] = [];
   for (const backendType of Object.values(EnvironmentUtil.BackendType)) {
     environmentTemplate.push({
       checked: currentEnvironment === backendType,
@@ -135,26 +135,26 @@ const createEnvironmentTemplates = () => {
   return environmentTemplate;
 };
 
-const versionTemplate: Electron.MenuItemConstructorOptions = {
+const versionTemplate: MenuItemConstructorOptions = {
   enabled: false,
   label: `${config.name} Version ${config.version || 'Development'}`,
 };
 
-const chromeVersionTemplate: Electron.MenuItemConstructorOptions = {
+const chromeVersionTemplate: MenuItemConstructorOptions = {
   enabled: false,
   label: `Chrome Version ${process.versions.chrome}`,
 };
 
-const electronVersionTemplate: Electron.MenuItemConstructorOptions = {
+const electronVersionTemplate: MenuItemConstructorOptions = {
   enabled: false,
   label: `Electron Version ${process.versions.electron}`,
 };
 
-const separatorTemplate: Electron.MenuItemConstructorOptions = {
+const separatorTemplate: MenuItemConstructorOptions = {
   type: 'separator',
 };
 
-const menuTemplate: Electron.MenuItemConstructorOptions = {
+const menuTemplate: MenuItemConstructorOptions = {
   id: 'Developer',
   label: '&Developer',
   submenu: [

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -18,7 +18,7 @@
  */
 
 import autoLaunch = require('auto-launch');
-import {Menu, MenuItemConstructorOptions, dialog, globalShortcut, ipcMain, shell} from 'electron';
+import {Menu, MenuItemConstructorOptions, dialog, ipcMain, shell} from 'electron';
 import * as path from 'path';
 
 import {EVENT_TYPE} from '../lib/eventType';
@@ -356,8 +356,6 @@ const linuxTemplate: MenuItemConstructorOptions = {
   ],
 };
 
-const menuTemplate: MenuItemConstructorOptions[] = [conversationTemplate, editTemplate, windowTemplate, helpTemplate];
-
 const processMenu = (template: Iterable<MenuItemConstructorOptions>, language: Supportedi18nLanguage) => {
   for (const item of template) {
     if (item.submenu) {
@@ -391,6 +389,8 @@ const changeLocale = (language: Supportedi18nLanguage): void => {
 };
 
 export const createMenu = (isFullScreen: boolean): Menu => {
+  const menuTemplate = [conversationTemplate, editTemplate, windowTemplate, helpTemplate];
+
   if (!windowTemplate.submenu) {
     windowTemplate.submenu = [];
   }
@@ -414,6 +414,30 @@ export const createMenu = (isFullScreen: boolean): Menu => {
     windowTemplate.label = locale.getText('menuView');
     if (Array.isArray(windowTemplate.submenu)) {
       windowTemplate.submenu.unshift(toggleMenuTemplate, separatorTemplate);
+    }
+  }
+
+  if (Array.isArray(windowTemplate.submenu)) {
+    const muteShortcut = 'CmdOrCtrl+Alt+M';
+    logger.info(`Registering mute shortcut "${muteShortcut}" ...`);
+
+    windowTemplate.submenu.push({
+      accelerator: muteShortcut,
+      click: () =>
+        WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
+      label: 'Toggle mute',
+      visible: false,
+    });
+
+    const accountLimit = config.maximumAccounts;
+    for (let accountId = 0; accountId < accountLimit; accountId++) {
+      logger.info(`Registering account switching shortcut "CmdOrCtrl+${accountId + 1}" ...`);
+      windowTemplate.submenu.push({
+        accelerator: `CmdOrCtrl+${accountId + 1}`,
+        click: () => WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, accountId),
+        label: `Switch to account ${accountId + 1}`,
+        visible: false,
+      });
     }
   }
 
@@ -442,25 +466,6 @@ export const createMenu = (isFullScreen: boolean): Menu => {
   return Menu.buildFromTemplate(menuTemplate);
 };
 
-export const registerShortcuts = (): void => {
-  // Global mute shortcut
-  const muteShortcut = 'CmdOrCtrl+Alt+M';
-  logger.info(`Registering global mute shortcut "${muteShortcut}" ...`);
-  globalShortcut.register(muteShortcut, () =>
-    WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
-  );
-
-  // Global account switching shortcut
-  const accountLimit = config.maximumAccounts;
-  for (let accountId = 0; accountId < accountLimit; accountId++) {
-    logger.info(`Registering global account switching shortcut "CmdOrCtrl+${accountId + 1}" ...`);
-    globalShortcut.register(`CmdOrCtrl+${accountId + 1}`, () => {
-      logger.info(`Switching to account "${accountId}" ...`);
-      WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, accountId);
-    });
-  }
-};
-
 export const toggleMenuBar = (): void => {
   const mainBrowserWindow = WindowManager.getPrimaryWindow();
 
@@ -472,9 +477,4 @@ export const toggleMenuBar = (): void => {
       mainBrowserWindow.setMenuBarVisibility(!isVisible);
     }
   }
-};
-
-export const unregisterGlobalShortcuts = (): void => {
-  logger.info('Unregistering all global shortcuts ...');
-  globalShortcut.unregisterAll();
 };

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -429,13 +429,13 @@ export const createMenu = (isFullScreen: boolean): Menu => {
       visible: false,
     };
 
-    const switchShortcuts: MenuItemConstructorOptions[] = [...Array(config.maximumAccounts).keys()].map(accountId => {
-      const switchAccelerator = `CmdOrCtrl+${accountId + 1}`;
+    const switchShortcuts: MenuItemConstructorOptions[] = [...Array(config.maximumAccounts).keys()].map(index => {
+      const switchAccelerator = `CmdOrCtrl+${index + 1}`;
       logger.info(`Registering account switching shortcut "${switchAccelerator}" ...`);
       return {
         accelerator: switchAccelerator,
-        click: () => WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, accountId),
-        label: `Switch to account ${accountId + 1}`,
+        click: () => WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, index),
+        label: `Switch to account ${index + 1}`,
         visible: false,
       };
     });

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -418,27 +418,29 @@ export const createMenu = (isFullScreen: boolean): Menu => {
   }
 
   if (Array.isArray(windowTemplate.submenu)) {
-    const muteShortcut = 'CmdOrCtrl+Alt+M';
-    logger.info(`Registering mute shortcut "${muteShortcut}" ...`);
+    const muteAccelerator = 'CmdOrCtrl+Alt+M';
+    logger.info(`Registering mute shortcut "${muteAccelerator}" ...`);
 
-    windowTemplate.submenu.push({
-      accelerator: muteShortcut,
+    const muteShortcut: MenuItemConstructorOptions = {
+      accelerator: muteAccelerator,
       click: () =>
         WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
       label: 'Toggle mute',
       visible: false,
-    });
+    };
 
-    const accountLimit = config.maximumAccounts;
-    for (let accountId = 0; accountId < accountLimit; accountId++) {
-      logger.info(`Registering account switching shortcut "CmdOrCtrl+${accountId + 1}" ...`);
-      windowTemplate.submenu.push({
-        accelerator: `CmdOrCtrl+${accountId + 1}`,
+    const switchShortcuts: MenuItemConstructorOptions[] = [...Array(config.maximumAccounts).keys()].map(accountId => {
+      const switchAccelerator = `CmdOrCtrl+${accountId + 1}`;
+      logger.info(`Registering account switching shortcut "${switchAccelerator}" ...`);
+      return {
+        accelerator: switchAccelerator,
         click: () => WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, accountId),
         label: `Switch to account ${accountId + 1}`,
         visible: false,
-      });
-    }
+      };
+    });
+
+    windowTemplate.submenu.push(muteShortcut, ...switchShortcuts);
   }
 
   if (EnvironmentUtil.platform.IS_LINUX) {

--- a/electron/src/runtime/lifecycle.ts
+++ b/electron/src/runtime/lifecycle.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {app, globalShortcut, ipcMain} from 'electron';
+import {app, ipcMain} from 'electron';
 import * as path from 'path';
 
 import {EVENT_TYPE} from '../lib/eventType';
@@ -62,7 +62,6 @@ export const quit = () => {
   settings.persistToFile();
 
   logger.info('Unregistering all global shortcuts ...');
-  globalShortcut.unregisterAll();
 
   logger.info('Exiting ...');
   app.exit();


### PR DESCRIPTION
The trick here is to create an invisible menu item with an accelerator (the shortcut) which will act as a local shortcut. See [Local Shortcuts](https://github.com/electron/electron/blob/v5.0.12/docs/tutorial/keyboard-shortcuts.md#local-shortcuts).

This fixes https://github.com/wireapp/wire-desktop/issues/2577.