### PR TITLE
build: Delete node_modules folder on start

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -30,7 +30,7 @@ node('built-in') {
 
   stage('Checkout & Clean') {
     git branch: "${GIT_BRANCH}", url: 'https://github.com/wireapp/wire-desktop.git'
-    sh returnStatus: true, script: 'rm -rf *.pkg *.zip ./wrap/dist/'
+    sh returnStatus: true, script: 'rm -rf *.pkg *.zip ./wrap/dist/ ./node_modules/'
   }
 
   def projectName = env.WRAPPER_BUILD.tokenize('#')[0]


### PR DESCRIPTION
Better cleanup to solve permission issues that might happen.