### PR TITLE
build: macOS keychain password may contain special characters

### DIFF
--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -33,7 +33,7 @@ node('master') {
   stage('Build') {
     try {
       withCredentials([string(credentialsId: 'MACOS_KEYCHAIN_PASSWORD', variable: 'MACOS_KEYCHAIN_PASSWORD')]) {
-        sh "security unlock-keychain -p ${MACOS_KEYCHAIN_PASSWORD} /Users/jenkins/Library/Keychains/login.keychain"
+        sh "security unlock-keychain -p \"${MACOS_KEYCHAIN_PASSWORD}\" /Users/jenkins/Library/Keychains/login.keychain"
       }
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'


### PR DESCRIPTION
This fixes issues with certain passwords. Already tested with the last build on macOS production job.