### PR TITLE
Disable media session and media key features

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -146,6 +146,9 @@ app.setAppUserModelId(config.appUserModelId);
 
 // do not use mdns for local ip obfuscation to prevent windows firewall prompt
 app.commandLine.appendSwitch('disable-features', 'WebRtcHideLocalIpsWithMdns');
+// disable media session and hardware media key features as Wire is not a media player
+app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
+app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
 
 try {
   logger.info('GPUFeatureStatus:', app.getGPUFeatureStatus());


### PR DESCRIPTION
# What's new in this PR?

### Issues

When an audio message or a video is played, Wire is wrongly detected as a media player and takes precedence over other music or video players when a user presses hardware media keys.

The OS may also display Wire as a media player named "Chromium" with play/pause, previous and next controls, of which only the play/pause button is functional. It keeps being show even after the audio message or the video has finished playing.

### Causes

Electron enables `HardwareMediaKeyHandling` and `MediaSessionService` features by default.

### Solutions

Disable those features.

### Testing

#### How to Test

##### Without this patch

Wire should be visible in the audio controls section in the system tray on Linux (at least on GNOME and KDE) when a user plays an audio message or a video.

The behaviour on Windows should be similar.

It also gets detected as a media player on external devices when using KDE Connect media controls.

Depending on the system configuration, Wire may or may not respond to hardware media keys.

##### With this patch

None of the above happens.

### Notes

I submitted this PR because Wire always ends up showing on my phone with KDE Connect media controls when I play and audio message on my computer, and it remains there until I dismiss a notification or play something in a real media player, or quit Wire. That is because the MedaSession does not get destroyed after the audio message or a video has finished playing, and every play/pause triggers KDE Connect to show Wire as a currently active media player. The media controls section in the system tray does exactly the same thing, but that's not such a big problem since it is not always visible on screen.