### PR TITLE
fix: Do not assume base64 encoded string when encrypting/decrypting

### DIFF
--- a/electron/src/global.ts
+++ b/electron/src/global.ts
@@ -64,8 +64,8 @@ declare global {
       environment: typeof EnvironmentUtil;
       openGraphAsync(url: string): Promise<OpenGraphResult>;
       systemCrypto?: {
-        decrypt: (value: Uint8Array) => Promise<string>;
-        encrypt: (encrypted: string) => Promise<Uint8Array>;
+        decrypt: (payload: Uint8Array) => Promise<string>;
+        encrypt: (value: string) => Promise<Uint8Array>;
         /**
          * version:
          *   - undefined: the encrypt/decrypt methods would take and return Uint8Array (and try to parse them as base64)

--- a/electron/src/global.ts
+++ b/electron/src/global.ts
@@ -64,8 +64,14 @@ declare global {
       environment: typeof EnvironmentUtil;
       openGraphAsync(url: string): Promise<OpenGraphResult>;
       systemCrypto?: {
-        decrypt: (value: Uint8Array) => Promise<Uint8Array>;
-        encrypt: (encrypted: Uint8Array) => Promise<Uint8Array>;
+        decrypt: (value: Uint8Array) => Promise<string>;
+        encrypt: (encrypted: string) => Promise<Uint8Array>;
+        /**
+         * version:
+         *   - undefined: the encrypt/decrypt methods would take and return Uint8Array (and try to parse them as base64)
+         *   - 1: the encrypt/decrypt methods would take and return string (no assumption on the format (base64, hex, etc.)))
+         */
+        version: number;
       };
     }
   }

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -243,14 +243,13 @@ process.once('loaded', () => {
     getDesktopSources: opts => ipcRenderer.invoke(EVENT_TYPE.ACTION.GET_DESKTOP_SOURCES, opts),
   };
   global.systemCrypto = {
-    decrypt: async (encrypted: Uint8Array): Promise<Uint8Array> => {
-      const plainText = await ipcRenderer.invoke(EVENT_TYPE.ACTION.DECRYPT, encrypted);
-      return Decoder.fromBase64(plainText).asBytes;
+    decrypt: async (encrypted: Uint8Array): Promise<string> => {
+      return ipcRenderer.invoke(EVENT_TYPE.ACTION.DECRYPT, encrypted);
     },
-    encrypt: (value: Uint8Array): Promise<Uint8Array> => {
-      const strValue = Encoder.toBase64(value).asString;
-      return ipcRenderer.invoke(EVENT_TYPE.ACTION.ENCRYPT, strValue);
+    encrypt: (value: string): Promise<Uint8Array> => {
+      return ipcRenderer.invoke(EVENT_TYPE.ACTION.ENCRYPT, value);
     },
+    version: 1,
   };
   global.environment = EnvironmentUtil;
   global.openGraphAsync = getOpenGraphDataViaChannel;


### PR DESCRIPTION
With the previous version, we assumed that the decrypted string will be base65 encoded. Which is not necessarily true. We also need to be able to decrypt random bytes