### PR TITLE
[chore] add yarn installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Cross platform desktop app, wrapping the [wire-webapp](https://github.com/wireap
 - Git
 - Yarn (Install using the official instructions at https://yarnpkg.com/lang/en/docs/install/, and not using the package recommended by apt-get)
 
-### Install Yarn
+### Install Dependencies
 
 ```shell
+sudo apt install git npm nodejs
 npm install --global yarn
 ```
 ### Clone

--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ Cross platform desktop app, wrapping the [wire-webapp](https://github.com/wireap
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) >= 10
+- Npm
 - Git
+- Yarn (Install using the official instructions at https://yarnpkg.com/lang/en/docs/install/, and not using the package recommended by apt-get)
 
+### Install Yarn
+
+```shell
+npm install --global yarn
+```
 ### Clone
 
 ```shell


### PR DESCRIPTION
This is a recreation of #5271 

The reason was that #5271 was based on the wrong branch after some branching changes were done on the current repo.