### PR TITLE
fix: run `prestart` befor running `start` to make sure changes in typescript are acutally being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "postinstall": "yarn configure",
     "prestart": "yarn build:ts && yarn bundle:dev",
     "prettier": "prettier \"**/*.{json,md,css,yml,html}\"",
-    "start": "cross-env NODE_DEBUG='@wireapp*' electron . --no-sandbox --inspect --devtools --enable-logging",
+    "start": "yarn prestart && cross-env NODE_DEBUG='@wireapp*' electron . --no-sandbox --inspect --devtools --enable-logging",
     "start:dev": "yarn start --env=https://wire-webapp-dev.zinfra.io",
     "start:proxy": "yarn start --env=https://wire-webapp-dev.zinfra.io --proxy-server=\"https://127.0.0.1:3128\"",
     "start:edge": "yarn start --env=https://wire-webapp-edge.zinfra.io",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
when using `yarn start` changes to typescript code are not used by the started application

### Solutions
run `yarn prestart` when executing `yarn start`

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

1. make modifications to typescript code
2. see that they are applied when using `yarn start`


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
