### PR TITLE
fix: Disable Blink features

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -195,6 +195,7 @@ const showMainWindow = async (mainWindowState: WindowStateKeeper.State) => {
     titleBarStyle: 'hiddenInset',
     webPreferences: {
       backgroundThrottling: false,
+      enableBlinkFeatures: '',
       nodeIntegration: false,
       preload: PRELOAD_JS,
       webviewTag: true,
@@ -526,6 +527,7 @@ class ElectronWrapperInit {
             webPreferences.nodeIntegration = false;
             webPreferences.preloadURL = fileUrl(PRELOAD_RENDERER_JS);
             webPreferences.webSecurity = true;
+            webPreferences.enableBlinkFeatures = '';
           });
           break;
         }

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -66,6 +66,7 @@ const showWindow = async () => {
       show: false,
       title: config.name,
       webPreferences: {
+        enableBlinkFeatures: '',
         javascript: false,
         nodeIntegration: false,
         nodeIntegrationInWorker: false,

--- a/electron/src/window/ProxyPromptWindow.ts
+++ b/electron/src/window/ProxyPromptWindow.ts
@@ -52,6 +52,7 @@ const showWindow = async () => {
       show: false,
       title: config.name,
       webPreferences: {
+        enableBlinkFeatures: '',
         javascript: true,
         nodeIntegration: false,
         nodeIntegrationInWorker: false,


### PR DESCRIPTION
See Electron Docs: "[Do Not Use `enableBlinkFeatures`](https://github.com/electron/electron/blob/master/docs/tutorial/security.md#9-do-not-use-enableblinkfeatures)".

The docs recommend to not use `enableBlinkFeatures` at all but then the console log tells me:
```
"Electron Security Warning (enableBlinkFeatures) font-weight: bold; This renderer process has additional "enableBlinkFeatures"
  enabled. This exposes users of this app to some security risk. If you do not
  need this feature, you should disable it.

For more information and help, consult
https://electronjs.org/docs/tutorial/security.
This warning will not show up
once the app is packaged."
```