### PR TITLE
fix: replace localhost environment option by localzinfra

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -668,32 +668,6 @@ class ElectronWrapperInit {
 
           contents.session.setCertificateVerifyProc(setCertificateVerifyProc);
 
-          // Override remote Access-Control-Allow-Origin for localhost (CORS bypass)
-          const isLocalhostEnvironment =
-            EnvironmentUtil.getEnvironment() == EnvironmentUtil.BackendType.LOCALHOST.toUpperCase();
-          if (isLocalhostEnvironment) {
-            const filter: WebRequestFilter = {
-              urls: config.backendOrigins.map(value => `${value}/*`),
-            };
-
-            const listenerOnHeadersReceived = (
-              details: OnHeadersReceivedListenerDetails,
-              callback: (response: HeadersReceivedResponse) => void,
-            ): void => {
-              const responseHeaders = {
-                'Access-Control-Allow-Credentials': ['true'],
-                'Access-Control-Allow-Origin': [EnvironmentUtil.URL_WEBAPP.LOCALHOST],
-              };
-
-              callback({
-                cancel: false,
-                responseHeaders: {...details.responseHeaders, ...responseHeaders},
-              });
-            };
-
-            contents.session.webRequest.onHeadersReceived(filter, listenerOnHeadersReceived);
-          }
-
           contents.on('before-input-event', (_event, input) => {
             if (input.type === 'keyUp' && input.key === 'Alt') {
               const mainBrowserWindow = WindowManager.getPrimaryWindow();

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -27,7 +27,7 @@ export enum BackendType {
   DEVELOPMENT = 'DEVELOPMENT',
   EDGE = 'EDGE',
   INTERNAL = 'INTERNAL',
-  LOCALHOST = 'LOCALHOST',
+  LOCALZINFRA = 'LOCALZINFRA',
   MASTER = 'MASTER',
   PRODUCTION = 'PRODUCTION',
   QA = 'QA',
@@ -53,7 +53,7 @@ export const URL_WEBAPP: Record<BackendType, string> = {
   MASTER: 'https://wire-webapp-master.zinfra.io',
   QA: 'https://wire-webapp-qa.zinfra.io',
   INTERNAL: 'https://wire-webapp-staging.wire.com',
-  LOCALHOST: 'https://localhost:8081',
+  LOCALZINFRA: 'https://local.zinfra.io:8081',
   PRODUCTION: config.appBase,
   CUSTOM: settings.restore(SettingsType.CUSTOM_WEBAPP_URL, config.appBase),
 };

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "postinstall": "yarn configure",
     "prestart": "yarn build:ts && yarn bundle:dev",
     "prettier": "prettier \"**/*.{json,md,css,yml,html}\"",
-    "start": "cross-env NODE_DEBUG=@wireapp* electron . --no-sandbox --inspect --devtools --enable-logging",
+    "start": "cross-env NODE_DEBUG='@wireapp*' electron . --no-sandbox --inspect --devtools --enable-logging",
     "start:dev": "yarn start --env=https://wire-webapp-dev.zinfra.io",
     "start:proxy": "yarn start --env=https://wire-webapp-dev.zinfra.io --proxy-server=\"https://127.0.0.1:3128\"",
     "start:edge": "yarn start --env=https://wire-webapp-edge.zinfra.io",

--- a/package.json
+++ b/package.json
@@ -175,8 +175,6 @@
     "start:proxy": "yarn start --env=https://wire-webapp-dev.zinfra.io --proxy-server=\"https://127.0.0.1:3128\"",
     "start:edge": "yarn start --env=https://wire-webapp-edge.zinfra.io",
     "start:internal": "yarn start --env=https://wire-webapp-staging.wire.com",
-    "start:localhost": "yarn start --env=http://localhost:8081",
-    "start:localhostHttps": "yarn start --env=https://localhost:8081",
     "start:localzinfra": "yarn start --env=https://local.zinfra.io:8081",
     "start:prod": "yarn start --env=https://app.wire.com",
     "start:rc": "yarn start --env=https://wire-webapp-rc.zinfra.io",


### PR DESCRIPTION
### Issue
- localhost should not be used as a development environment anymore and local.zinfra.io is used instead
- the CORS bypass in `main.ts` is not necessary

### Solution
- replace the localhost option by localzinfra
- remove the 2 scripts using localhost from `package.json`
- remove the CORS bypass entirely

#### Addition
- fix the broken start script in `package.json` by wrapping `@wireapp*` in single quotes