### PR TITLE
chore: replace master with built-in label for Jenkins pipeline

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -22,7 +22,7 @@ Internal
 Production
 Custom (needs special env variables)
 */
-node('master') {
+node('built-in') {
   def jenkinsbot_secret = ''
   withCredentials([string(credentialsId: 'JENKINSBOT_WRAPPER_CHAT', variable: 'JENKINSBOT_SECRET')]) {
     jenkinsbot_secret = env.JENKINSBOT_SECRET

--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -3,7 +3,7 @@ def parseJson(def text) {
   new groovy.json.JsonSlurperClassic().parseText(text)
 }
 
-node('master') {
+node('built-in') {
   def production = params.PRODUCTION
   def custom = params.CUSTOM
   def NODE = tool name: 'node-v14.15.3', type: 'nodejs'


### PR DESCRIPTION
_No masters, no slaves_

# What's new in this PR?

The word "master" is being retired as the term for the main Jenkins process and the built-in node. The built-in node is called just "built-in node" with the label "built-in" instead of the label "master".

The current version of Jenkins still understands the label "master" but in future versions this will be probably removed. The PR replaces all usages of "master" node.