### PR TITLE
runfix: Import uuid 7.x

### DIFF
--- a/electron/renderer/src/actions/index.js
+++ b/electron/renderer/src/actions/index.js
@@ -19,7 +19,7 @@
 
 /* eslint-disable no-console */
 
-import uuid from 'uuid/v4';
+import {v4 as uuid} from 'uuid';
 
 import {config} from '../../../dist/settings/config';
 import {verifyObjectProperties} from '../lib/verifyObjectProperties';

--- a/electron/renderer/src/reducers/accountReducer.js
+++ b/electron/renderer/src/reducers/accountReducer.js
@@ -17,7 +17,7 @@
  *
  */
 
-import uuid from 'uuid/v4';
+import {v4 as uuid} from 'uuid';
 
 import {ActionType} from '../actions';
 


### PR DESCRIPTION
This fixes https://github.com/wireapp/wire-desktop/issues/3763.

The import for `uuid` 7.x changed, see https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#700-2020-02-24 and https://github.com/uuidjs/uuid#create-version-4-random-uuids.