### PR TITLE
feat: Set TLS 1.2 as minimum version for connections (SQCORE-652)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -652,7 +652,7 @@ class ElectronWrapperInit {
             params.plugins = 'false';
             webPreferences.allowRunningInsecureContent = false;
             webPreferences.contextIsolation = false;
-            webPreferences.experimentalFeatures = true;
+            webPreferences.experimentalFeatures = false;
             webPreferences.nodeIntegration = false;
             webPreferences.preload = PRELOAD_RENDERER_JS;
             webPreferences.spellcheck = enableSpellChecking;

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -713,6 +713,9 @@ class ElectronWrapperInit {
             }
           }
 
+          // Disable TLS < v1.2
+          contents.session.setSSLConfig({minVersion: 'tls1.2'});
+
           contents.session.setCertificateVerifyProc(setCertificateVerifyProc);
 
           contents.on('before-input-event', (_event, input) => {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Electron by default supports TLS connections from tls1 up to tls1.3

### Solutions

This PR sets the minimum version for all TLS connections to tls1.2

### Testing

#### How to Test

All automated tests must pass, regular usage does not encounter tls connections supporting only tls1 or tls1.1.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
