### PR TITLE
runfix: Use opacity instead of TransitionContainer on the LoadingSpinner

### DIFF
--- a/electron/renderer/src/components/LoadingSpinner.css
+++ b/electron/renderer/src/components/LoadingSpinner.css
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+#loading-spinner-wrapper {
+  display: flex;
+  height: 100vh;
+  position: absolute;
+  width: 100%;
+  z-index: 99;
+  transition: opacity 0.25s ease-in-out;
+  -moz-transition: opacity 0.25s ease-in-out;
+  -webkit-transition: opacity 0.25s ease-in-out;
+}
+
+#loading-spinner-box {
+  margin: 0 auto;
+}

--- a/electron/renderer/src/components/LoadingSpinner.css
+++ b/electron/renderer/src/components/LoadingSpinner.css
@@ -17,7 +17,7 @@
  *
  */
 
-#loading-spinner-wrapper {
+.loading-spinner-wrapper {
   display: flex;
   height: 100vh;
   position: absolute;
@@ -28,6 +28,6 @@
   -webkit-transition: opacity 0.25s ease-in-out;
 }
 
-#loading-spinner-box {
+.loading-spinner-box {
   margin: 0 auto;
 }

--- a/electron/renderer/src/components/LoadingSpinner.jsx
+++ b/electron/renderer/src/components/LoadingSpinner.jsx
@@ -18,7 +18,9 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import {FlexBox, Loading, COLOR, TransitionContainer, Opacity} from '@wireapp/react-ui-kit';
+import {FlexBox, Loading, COLOR} from '@wireapp/react-ui-kit';
+
+import './LoadingSpinner.css';
 
 const LoadingSpinner = ({webviewRef}) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -38,36 +40,15 @@ const LoadingSpinner = ({webviewRef}) => {
   return (
     <div
       style={{
-        display: 'flex',
-        height: '100%',
-        position: 'absolute',
-        width: '100%',
-        zIndex: 99,
+        backgroundColor: COLOR.GRAY_LIGHTEN_88,
+        opacity: isLoading ? 1 : 0,
       }}
+      id="loading-spinner-wrapper"
       data-uie-name="loading-spinner-wrapper"
     >
-      <TransitionContainer
-        style={{
-          height: '100%',
-          width: '100%',
-        }}
-      >
-        {isLoading && (
-          <Opacity timeout={500}>
-            <div
-              style={{
-                backgroundColor: COLOR.GRAY_LIGHTEN_88,
-                display: 'flex',
-                height: '100vh',
-              }}
-            >
-              <FlexBox align="center" justify="space-around" style={{margin: '0 auto'}}>
-                <Loading data-uie-name="loading-spinner-element" />
-              </FlexBox>
-            </div>
-          </Opacity>
-        )}
-      </TransitionContainer>
+      <FlexBox align="center" justify="space-around" id="loading-spinner-box">
+        <Loading data-uie-name="loading-spinner-element" />
+      </FlexBox>
     </div>
   );
 };

--- a/electron/renderer/src/components/LoadingSpinner.jsx
+++ b/electron/renderer/src/components/LoadingSpinner.jsx
@@ -39,14 +39,14 @@ const LoadingSpinner = ({webviewRef}) => {
 
   return (
     <div
+      className="loading-spinner-wrapper"
+      data-uie-name="loading-spinner-wrapper"
       style={{
         backgroundColor: COLOR.GRAY_LIGHTEN_88,
         opacity: isLoading ? 1 : 0,
       }}
-      id="loading-spinner-wrapper"
-      data-uie-name="loading-spinner-wrapper"
     >
-      <FlexBox align="center" justify="space-around" id="loading-spinner-box">
+      <FlexBox align="center" justify="space-around" className="loading-spinner-box">
         <Loading data-uie-name="loading-spinner-element" />
       </FlexBox>
     </div>


### PR DESCRIPTION
Since we removed only the `FlexBox` and the Loading Spinner itself after the page is loaded, we had a left-over element over the whole interface which rendered the app useless :slightly_smiling_face: 