### PR TITLE
fix: Improve how webapp environments are displayed in the dev menu

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -93,7 +93,7 @@ const customProtocolHandler = new CustomProtocolHandler();
 
 // Config
 const argv = minimist(process.argv.slice(1));
-const BASE_URL = EnvironmentUtil.web.getWebappUrl(argv[config.ARGUMENT.ENV]);
+const BASE_URL = EnvironmentUtil.web.getWebappUrl();
 const fileBasedProxyConfig = settings.restore<string | undefined>(SettingsType.PROXY_SERVER_URL);
 
 const logger = getLogger(path.basename(__filename));

--- a/electron/src/menu/developer.ts
+++ b/electron/src/menu/developer.ts
@@ -73,9 +73,12 @@ const createEnvironmentTemplates = (): MenuItemConstructorOptions[] => {
   for (const env of environments) {
     environmentTemplate.push({
       checked: env.isActive,
+      enabled: !!env.server,
       click: async () => {
-        setEnvironment(env.server);
-        await lifecycle.relaunch();
+        if (env.server) {
+          setEnvironment(env.server);
+          await lifecycle.relaunch();
+        }
       },
       label: env.name,
       type: 'radio',

--- a/electron/src/menu/developer.ts
+++ b/electron/src/menu/developer.ts
@@ -20,12 +20,10 @@
 import {MenuItem, MenuItemConstructorOptions} from 'electron';
 
 import {executeJavaScriptWithoutResult} from '../lib/ElectronUtil';
-import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
+import {getAvailebleEnvironments, setEnvironment} from '../runtime/EnvironmentUtil';
 import * as lifecycle from '../runtime/lifecycle';
 import {config} from '../settings/config';
 import {WindowManager} from '../window/WindowManager';
-
-const currentEnvironment = EnvironmentUtil.getEnvironment();
 
 const reloadTemplate: MenuItemConstructorOptions = {
   click: () => WindowManager.getPrimaryWindow()?.reload(),
@@ -70,20 +68,16 @@ const devToolsTemplate: MenuItemConstructorOptions = {
 
 const createEnvironmentTemplates = (): MenuItemConstructorOptions[] => {
   const environmentTemplate: MenuItemConstructorOptions[] = [];
-  const environments: Partial<typeof EnvironmentUtil.URL_WEBAPP> = {...EnvironmentUtil.URL_WEBAPP};
-  // remove the custom environment entry if it points to production (because this is the fallback)
-  if (environments.CUSTOM === config.appBase) {
-    delete environments.CUSTOM;
-  }
+  const environments = getAvailebleEnvironments();
 
-  for (const [backendType, backendURL] of Object.entries(environments)) {
+  for (const env of environments) {
     environmentTemplate.push({
-      checked: currentEnvironment === backendType,
+      checked: env.isActive,
       click: async () => {
-        EnvironmentUtil.setEnvironment(backendType as EnvironmentUtil.BackendType);
+        setEnvironment(env.server);
         await lifecycle.relaunch();
       },
-      label: backendURL!.replace(/^https?:\/\//, ''),
+      label: env.name,
       type: 'radio',
     });
   }

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -101,6 +101,11 @@ function getWebappUrl() {
   return customWebappUrl ?? envUrl ?? config.appBase;
 }
 
+/**
+ * Gives all the environments that are available to the app.
+ * It will add the custom url (set by the --env option) if set
+ * @returns {AvailableEnvironment[]} all the environment the app can run against
+ */
 export function getAvailebleEnvironments(): AvailableEnvironment[] {
   const customEnv = customWebappUrl
     ? {

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -50,7 +50,7 @@ const URL_WEBSITE = {
 const webappEnvironments = {
   [ServerType.PRODUCTION]: {name: 'Production', server: ServerType.PRODUCTION, url: 'https://app.wire.com'},
   [ServerType.BETA]: {name: 'Beta', server: ServerType.BETA, url: 'https://wire-webapp-staging.wire.com'},
-  [ServerType.EDGE]: {name: 'Edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.zinfra.io'},
+  [ServerType.EDGE]: {name: 'Edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.wire.com'},
 } as const;
 
 export const app = {

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -48,9 +48,9 @@ const URL_WEBSITE = {
 };
 
 const webappEnvironments = {
-  [ServerType.PRODUCTION]: {name: 'production', server: ServerType.PRODUCTION, url: 'https://app.wire.com'},
-  [ServerType.BETA]: {name: 'beta', server: ServerType.BETA, url: 'https://wire-webapp-staging.wire.com'},
-  [ServerType.EDGE]: {name: 'edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.zinfra.io'},
+  [ServerType.PRODUCTION]: {name: 'Production', server: ServerType.PRODUCTION, url: 'https://app.wire.com'},
+  [ServerType.BETA]: {name: 'Beta', server: ServerType.BETA, url: 'https://wire-webapp-staging.wire.com'},
+  [ServerType.EDGE]: {name: 'Edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.zinfra.io'},
 } as const;
 
 export const app = {

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -30,7 +30,7 @@ const isProdEnvironment = !!customWebappUrl;
 export enum ServerType {
   PRODUCTION = 'PRODUCTION',
   EDGE = 'EDGE',
-  STAGING = 'STAGING',
+  BETA = 'INTERNAL',
 }
 
 interface AvailableEnvironment {
@@ -49,7 +49,7 @@ const URL_WEBSITE = {
 
 const webappEnvironments = {
   [ServerType.PRODUCTION]: {name: 'production', server: ServerType.PRODUCTION, url: 'https://app.wire.com'},
-  [ServerType.STAGING]: {name: 'beta', server: ServerType.STAGING, url: 'https://wire-webapp-staging.wire.com'},
+  [ServerType.BETA]: {name: 'beta', server: ServerType.BETA, url: 'https://wire-webapp-staging.wire.com'},
   [ServerType.EDGE]: {name: 'edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.zinfra.io'},
 } as const;
 

--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -42,11 +42,6 @@ interface AvailableEnvironment {
 
 let currentEnvironment: ServerType;
 
-const URL_ADMIN = {
-  PRODUCTION: config.adminUrl,
-  STAGING: 'https://wire-admin-staging.zinfra.io',
-};
-
 const URL_WEBSITE = {
   PRODUCTION: config.websiteUrl,
   STAGING: 'https://wire-website-staging.zinfra.io',
@@ -99,7 +94,7 @@ const restoreEnvironment = (): ServerType => {
   return restoredEnvironment;
 };
 
-export const setEnvironment = (env?: ServerType): void => {
+export const setEnvironment = (env: ServerType): void => {
   currentEnvironment = env || restoreEnvironment();
   settings.save(SettingsType.ENV, currentEnvironment);
   settings.persistToFile();
@@ -113,7 +108,6 @@ export function getAvailebleEnvironments(): AvailableEnvironment[] {
   const customEnv = customWebappUrl
     ? {
         name: customWebappUrl.replace(/^https?:\/\//, ''),
-        server: ServerType.PRODUCTION,
         url: customWebappUrl,
         isActive: true,
       }
@@ -132,10 +126,6 @@ export function getAvailebleEnvironments(): AvailableEnvironment[] {
 }
 
 export const web = {
-  getAdminUrl: (path: string = ''): string => {
-    const baseUrl = isProdEnvironment ? URL_ADMIN.PRODUCTION : URL_ADMIN.STAGING;
-    return `${baseUrl}${path}`;
-  },
   getWebappUrl,
   getWebsiteUrl: (path: string = ''): string => {
     const baseUrl = isProdEnvironment ? URL_WEBSITE.PRODUCTION : URL_WEBSITE.STAGING;


### PR DESCRIPTION
This is the environments menu we currently have 

<img width="343" alt="image" src="https://github.com/wireapp/wire-desktop/assets/1090716/4f0acd97-2901-4461-9e63-d3beeb032bde">

This PR will simplify this menu and only allow 3 envs:
- production
- beta (currently staging, the one used by Internal wrapper by default)
- edge (bleeding edge code straight from dev, but the courageous ones)

![image](https://github.com/wireapp/wire-desktop/assets/1090716/d974cc07-25f6-46be-87de-fcb741d6b0b9)
