### PR TITLE
fix: prevent webapp from closing itself (SQSERVICES-1919)

### DIFF
--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -279,3 +279,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   // include context menu
   await import('./menu/preload-context');
 });
+
+// overwrite window.close() to prevent webapp from closing itself
+// see SQSERVICES-1882 and SQSERVICES-1919
+window.close = () => {};


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Electron webviews can close themself. If the webapp e.g. by mistake (SQSERVICES-1882) closes itself, some functionality gets disconnected. In this case shortcuts were no longer working

### Solutions

Removing the functionality to close itself via preload script, prevents the webapp even by mistake from closing itself.


### Testing

#### How to Test

Application should work as expected, all functionality tests must pass.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
