### PR TITLE
chore: Turn web chapter into code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AndyLnd @bennycode @ffflorian @thisisamir98 @Yserz


### PR DESCRIPTION
Follow-up to https://github.com/wireapp/wire-webapp/pull/11293