### PR TITLE
fix: Create shortcuts manually to re-enable clickable notifications (SQCORE-544)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -133,7 +133,7 @@ Object.entries(config).forEach(([key, value]) => {
 });
 
 // Squirrel setup
-app.setAppUserModelId(`com.squirrel.wire.${config.name.toLowerCase()}`);
+app.setAppUserModelId(config.appUserModelId);
 
 try {
   logger.info('GPUFeatureStatus:', app.getGPUFeatureStatus());

--- a/electron/src/settings/config.ts
+++ b/electron/src/settings/config.ts
@@ -67,6 +67,7 @@ enum ARGUMENT {
 export const config = {
   ...wireJson,
   ARGUMENT,
+  appUserModelId: `com.squirrel.wire.${wireJson.name.toLowerCase()}`,
   backendOrigins: ['https://staging-nginz-https.zinfra.io', 'https://prod-nginz-https.wire.com'],
   logFileName: 'console.log',
   maximumAccounts: parseInt(wireJson.maximumAccounts, 10),

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -127,7 +127,7 @@ function createShortcuts(): void {
   logger.info('Created shortcuts:', {desktop: desktopResult, quickLaunch: quickLaunchResult, start: startResult});
 }
 
-export async function removeShortcuts(): Promise<void> {
+async function removeShortcuts(): Promise<void> {
   logger.info('Removing all shortcuts ...');
   await fs.remove(startShortcut);
   await fs.remove(desktopShortcut);

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -105,6 +105,9 @@ async function spawnUpdate(args: string[]): Promise<void> {
 }
 
 function createShortcut(location: string): boolean {
+  // As documented in https://github.com/electron/windows-installer/issues/296,
+  // Squirrel has problems with notification clicks on Windows 10.
+  // The easiest workaround is to create shortcuts on our own.
   return shell.writeShortcutLink(location, 'create', {
     appUserModelId: config.appUserModelId,
     target: process.execPath,


### PR DESCRIPTION
This fixes https://github.com/wireapp/wire-desktop/issues/4160.