### PR TITLE
fix(build-tools): Don't ask to integrate AppImage

### DIFF
--- a/bin/build-tools/lib/build-linux.ts
+++ b/bin/build-tools/lib/build-linux.ts
@@ -75,6 +75,10 @@ export function buildLinuxConfig(
   const debDepends = ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'];
 
   const builderConfig: electronBuilder.Configuration = {
+    appImage: {
+      ...platformSpecificConfig,
+      systemIntegration: 'doNotAsk',
+    },
     asar: commonConfig.enableAsar,
     buildVersion: commonConfig.version,
     deb: {


### PR DESCRIPTION
This fixes https://github.com/wireapp/wire-desktop/issues/2648.