### PR TITLE
fix: Update link to release notes

### DIFF
--- a/electron/html/about.html
+++ b/electron/html/about.html
@@ -14,7 +14,7 @@
         <a href="https://support.wire.com/hc/articles/115001919905"><span data-string="aboutUpdate"></span></a>
       </p>
       <p>
-        <a href="https://medium.com/wire-news/desktop-updates"><span data-string="aboutReleases"></span></a>
+        <a href="https://medium.com/wire-news/link-medium-com-wire-news-wire-for-web/home"><span data-string="aboutReleases"></span></a>
       </p>
       <p><span id="copyright"></span></p>
     </div>


### PR DESCRIPTION
@marcoconti83 if possible we would like to use "https://medium.com/wire-news/webapp-updates/home" instead of "https://medium.com/wire-news/link-medium-com-wire-news-wire-for-web/home" to be consistent with the other release notes links (such as https://medium.com/wire-news/ios-updates/home).