### PR TITLE
fix: Don't render LoadingSpinner after it has faded out

### DIFF
--- a/electron/renderer/src/components/LoadingSpinner.css
+++ b/electron/renderer/src/components/LoadingSpinner.css
@@ -19,6 +19,7 @@
 
 .loading-spinner-wrapper {
   height: 100vh;
+  display: flex;
   position: absolute;
   width: 100%;
   z-index: 2;

--- a/electron/renderer/src/components/LoadingSpinner.jsx
+++ b/electron/renderer/src/components/LoadingSpinner.jsx
@@ -22,8 +22,11 @@ import {FlexBox, Loading, COLOR} from '@wireapp/react-ui-kit';
 
 import './LoadingSpinner.css';
 
+const TRANSITION_GRACE_PERIOD_MS = 500;
+
 const LoadingSpinner = ({visible, webviewRef}) => {
   const [isLoading, setIsLoading] = useState(true);
+  const [isFinished, setIsFinished] = useState(false);
 
   useEffect(() => {
     const webview = webviewRef.current;
@@ -37,13 +40,30 @@ const LoadingSpinner = ({visible, webviewRef}) => {
     }
   });
 
+  useEffect(() => {
+    if (!isLoading) {
+      let timeout = setTimeout(() => {
+        timeout = null;
+        setIsFinished(true);
+      }, TRANSITION_GRACE_PERIOD_MS);
+
+      return () => {
+        if (timeout !== null) {
+          clearTimeout(timeout);
+        }
+      };
+    }
+  }, [isLoading]);
+
+  if (!visible || isFinished) {
+    return null;
+  }
   return (
     <div
       className="loading-spinner-wrapper"
       data-uie-name="loading-spinner-wrapper"
       style={{
         backgroundColor: COLOR.GRAY_LIGHTEN_88,
-        display: visible ? 'flex' : 'none',
         opacity: isLoading ? 1 : 0,
         pointerEvents: isLoading ? 'all' : 'none',
       }}


### PR DESCRIPTION
This pull request attempts to reduce Wire's CPU usage when idle.

In the discussions related to issues #2507 and #2239 (and maybe elsewhere) @charlag et al. tracked down a culprit for some surpsingly high constant CPU load. The LoadingSpinner component is always rendered on top of the rest of the UI with 0 opacity after it has initially faded out, continuously using resources.

This pull request addresses the issue ~~by hooking to the `onTransitionEnd` and `onTransitionCanceled` events and set a flag marking the fade out completed~~ giving the fade out transition a fixed amount of time to finish. After this the component returns `null`, effectively removing the LoadingSpinner contents from the DOM tree.

Personally, I've noticed constant ~15% load when Wire was idling on my M1 MacBook Air. Launching Wire with devtools enabled and removing the spinner from the DOM drops the idle CPU usage to near zero. I couldn't get the build infra work 100% on my machine, so @ikisusi and @esatormi volunteered to test this patch on their Intel Macs, both getting similar results. @ikisusi's CPU activity monitor looked like this _before_ applying the patch (and after the spinned had faded to 0 opacity):

<img width="710" alt="before" src="https://user-images.githubusercontent.com/19776768/124623993-27855c00-de85-11eb-9e35-c9d0cddb0722.png">

And like this _after_ applying the patch:

<img width="704" alt="after" src="https://user-images.githubusercontent.com/19776768/124624003-2a804c80-de85-11eb-9e75-8d89e8bfe9ea.png">