### PR TITLE
chore: Bump electron version in dependabot config (SQSERVICES-1490)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       # in progress, always takes some time to follow all breaking changes
       - dependency-name: electron
         versions:
-          - '> 11.x'
+          - '> 18.x'
       - dependency-name: electron-builder
         versions:
           - '> 20.x'


### PR DESCRIPTION
# What's new in this PR?

### Issues

Dependabot is not notifying about new electron updates.

### Solutions

Update dependabot config to use currently used electron version.

