### PR TITLE
refactor: Build for ES6 and Chrome 78

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,4 @@
-const plugins = [
-  '@babel/plugin-proposal-class-properties',
-  '@babel/plugin-proposal-object-rest-spread',
-  '@babel/plugin-proposal-optional-chaining',
-];
+const plugins = ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-optional-chaining'];
 
 const buildPresets = ({modules = false, debug = false}) => {
   return [
@@ -14,7 +10,7 @@ const buildPresets = ({modules = false, debug = false}) => {
         debug,
         modules,
         targets: {
-          browsers: ['chrome >= 66'],
+          browsers: ['chrome >= 78'],
         },
         useBuiltIns: 'usage',
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@babel/core": "7.7.4",
     "@babel/plugin-proposal-class-properties": "7.7.4",
-    "@babel/plugin-proposal-object-rest-spread": "7.7.4",
     "@babel/plugin-proposal-optional-chaining": "7.7.4",
     "@babel/preset-env": "7.7.4",
     "@babel/preset-react": "7.7.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "rootDir": "electron/src",
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es6"
   },
   "exclude": ["bin", "electron/dist", "electron/**/*.test*.ts", "node_modules", "wrap"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.7.4"
 
-"@babel/plugin-proposal-object-rest-spread@7.7.4", "@babel/plugin-proposal-object-rest-spread@^7.7.4":
+"@babel/plugin-proposal-object-rest-spread@^7.7.4":
   version "7.7.4"
   resolved "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz#cc57849894a5c774214178c8ab64f6334ec8af71"
   integrity sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==


### PR DESCRIPTION
Since Electron 7.1.3 is based on Chrome 78, we can also build for this version.