### PR TITLE
Revert "fix: Use single instance lock instead of variable"

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -602,7 +602,7 @@ lifecycle.checkSingleInstance();
 lifecycle.checkForUpdate().catch(error => logger.error(error));
 
 // Stop further execution on update to prevent second tray icon
-if (app.hasSingleInstanceLock()) {
+if (lifecycle.isFirstInstance) {
   addLinuxWorkarounds();
   bindIpcEvents();
   handleAppEvents();

--- a/electron/src/runtime/lifecycle.ts
+++ b/electron/src/runtime/lifecycle.ts
@@ -30,10 +30,11 @@ import * as EnvironmentUtil from './EnvironmentUtil';
 
 const logger = getLogger(path.basename(__filename));
 
+export let isFirstInstance: boolean | undefined = undefined;
+
 export async function checkForUpdate(): Promise<void> {
   if (EnvironmentUtil.platform.IS_WINDOWS) {
     logger.info('Checking for Windows update ...');
-    const isFirstInstance = app.hasSingleInstanceLock();
     await Squirrel.handleSquirrelEvent(isFirstInstance);
 
     ipcMain.on(EVENT_TYPE.WRAPPER.UPDATE, () => Squirrel.installUpdate());
@@ -42,11 +43,12 @@ export async function checkForUpdate(): Promise<void> {
 
 export const checkSingleInstance = () => {
   if (process.mas) {
+    isFirstInstance = true;
   } else {
-    const gotSingleInstanceLock = app.requestSingleInstanceLock();
-    logger.info('Checking if we are the first instance ...', gotSingleInstanceLock);
+    isFirstInstance = app.requestSingleInstanceLock();
+    logger.info('Checking if we are the first instance ...', isFirstInstance);
 
-    if (!EnvironmentUtil.platform.IS_WINDOWS && !gotSingleInstanceLock) {
+    if (!EnvironmentUtil.platform.IS_WINDOWS && !isFirstInstance) {
       quit();
     } else {
       app.on('second-instance', () => WindowManager.showPrimaryWindow());


### PR DESCRIPTION
Reverts wireapp/wire-desktop#3482