### PR TITLE
runfix: rename secretsCrypto to support broken clients [FS-1083]

### DIFF
--- a/electron/src/global.ts
+++ b/electron/src/global.ts
@@ -63,7 +63,7 @@ declare global {
       };
       environment: typeof EnvironmentUtil;
       openGraphAsync(url: string): Promise<OpenGraphResult>;
-      secretsCrypto?: {
+      systemCrypto?: {
         decrypt: (value: Uint8Array) => Promise<Uint8Array>;
         encrypt: (encrypted: Uint8Array) => Promise<Uint8Array>;
       };

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -242,7 +242,7 @@ process.once('loaded', () => {
   global.desktopCapturer = {
     getDesktopSources: opts => ipcRenderer.invoke(EVENT_TYPE.ACTION.GET_DESKTOP_SOURCES, opts),
   };
-  global.secretsCrypto = {
+  global.systemCrypto = {
     decrypt: async (encrypted: Uint8Array): Promise<Uint8Array> => {
       const plainText = await ipcRenderer.invoke(EVENT_TYPE.ACTION.DECRYPT, encrypted);
       return Decoder.fromBase64(plainText).asBytes;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We want to add backward compatibility for the clients that were broken after mistakenly enabling `FEATURE_ENABLE_MLS` flag on their environment. We want to disable MLS for these clients. 

The (a little bit hacky) solution is to rename electron's `secretsCrypto` global config to `systemCrypto` and then on the `webapp` side, check if a current client is using desktop wrapper and the new global is defined and enable MLS only in this case.

#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
