### PR TITLE
fix: [wire-desktop] Keyboard navigation can move focus into second account invisible settings(ACC-393)

### DIFF
--- a/electron/renderer/src/components/Sidebar.jsx
+++ b/electron/renderer/src/components/Sidebar.jsx
@@ -23,7 +23,7 @@ import {connect} from 'react-redux';
 import {EVENT_TYPE} from '../../../dist/lib/eventType';
 import {addAccountWithSession, setAccountContextHidden, toggleEditAccountMenuVisibility} from '../actions';
 import {colorFromId} from '../lib/accentColor';
-import {preventFocus} from '../lib/util';
+import {preventFocus, isEnterKey} from '../lib/keyboardUtil';
 import AccountIcon from './AccountIcon';
 import AddAccountTrigger from './context/AddAccountTrigger';
 import EditAccountMenu from './context/EditAccountMenu';
@@ -45,6 +45,10 @@ const getClassName = account => {
   return `Sidebar-icon${showIconBadge}${showIconCursor}`;
 };
 
+const handleSwitchAccount = accountIndex => {
+  window.dispatchEvent(new CustomEvent(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, {detail: {accountIndex: accountIndex}}));
+};
+
 const Sidebar = ({
   accounts,
   currentAccentID,
@@ -61,35 +65,40 @@ const Sidebar = ({
     onMouseDown={preventFocus()}
     onClick={connected.setAccountContextHidden}
   >
-    {accounts.map(account => (
-      <div className="Sidebar-cell" key={account.id}>
-        <div
-          style={{color: colorFromId(currentAccentID)}}
-          className={getClassName(account)}
-          onClick={preventFocus(() =>
-            window.dispatchEvent(
-              new CustomEvent(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, {detail: {accountIndex: accounts.indexOf(account)}}),
-            ),
-          )}
-          onContextMenu={preventFocus(event => {
-            const isAtLeastAdmin =
-              account.teamRole === 'z.team.TeamRole.ROLE.OWNER' || account.teamRole === 'z.team.TeamRole.ROLE.ADMIN';
-            const {centerX, centerY} = centerOfEventTarget(event);
-            connected.toggleEditAccountMenuVisibility(
-              centerX,
-              centerY,
-              account.id,
-              account.sessionID,
-              account.lifecycle,
-              isAtLeastAdmin,
-            );
-          })}
-          onMouseDown={preventFocus()}
-        >
-          <AccountIcon account={account} />
+    {accounts.map(account => {
+      const accountIndex = accounts.indexOf(account);
+      return (
+        <div className="Sidebar-cell" key={account.id}>
+          <div
+            style={{color: colorFromId(currentAccentID)}}
+            className={getClassName(account)}
+            tabIndex={0}
+            onClick={preventFocus(() => handleSwitchAccount(accountIndex))}
+            onKeyDown={event => {
+              if (isEnterKey(event)) {
+                handleSwitchAccount(accountIndex);
+              }
+            }}
+            onContextMenu={preventFocus(event => {
+              const isAtLeastAdmin =
+                account.teamRole === 'z.team.TeamRole.ROLE.OWNER' || account.teamRole === 'z.team.TeamRole.ROLE.ADMIN';
+              const {centerX, centerY} = centerOfEventTarget(event);
+              connected.toggleEditAccountMenuVisibility(
+                centerX,
+                centerY,
+                account.id,
+                account.sessionID,
+                account.lifecycle,
+                isAtLeastAdmin,
+              );
+            })}
+            onMouseDown={preventFocus()}
+          >
+            <AccountIcon account={account} />
+          </div>
         </div>
-      </div>
-    ))}
+      );
+    })}
     {!isAddingAccount && !hasReachedLimitOfAccounts && (
       <AddAccountTrigger id="account" onClick={connected.addAccountWithSession} />
     )}

--- a/electron/renderer/src/components/Webview.jsx
+++ b/electron/renderer/src/components/Webview.jsx
@@ -253,6 +253,7 @@ const Webview = ({
         webpreferences="backgroundThrottling=false"
         ref={webviewRef}
         style={{backgroundColor: COLOR.GRAY_LIGHTEN_88}}
+        tabIndex={-1}
       />
       {webviewError && (
         <div

--- a/electron/renderer/src/components/context/ContextMenu.css
+++ b/electron/renderer/src/components/context/ContextMenu.css
@@ -45,6 +45,10 @@
   transition-duration: var(--animation-timing-slow);
 }
 
+.ContextMenuTrigger:focus-visible {
+  opacity: 1;
+}
+
 .ContextMenu-item:hover,
 .ContextMenu-item.selected {
   background-color: rgba(0, 0, 0, 0.16);

--- a/electron/renderer/src/lib/keyboardUtil.js
+++ b/electron/renderer/src/lib/keyboardUtil.js
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/electron/renderer/src/lib/keyboardUtil.js
+++ b/electron/renderer/src/lib/keyboardUtil.js
@@ -17,28 +17,13 @@
  *
  */
 
-import React from 'react';
+export const KEY = {
+  ENTER: 'Enter',
+};
 
-import {isEnterKey} from '../../../src/lib/keyboardUtil';
+export const isKey = (keyboardEvent, expectedKey = '') => {
+  const eventKey = keyboardEvent?.key?.toLowerCase() || '';
+  return eventKey === expectedKey.toLowerCase();
+};
 
-const AddAccountTrigger = ({forceVisible, onClick}) => (
-  <div
-    className={`Sidebar-cell${forceVisible ? '' : ' ContextMenuTrigger'}`}
-    onClick={onClick}
-    onKeyDown={event => {
-      if (isEnterKey(event)) {
-        onClick();
-      }
-    }}
-    data-uie-name="do-open-plus-menu"
-    tabIndex={0}
-  >
-    <div className="Sidebar-account-add">
-      <svg width="12" height="12" viewBox="0 0 12 12">
-        <path d="M0 5.25v1.5h5.25V12h1.5V6.75H12v-1.5H6.75V0h-1.5v5.25" fillRule="evenodd" />
-      </svg>
-    </div>
-  </div>
-);
-
-export default AddAccountTrigger;
+export const isEnterKey = keyboardEvent => isKey(keyboardEvent, KEY.ENTER);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [wire-desktop] Keyboard navigation can move focus into second account invisible settings
  
- The **PR Description**
  - keyboard navigation from ephemeral button(chat message actions) should focus on the account sidebar
- make accounts sidebar keyboard accessible
- accounts can be opened using keyboard(enter key)
- trap the focus in sidebar accounts
- add account button should be tabbed and focusable
- add account can be opened using keyboard
----