### PR TITLE
 fix: remove specific versions for electron in dependabot config (SQSERVICES-1490)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: '05:00'
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,12 @@ updates:
     open-pull-requests-limit: 99
     versioning-strategy: increase
     ignore:
-      # our current Electron version uses Node.js 14
-      - dependency-name: '@types/node'
-        versions:
-          - '> 14.x'
-      # in progress, always takes some time to follow all breaking changes
+      # don't perform major updates for electron automatically
       - dependency-name: electron
-        versions:
-          - '> 18.x'
+        update-types: ['version-update:semver-major']
+      # don't perform major updates for the used node version as it is defined by the used electron version
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
       - dependency-name: electron-builder
         versions:
           - '> 20.x'


### PR DESCRIPTION

# What's new in this PR?
### Issues

Dependabot is still not notifying about new electron updates.
Because of the fact that the currently used version is inside of the ignore range.

### Solutions

Change dependabot config to use update-types, to limit updates to stay within the current major version.