### PR TITLE
fix: appcenter uploads for internal releases

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -143,7 +143,7 @@ node('master') {
 
           if (!params.Release.equals('Production')) {
             withCredentials([string(credentialsId: 'APPCENTER_TOKEN', variable: 'APP_CENTER_TOKEN')]) {
-              files = findFiles(glob: 'wrap/dist/*.zip')
+              files = findFiles(glob: 'wrap/dist/*.pkg')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -153,7 +153,7 @@ node('master') {
               // pkg uploads require build version and build number to be set
               withEnv(["PATH+NODE=${NODE}/bin"]) {
                 sh 'npm install -g appcenter-cli'
-                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
+                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '" --debug'
               }
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -120,7 +120,7 @@ node('master') {
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               // Windows uploads require build version to be set
               withEnv(["PATH+NODE=${NODE}/bin"]) {
-                sh 'npm install -q appcenter-cli'
+                sh 'npm install -g appcenter-cli'
                 sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
               }
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
@@ -152,7 +152,7 @@ node('master') {
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               // pkg uploads require build version and build number to be set
               withEnv(["PATH+NODE=${NODE}/bin"]) {
-                sh 'npm install -q appcenter-cli'
+                sh 'npm install -g appcenter-cli'
                 sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
               }
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -119,7 +119,7 @@ node('master') {
               files = findFiles(glob: '*.zip')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               // Windows upload needs to set build_version via plugin
-              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", buildNumber: "${buildNumber}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
+              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }
           } catch(e) {

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -64,6 +64,7 @@ node('master') {
       withEnv(["PATH+NODE=${NODE}/bin"]) {
         sh 'node -v'
         sh 'npm -v'
+        sh 'npm install -q appcenter-cli'
         sh 'npm install -g yarn'
         sh 'yarn --ignore-scripts'
       }
@@ -147,7 +148,9 @@ node('master') {
             withCredentials([string(credentialsId: 'APPCENTER_TOKEN', variable: 'APP_CENTER_TOKEN')]) {
               files = findFiles(glob: 'wrap/dist/*.pkg')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
-              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
+              withEnv(["PATH+NODE=${NODE}/bin"]) {
+                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
+              }
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }
           }

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -145,7 +145,7 @@ node('master') {
             withCredentials([string(credentialsId: 'APPCENTER_TOKEN', variable: 'APP_CENTER_TOKEN')]) {
               files = findFiles(glob: 'wrap/dist/*.pkg')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
-              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
+              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }
           }

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -35,6 +35,8 @@ node('master') {
 
   def projectName = env.WRAPPER_BUILD.tokenize('#')[0]
   def version = env.WRAPPER_BUILD.tokenize('#')[1]
+  echo('version: ' + version)
+  def buildNumber = version.tokenize('.')[2]
   def NODE = tool name: 'node-v14.15.3', type: 'nodejs'
   env.DRY_RUN = params.DRY_RUN ? "--dry-run" : ""
 
@@ -117,7 +119,7 @@ node('master') {
               files = findFiles(glob: '*.zip')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               // Windows upload needs to set build_version via plugin
-              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
+              appCenter ownerName: 'Wire', apiToken: env.APP_CENTER_TOKEN, appName: appName, buildVersion: "${version}", buildNumber: "${buildNumber}", distributionGroups: distributionGroups, pathToApp: files[0].path, releaseNotes: 'Uploaded by Jenkins deploy job'
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }
           } catch(e) {

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -153,7 +153,7 @@ node('master') {
               // pkg uploads require build version and build number to be set
               withEnv(["PATH+NODE=${NODE}/bin"]) {
                 sh 'npm install -g appcenter-cli'
-                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '" --debug'
+                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
               }
               wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
             }

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -114,7 +114,7 @@ node('master') {
           def appName = 'Wire-Windows-Internal'
           def distributionGroups = 'All-users-of-Wire-Windows-Internal, Collaborators'
           try {
-            withCredentials([string(credentialsId: 'APPCENTER_TOKEN', variable: 'APP_CENTER_TOKEN')]) {
+            withCredentials([string(credentialsId: 'APPCENTER_TOKEN_WINDOWS', variable: 'APP_CENTER_TOKEN')]) {
               zip dir: 'wrap/dist/', glob: '**/*.exe', zipFile: 'WireInternal-Setup.zip'
               files = findFiles(glob: '*.zip')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
@@ -147,7 +147,7 @@ node('master') {
           }
 
           if (!params.Release.equals('Production')) {
-            withCredentials([string(credentialsId: 'APPCENTER_TOKEN', variable: 'APP_CENTER_TOKEN')]) {
+            withCredentials([string(credentialsId: 'APPCENTER_TOKEN_MACOS', variable: 'APP_CENTER_TOKEN')]) {
               files = findFiles(glob: 'wrap/dist/*.pkg')
               echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
               // pkg uploads require build version and build number to be set


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Appcenter upload was not working anymore for windows and macOS internal builds.

### Causes

* The reason was that the user on appcenter was deleted who held the token for the upload.
* An additional reason for macOS was that we want to upload pkg files and these require a new parameter (build number) to be added. This parameter is not yet supported by the appCenter jenkins plugin.

### Solutions

* app specific tokens with write access were created and added to Jenkins
* The appCenter jenkins plugin was replaced with appcenter-cli (the official app from Microsoft which allows build numbers)

### Testing

It was tested by successfully upload the Wire Internal macOS app to appcenter.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
