### PR TITLE
fix: remove dead links from menu (SQCORE-1271)

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -260,14 +260,16 @@ const helpTemplate: MenuItemConstructorOptions = {
       click: () => openExternal(config.legalUrl, true),
       label: locale.getText('menuLegal'),
     },
-    {
-      click: () => openExternal(config.privacyUrl, true),
-      label: locale.getText('menuPrivacy'),
-    },
-    {
-      click: () => openExternal(config.licensesUrl, true),
-      label: locale.getText('menuLicense'),
-    },
+    // TODO: removing these temporarily until such a time as the website is fixed.
+    // See https://wearezeta.atlassian.net/browse/SQCORE-1271 for more information.
+    // {
+    //   click: () => openExternal(config.privacyUrl, true),
+    //   label: locale.getText('menuPrivacy'),
+    // },
+    // {
+    //   click: () => openExternal(config.licensesUrl, true),
+    //   label: locale.getText('menuLicense'),
+    // },
     {
       click: () => openExternal(config.supportUrl, true),
       label: locale.getText('menuSupport'),


### PR DESCRIPTION
This PR temporarily removes broken links from the desktop menu. 

The goal would be to have the wire website updated to add these back eventually. 

Until then, the legal link will direct to a location where the other two are accessible. 