### PR TITLE
runfix: Re-enable global shortcuts for macOS (WEBAPP-6528)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -252,8 +252,11 @@ const showMainWindow = async (mainWindowState: WindowStateKeeper.State) => {
   });
 
   main.on('focus', () => {
+    systemMenu.registerGlobalShortcuts();
     main.flashFrame(false);
   });
+
+  main.on('blur', () => systemMenu.unregisterGlobalShortcuts());
 
   main.on('page-title-updated', () => tray.showUnreadCount(main));
 
@@ -269,6 +272,7 @@ const showMainWindow = async (mainWindowState: WindowStateKeeper.State) => {
       } else {
         main.hide();
       }
+      systemMenu.unregisterGlobalShortcuts();
     }
   });
 

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -418,7 +418,7 @@ export const createMenu = (isFullScreen: boolean): Menu => {
   }
 
   if (Array.isArray(windowTemplate.submenu)) {
-    const muteAccelerator = 'CmdOrCtrl+Alt+M';
+    const muteAccelerator = 'Ctrl+Alt+M';
     logger.info(`Registering mute shortcut "${muteAccelerator}" ...`);
 
     const muteShortcut: MenuItemConstructorOptions = {
@@ -429,8 +429,8 @@ export const createMenu = (isFullScreen: boolean): Menu => {
       visible: false,
     };
 
-    const switchShortcuts: MenuItemConstructorOptions[] = [...Array(config.maximumAccounts)].map((_, index) => {
-      const switchAccelerator = `CmdOrCtrl+${index + 1}`;
+    const switchShortcuts: MenuItemConstructorOptions[] = Array.from({length: config.maximumAccounts}, (_, index) => {
+      const switchAccelerator = `Ctrl+${index + 1}`;
       logger.info(`Registering account switching shortcut "${switchAccelerator}" ...`);
 
       return {
@@ -484,15 +484,15 @@ export const toggleMenuBar = (): void => {
 
 export const registerGlobalShortcuts = (): void => {
   if (EnvironmentUtil.platform.IS_MAC_OS) {
-    const muteAccelerator = 'CmdOrCtrl+Alt+M';
+    const muteAccelerator = 'Cmd+Alt+M';
     logger.info(`Registering global mute shortcut "${muteAccelerator}" ...`);
 
     globalShortcut.register(muteAccelerator, () =>
       WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
     );
 
-    for (const index in [...Array(config.maximumAccounts)]) {
-      const switchAccelerator = `CmdOrCtrl+${index + 1}`;
+    for (const index in Array.from({length: config.maximumAccounts})) {
+      const switchAccelerator = `Cmd+${index + 1}`;
       logger.info(`Registering global account switching shortcut "${switchAccelerator}" ...`);
 
       if (EnvironmentUtil.platform.IS_MAC_OS) {

--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -491,16 +491,14 @@ export const registerGlobalShortcuts = (): void => {
       WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
     );
 
-    for (const index in Array.from({length: config.maximumAccounts})) {
+    Array.from({length: config.maximumAccounts}, (_, index) => {
       const switchAccelerator = `Cmd+${index + 1}`;
       logger.info(`Registering global account switching shortcut "${switchAccelerator}" ...`);
 
-      if (EnvironmentUtil.platform.IS_MAC_OS) {
-        globalShortcut.register(switchAccelerator, () => {
-          WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, index);
-        });
-      }
-    }
+      globalShortcut.register(switchAccelerator, () => {
+        WindowManager.sendActionToPrimaryWindow(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, index);
+      });
+    });
   }
 };
 


### PR DESCRIPTION
This re-enables global shortcuts for macOS since the trick from https://github.com/wireapp/wire-desktop/pull/3207 doesn't work here.