### PR TITLE
refactor: new URL instead of URL.parse

### DIFF
--- a/electron/src/runtime/OriginValidator.ts
+++ b/electron/src/runtime/OriginValidator.ts
@@ -17,10 +17,10 @@
  *
  */
 
-import * as url from 'url';
+import {URL} from 'url';
 
 export const OriginValidator = {
   isMatchingHost(urlString: string, baseUrl: string): boolean {
-    return url.parse(urlString).host === url.parse(baseUrl).host;
+    return new URL(urlString).host === new URL(baseUrl).host;
   },
 };

--- a/electron/src/window/WindowUtil.ts
+++ b/electron/src/window/WindowUtil.ts
@@ -19,7 +19,7 @@
 
 import {BrowserWindow, screen, shell} from 'electron';
 import * as path from 'path';
-import * as URL from 'url';
+import {URL} from 'url';
 
 import {getLogger} from '../logging/getLogger';
 import {showWarningDialog} from '../lib/showDialog';
@@ -58,7 +58,7 @@ export const isInView = (win: BrowserWindow): boolean => {
 
 export const openExternal = async (url: string, httpsOnly: boolean = false): Promise<void> => {
   try {
-    const urlProtocol = URL.parse(url).protocol || '';
+    const urlProtocol = new URL(url).protocol || '';
     const allowedProtocols = ['https:'];
 
     if (!httpsOnly) {


### PR DESCRIPTION
`URL.parse()` is [deprecated](https://nodejs.org/docs/latest-v12.x/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost).