### PR TITLE
fix: Possible interpolation of sensitive environment variables on build jobs (SQPIT-394)

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -36,7 +36,7 @@ node('master') {
   def projectName = env.WRAPPER_BUILD.tokenize('#')[0]
   def version = env.WRAPPER_BUILD.tokenize('#')[1]
   def NODE = tool name: 'node-v12.20.0', type: 'nodejs'
-  def DRY_RUN = params.DRY_RUN ? "--dry-run" : ""
+  env.DRY_RUN = params.DRY_RUN ? "--dry-run" : ""
 
   stage('Get build artifacts') {
     try {
@@ -73,24 +73,24 @@ node('master') {
 
   stage('Upload to S3') {
     withEnv(["PATH+NODE=${NODE}/bin"]) {
-      def SEARCH_PATH = './wrap/dist/'
+      env.SEARCH_PATH = './wrap/dist/'
 
       if (projectName.contains('Windows')) {
-        def S3_PATH = ''
+        env.S3_PATH = ''
         def AWS_ACCESS_KEY_CREDENTIALS_ID = ''
         def AWS_SECRET_CREDENTIALS_ID = ''
 
           if (params.Release.equals('Production')) {
-            S3_PATH = 'win/prod'
+            env.S3_PATH = 'win/prod'
             AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
             AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
           } else if (params.Release.equals('Internal')) {
-            S3_PATH = 'win/internal'
+            env.S3_PATH = 'win/internal'
             AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
             AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
           } else if (params.Release.equals('Custom')) {
-            S3_BUCKET = params.WIN_S3_BUCKET
-            S3_PATH = params.WIN_S3_PATH
+            env.S3_BUCKET = params.WIN_S3_BUCKET
+            env.S3_PATH = params.WIN_S3_PATH
             AWS_ACCESS_KEY_CREDENTIALS_ID = params.AWS_CUSTOM_ACCESS_KEY_ID
             AWS_SECRET_CREDENTIALS_ID = params.AWS_CUSTOM_SECRET_ACCESS_KEY
           }
@@ -249,7 +249,7 @@ node('master') {
     stage('Upload build as draft to GitHub') {
       try {
         withEnv(["PATH+NODE=${NODE}/bin"]) {
-          def SEARCH_PATH = './wrap/dist/'
+          env.SEARCH_PATH = './wrap/dist/'
 
           withCredentials([string(credentialsId: 'GITHUB_ACCESS_TOKEN', variable: 'GITHUB_ACCESS_TOKEN')]) {
             sh 'jenkins/ts-node.sh ./bin/deploy-tools/github-draft-cli.ts --github-token \"$GITHUB_ACCESS_TOKEN\" --wrapper-build \"$WRAPPER_BUILD\" --path \"$SEARCH_PATH\" $DRY_RUN'

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -100,7 +100,7 @@ node('master') {
             string(credentialsId: AWS_ACCESS_KEY_CREDENTIALS_ID, variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: AWS_SECRET_CREDENTIALS_ID, variable: 'AWS_SECRET_ACCESS_KEY')
           ]) {
-            sh "jenkins/ts-node.sh ./bin/deploy-tools/s3-cli.ts --bucket \"${S3_BUCKET}\" --s3path \"${S3_PATH}\" --key-id \"${AWS_ACCESS_KEY_ID}\" --secret-key \"${AWS_SECRET_ACCESS_KEY}\" --wrapper-build \"${WRAPPER_BUILD}\" --path \"${SEARCH_PATH}\" ${DRY_RUN}"
+            sh 'jenkins/ts-node.sh ./bin/deploy-tools/s3-cli.ts --bucket \"$S3_BUCKET\" --s3path \"$S3_PATH\" --key-id \"$AWS_ACCESS_KEY_ID\" --secret-key \"$AWS_SECRET_ACCESS_KEY\" --wrapper-build \"$WRAPPER_BUILD\" --path \"$SEARCH_PATH\" $DRY_RUN'
           }
         } catch(e) {
           currentBuild.result = 'FAILED'
@@ -252,7 +252,7 @@ node('master') {
           def SEARCH_PATH = './wrap/dist/'
 
           withCredentials([string(credentialsId: 'GITHUB_ACCESS_TOKEN', variable: 'GITHUB_ACCESS_TOKEN')]) {
-            sh "jenkins/ts-node.sh ./bin/deploy-tools/github-draft-cli.ts --github-token \"${env.GITHUB_ACCESS_TOKEN}\" --wrapper-build \"${WRAPPER_BUILD}\" --path \"${SEARCH_PATH}\" ${DRY_RUN}"
+            sh 'jenkins/ts-node.sh ./bin/deploy-tools/github-draft-cli.ts --github-token \"$GITHUB_ACCESS_TOKEN\" --wrapper-build \"$WRAPPER_BUILD\" --path \"$SEARCH_PATH\" $DRY_RUN'
           }
         }
       } catch(e) {

--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -33,7 +33,7 @@ node('master') {
   stage('Build') {
     try {
       withCredentials([string(credentialsId: 'MACOS_KEYCHAIN_PASSWORD', variable: 'MACOS_KEYCHAIN_PASSWORD')]) {
-        sh "security unlock-keychain -p \"${MACOS_KEYCHAIN_PASSWORD}\" /Users/jenkins/Library/Keychains/login.keychain"
+        sh 'security unlock-keychain -p \"$MACOS_KEYCHAIN_PASSWORD\" /Users/jenkins/Library/Keychains/login.keychain'
       }
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'


### PR DESCRIPTION
Double quotes are replaced by single quotes to not leak sensitive data on remote machine in build process (very minor security issue because it needs access on the machine). For this to work some variables had to be made environment variables.

See https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation for explanation