### PR TITLE
fix: Don't use result of executeJavaScript (WEBAPP-7090)

### DIFF
--- a/electron/src/lib/ElectronUtil.ts
+++ b/electron/src/lib/ElectronUtil.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2020 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,13 @@
  *
  */
 
-const {webFrame, remote} = require('electron');
-const {SingleSignOn} = remote.require('./sso/SingleSignOn');
+import type {WebContents} from 'electron';
 
-webFrame.executeJavaScript(SingleSignOn.getWindowOpenerScript()).catch(error => console.warn(error));
+export async function executeJavaScriptWithoutResult(snippet: string, target: WebContents) {
+  // This removes all trailing `;` and adds `;0` at the end of the snippet to
+  // ensure the resulting value of `executeJavaScript()` is not used.
+  // See https://github.com/electron/electron/issues/23722.
+
+  snippet = `${snippet.replace(/;+$/, '')};0`;
+  await target.executeJavaScript(snippet);
+}

--- a/electron/src/menu/developer.ts
+++ b/electron/src/menu/developer.ts
@@ -17,11 +17,12 @@
  *
  */
 
-import {MenuItem, MenuItemConstructorOptions} from 'electron';
+import {MenuItem, MenuItemConstructorOptions, WebContents} from 'electron';
 
 import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
 import * as lifecycle from '../runtime/lifecycle';
 import {config} from '../settings/config';
+import {executeJavaScriptWithoutResult} from '../lib/ElectronUtil';
 import {WindowManager} from '../window/WindowManager';
 
 const currentEnvironment = EnvironmentUtil.getEnvironment();
@@ -34,6 +35,11 @@ const reloadTemplate: MenuItemConstructorOptions = {
     }
   },
   label: 'Reload',
+};
+
+const openDevTools = async (webViewIndex: number, webContents: WebContents): Promise<void> => {
+  const snippet = `document.getElementsByTagName("webview")[${webViewIndex}].openDevTools({mode: "detach"})`;
+  await executeJavaScriptWithoutResult(snippet, webContents);
 };
 
 const devToolsTemplate: MenuItemConstructorOptions = {
@@ -53,8 +59,7 @@ const devToolsTemplate: MenuItemConstructorOptions = {
       click: async () => {
         const primaryWindow = WindowManager.getPrimaryWindow();
         if (primaryWindow) {
-          const command = 'document.getElementsByTagName("webview")[0].openDevTools({mode: "detach"})';
-          await primaryWindow.webContents.executeJavaScript(command);
+          await openDevTools(0, primaryWindow.webContents);
         }
       },
       label: 'First',
@@ -63,8 +68,7 @@ const devToolsTemplate: MenuItemConstructorOptions = {
       click: async () => {
         const primaryWindow = WindowManager.getPrimaryWindow();
         if (primaryWindow) {
-          const command = 'document.getElementsByTagName("webview")[1].openDevTools({mode: "detach"})';
-          await primaryWindow.webContents.executeJavaScript(command);
+          await openDevTools(1, primaryWindow.webContents);
         }
       },
       label: 'Second',
@@ -73,8 +77,7 @@ const devToolsTemplate: MenuItemConstructorOptions = {
       click: async () => {
         const primaryWindow = WindowManager.getPrimaryWindow();
         if (primaryWindow) {
-          const command = 'document.getElementsByTagName("webview")[2].openDevTools({mode: "detach"})';
-          await primaryWindow.webContents.executeJavaScript(command);
+          await openDevTools(2, primaryWindow.webContents);
         }
       },
       label: 'Third',


### PR DESCRIPTION
This removes all trailing `;` and adds `;0` at the end of JS snippets which are to be executed on a `webContent` to ensure the resulting value of `executeJavaScript()` is not used. See https://github.com/electron/electron/issues/23722.

I could not make use of the util function in the SSO preload, but this area will be improved soon.