### PR TITLE
fix(windows): Feed root level exe file to app shortcuts

### DIFF
--- a/electron/src/update/shortcuts.ts
+++ b/electron/src/update/shortcuts.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {shell} from 'electron';
+import fs from 'fs-extra';
+
+export function createShortcuts(locations: string[], execPath: string, appUserModelId: string) {
+  // As documented in https://github.com/electron/windows-installer/issues/296,
+  // Squirrel has problems with notification clicks on Windows 10.
+  // The easiest workaround is to create shortcuts on our own.
+  locations.forEach(location => {
+    shell.writeShortcutLink(location, {
+      appUserModelId: appUserModelId,
+      target: execPath,
+    });
+  });
+}
+
+export async function removeShortcuts(shortcutPaths: string[]) {
+  return Promise.all(shortcutPaths.map(shortcutPath => fs.remove(shortcutPath)));
+}

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -19,7 +19,6 @@
 
 // https://github.com/atom/atom/blob/ce18e1b7d65808c42df5b612d124935ab5c06490/src/main-process/squirrel-update.js
 
-import {app} from 'electron';
 import {StringUtil} from '@wireapp/commons';
 import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
@@ -51,17 +50,6 @@ enum SQUIRREL_EVENT {
   UNINSTALL = '--squirrel-uninstall',
   UPDATED = '--squirrel-updated',
 }
-
-const linkName = `${config.name}.lnk`;
-const shortcutsMap = {
-  desktop: path.join(app.getPath('desktop'), linkName),
-  quickLaunch: process.env.APPDATA
-    ? path.resolve(process.env.APPDATA, 'Microsoft/Internet Explorer/Quick Launch/User Pinned/TaskBar', linkName)
-    : undefined,
-  start: path.join(app.getPath('appData'), 'Microsoft/Windows/Start Menu/Programs', linkName),
-};
-
-const shortcuts = Object.values(shortcutsMap).filter((path): path is string => !!path);
 
 function spawn(command: string, args: string[]): Promise<void> {
   const commandFile = path.basename(command);
@@ -135,14 +123,14 @@ export async function handleSquirrelArgs(): Promise<void> {
   switch (squirrelEvent) {
     case SQUIRREL_EVENT.INSTALL:
     case SQUIRREL_EVENT.UPDATED: {
-      logger.info(`Creating shortcuts for exe ${exePath} (${JSON.stringify(shortcuts)})...`);
-      await createShortcuts(shortcuts, exePath, config.appUserModelId);
+      logger.info(`Creating shortcuts for exe ${exePath}...`);
+      await createShortcuts(exePath);
       await lifecycle.quit();
       return;
     }
 
     case SQUIRREL_EVENT.UNINSTALL: {
-      await removeShortcuts(shortcuts);
+      await removeShortcuts();
       await lifecycle.quit();
       return;
     }

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -98,11 +98,11 @@ async function spawnUpdate(args: string[]): Promise<void> {
 }
 
 function createShortcuts(): Promise<void> {
-  return spawnUpdate(['--createShortcut', `${config.name}.exe`]);
+  return spawnUpdate([`--createShortcut=${config.name}.exe`, '-l=StartMenu,Desktop,Startup']);
 }
 
 function removeShortcuts(): Promise<void> {
-  return spawnUpdate(['--removeShortcut', `${config.name}.exe`]);
+  return spawnUpdate([`--removeShortcut=${config.name}.exe`, '-l=StartMenu,Desktop,Startup']);
 }
 
 export async function installUpdate(): Promise<void> {

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -49,6 +49,8 @@ enum SQUIRREL_EVENT {
   UPDATED = '--squirrel-updated',
 }
 
+const shortcuts = ['StartMenu', 'Desktop', 'Startup'] as const;
+
 function spawn(command: string, args: string[]): Promise<void> {
   const commandFile = path.basename(command);
 
@@ -98,11 +100,11 @@ async function spawnUpdate(args: string[]): Promise<void> {
 }
 
 function createShortcuts(): Promise<void> {
-  return spawnUpdate([`--createShortcut=${config.name}.exe`, '-l=StartMenu,Desktop,Startup']);
+  return spawnUpdate([`--createShortcut=${config.name}.exe`, `-l=${shortcuts.join(',')}`]);
 }
 
 function removeShortcuts(): Promise<void> {
-  return spawnUpdate([`--removeShortcut=${config.name}.exe`, '-l=StartMenu,Desktop,Startup']);
+  return spawnUpdate([`--removeShortcut=${config.name}.exe`, `-l=${shortcuts.join(',')}`]);
 }
 
 export async function installUpdate(): Promise<void> {


### PR DESCRIPTION
Since https://github.com/wireapp/wire-desktop/pull/4965 we manually create the shortcuts to the application exec file. 
But because those shortcuts are based on the current `process.execPath` that resolves to the versioned exec file, we get shortcuts that link to a version that might at some point be an old version. 

We now use the root level `Wire.exe` file as the link target