### PR TITLE
runfix: Restore ability to use custom webapp url from init.json

### DIFF
--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -24,7 +24,8 @@ import {settings} from '../settings/ConfigurationPersistence';
 import {SettingsType} from '../settings/SettingsType';
 
 const argv = minimist(process.argv.slice(1));
-const customWebappUrl: string | undefined = argv[config.ARGUMENT.ENV];
+const webappUrlSetting = settings.restore<string | undefined>(SettingsType.CUSTOM_WEBAPP_URL);
+const customWebappUrl: string | undefined = argv[config.ARGUMENT.ENV] || webappUrlSetting;
 const isProdEnvironment = !!customWebappUrl;
 
 export enum ServerType {


### PR DESCRIPTION
This allows configuring the desktop app to hit a different webapp url by editing the `init.json` file

Was broken since #7106 