### PR TITLE
fix: use correct escaping in the context of regex

### DIFF
--- a/bin/build-tools/lib/build-windows.ts
+++ b/bin/build-tools/lib/build-windows.ts
@@ -63,7 +63,7 @@ export async function buildWindowsConfig(
     ignore: [
       new RegExp(`${commonConfig.electronDirectory}/renderer/src$`),
       new RegExp(`${commonConfig.electronDirectory}/src$`),
-      new RegExp(`/\.yarn$`),
+      new RegExp(`/\\.yarn$`),
       new RegExp(`/bin$`),
       new RegExp(`/jenkins$`),
     ],


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `.` was not correctly escaped, causing some linters to complain. Also It still matches any 5 character file/folder that ends with `yarn`.

### Solutions

Use correct escaping for the backslash, that is then escaping the `.` in the regex.

### Testing

Tested by verifying if the app.asar is below 75 MB and does not contain the `.yarn` folder.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
