### PR TITLE
runfix: use base64 encoding for key encryption [FS-1083]

### DIFF
--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -18,6 +18,7 @@
  */
 
 import {ipcRenderer, webFrame} from 'electron';
+import {Encoder, Decoder} from 'bazinga64';
 import * as path from 'path';
 import {WebAppEvents} from '@wireapp/webapp-events';
 import type {Availability} from '@wireapp/protocol-messaging';
@@ -243,13 +244,11 @@ process.once('loaded', () => {
   };
   global.secretsCrypto = {
     decrypt: async (encrypted: Uint8Array): Promise<Uint8Array> => {
-      const encoder = new TextEncoder();
       const plainText = await ipcRenderer.invoke(EVENT_TYPE.ACTION.DECRYPT, encrypted);
-      return encoder.encode(plainText);
+      return Decoder.fromBase64(plainText).asBytes;
     },
     encrypt: (value: Uint8Array): Promise<Uint8Array> => {
-      const decoder = new TextDecoder();
-      const strValue = decoder.decode(value);
+      const strValue = Encoder.toBase64(value).asString;
       return ipcRenderer.invoke(EVENT_TYPE.ACTION.ENCRYPT, strValue);
     },
   };


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When `FEATURE_ENABLE_MLS` flag was turned on for desktop wrapper, user was logged out from their account and was not able to login again.

### Causes

The reason behind this issue was the custom encryption/decryption method we were using for desktop wrapper (native `TextEncoder` and `TextDecoder` with electron's `safeStorage`). On the `webapp` side when logging in with brand new mls device (feature flag enabled). We were creating Uint8Array and filling it with random 16bits (`window.crypto.getRandomValues()` method). Some of the generated numbers were too big and couldn't be decoded (transformed to plain string) correctly using `TextDecoder` what resulted in error charcodes (�) appearing in saved key. Then when trying to log in saved decoded key was encoded incorrectly in 'read' process. The encoded key `Uint8Array`-shaped was different than decoded one (because of invalid decoding process), what resulted in CoreCrypto.init method throwing unhandled error (screen below)

<img width="439" alt="Screenshot 2022-10-17 at 14 16 10" src="https://user-images.githubusercontent.com/45733298/196388250-bf60f393-dfa2-43ae-94b0-9fb6e48b9976.png">

Console logs for more understanding (see the difference in number of bits):

<img width="480" alt="Screenshot 2022-10-18 at 08 42 50" src="https://user-images.githubusercontent.com/45733298/196388391-08b540df-17bd-408e-a1a9-cd15e2f2afed.png">

### Solutions

The solution was to use some other method of encryption/decryption. We decided to use base64 encoding for Uint8Array/string conversion (`Encoder` and `Decoder` from `bazinga64` package). Note that we're still using `safeStorage.(encryptString|decryptString)` 👍

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
