### PR TITLE
fix: Don't flicker tray icon on incoming messages

### DIFF
--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -69,11 +69,13 @@ export class TrayHandler {
   }
 
   showUnreadCount(win: BrowserWindow, count?: number, ignoreFlash?: boolean): void {
-    this.updateIcons(win, count);
-    if (!ignoreFlash) {
-      this.flashApplicationWindow(win, count);
+    if (count !== this.lastUnreadCount) {
+      this.updateIcons(win, count);
+      if (!ignoreFlash) {
+        this.flashApplicationWindow(win, count);
+      }
+      this.updateBadgeCount(count);
     }
-    this.updateBadgeCount(count);
   }
 
   private buildTrayMenu(): void {
@@ -88,11 +90,9 @@ export class TrayHandler {
       },
     ]);
 
-    if (this.trayIcon) {
-      this.trayIcon.on('click', () => WindowManager.showPrimaryWindow());
-      this.trayIcon.setContextMenu(contextMenu);
-      this.trayIcon.setToolTip(config.name);
-    }
+    this.trayIcon?.on('click', () => WindowManager.showPrimaryWindow());
+    this.trayIcon?.setContextMenu(contextMenu);
+    this.trayIcon?.setToolTip(config.name);
   }
 
   private flashApplicationWindow(win: BrowserWindow, count?: number): void {
@@ -114,9 +114,7 @@ export class TrayHandler {
     if (this.icons) {
       const trayImage = count ? this.icons.trayWithBadge : this.icons.tray;
 
-      if (this.trayIcon) {
-        this.trayIcon.setImage(trayImage);
-      }
+      this.trayIcon?.setImage(trayImage);
 
       const overlayImage = count ? this.icons.badge : null;
       win.setOverlayIcon(overlayImage, locale.getText('unreadMessages'));


### PR DESCRIPTION
This PR will let the app only update the tray icon if the number of unread messages is different from before (e.g. on an incoming message in a muted group the counter doesn't change but the tray icon change gets triggered).