### PR TITLE
runfix: add external theme update support for sidebar (ACC-199)

### DIFF
--- a/electron/renderer/src/components/Webview.jsx
+++ b/electron/renderer/src/components/Webview.jsx
@@ -217,7 +217,9 @@ const Webview = ({
         case EVENT_TYPE.UI.THEME_UPDATE: {
           const [theme] = args;
           const darkMode = theme === 'dark';
-          updateAccountDarkMode(account.id, darkMode);
+          if (darkMode !== account.darkMode) {
+            updateAccountDarkMode(account.id, darkMode);
+          }
           break;
         }
       }
@@ -241,13 +243,17 @@ const Webview = ({
     <>
       <LoadingSpinner visible={!!account.visible} webviewRef={webviewRef} />
       <webview
+        /* eslint-disable-next-line react/no-unknown-property */
         allowpopups="true"
+        /* eslint-disable-next-line react/no-unknown-property */
+        visible={String(!!account.visible)}
+        /* eslint-disable-next-line react/no-unknown-property */
+        partition={account.sessionID ? `persist:${account.sessionID}` : ''}
+        /* eslint-disable-next-line react/no-unknown-property */
+        webpreferences="backgroundThrottling=false"
         className={`Webview${account.visible ? '' : ' hide'}`}
         data-accountid={account.id}
-        visible={String(!!account.visible)}
         src={url}
-        partition={account.sessionID ? `persist:${account.sessionID}` : ''}
-        webpreferences="backgroundThrottling=false"
         ref={webviewRef}
         style={{backgroundColor: COLOR.GRAY_LIGHTEN_88}}
       />

--- a/electron/renderer/src/components/Webview.jsx
+++ b/electron/renderer/src/components/Webview.jsx
@@ -38,6 +38,7 @@ import {getText, wrapperLocale} from '../lib/locale';
 import {AccountSelector} from '../selector/AccountSelector';
 import './Webview.css';
 import {accountAction} from '../actions/AccountAction';
+/* eslint-disable react/no-unknown-property */
 
 const getEnvironmentUrl = account => {
   const currentLocation = new URL(window.location.href);
@@ -243,17 +244,13 @@ const Webview = ({
     <>
       <LoadingSpinner visible={!!account.visible} webviewRef={webviewRef} />
       <webview
-        /* eslint-disable-next-line react/no-unknown-property */
         allowpopups="true"
-        /* eslint-disable-next-line react/no-unknown-property */
-        visible={String(!!account.visible)}
-        /* eslint-disable-next-line react/no-unknown-property */
-        partition={account.sessionID ? `persist:${account.sessionID}` : ''}
-        /* eslint-disable-next-line react/no-unknown-property */
-        webpreferences="backgroundThrottling=false"
         className={`Webview${account.visible ? '' : ' hide'}`}
         data-accountid={account.id}
+        visible={String(!!account.visible)}
         src={url}
+        partition={account.sessionID ? `persist:${account.sessionID}` : ''}
+        webpreferences="backgroundThrottling=false"
         ref={webviewRef}
         style={{backgroundColor: COLOR.GRAY_LIGHTEN_88}}
       />

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -39,6 +39,8 @@ interface TeamAccountInfo {
   userID: string;
 }
 
+type Theme = 'dark' | 'default';
+
 const logger = getLogger(path.basename(__filename));
 
 function subscribeToThemeChange(): void {
@@ -132,8 +134,12 @@ const subscribeToWebappEvents = (): void => {
     }
   });
 
-  window.amplify.subscribe(WebAppEvents.PROPERTIES.UPDATE.INTERFACE.THEME, (theme: 'dark' | 'default') => {
+  window.amplify.subscribe(WebAppEvents.PROPERTIES.UPDATE.INTERFACE.THEME, (theme: Theme) => {
     ipcRenderer.sendToHost(EVENT_TYPE.UI.THEME_UPDATE, theme);
+  });
+
+  window.amplify.subscribe(WebAppEvents.PROPERTIES.UPDATED, (properties: {settings: {interface: {theme: Theme}}}) => {
+    ipcRenderer.sendToHost(EVENT_TYPE.UI.THEME_UPDATE, properties.settings.interface.theme);
   });
 };
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds support for sidebar theme change from external (other) client what didn't work previously. Sidebar theme was updated only when changed from inside electron app, it did not react to remote changes.

We listen for properties update event (`WebAppEvents.PROPERTIES.UPDATED`), read `theme` field form update object and pass it to electron's redux reducer which will update sidebar theme accordingly (only if it's different from previous state).

Before
![doesnotwork](https://user-images.githubusercontent.com/45733298/191940778-0b9d5737-f2cb-4991-9a83-dc0247e314bb.gif)

After:
![works](https://user-images.githubusercontent.com/45733298/191939657-cfbb24ac-d6dc-4897-ac3a-3b87854b18f0.gif)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
