### PR TITLE
fix: make the release and information url configurable by end user (WPB-5579)

### DIFF
--- a/bin/build-tools/lib/Config.ts
+++ b/bin/build-tools/lib/Config.ts
@@ -18,6 +18,8 @@
  */
 
 export interface CommonConfig {
+  aboutReleasesUrl: string;
+  aboutUpdatesUrl: string;
   adminUrl: string;
   appBase: string;
   buildDir: string;

--- a/bin/build-tools/lib/commonConfig.ts
+++ b/bin/build-tools/lib/commonConfig.ts
@@ -53,6 +53,8 @@ export async function getCommonConfig(envFile: string, wireJson: string): Promis
 
   const commonConfig: CommonConfig = {
     ...defaultConfig,
+    aboutReleasesUrl: process.env.URL_ABOUT_RELEASES || defaultConfig.aboutReleasesUrl,
+    aboutUpdatesUrl: process.env.URL_ABOUT_UPDATES || defaultConfig.aboutUpdatesUrl,
     adminUrl: process.env.URL_ADMIN || defaultConfig.adminUrl,
     appBase: process.env.APP_BASE || defaultConfig.appBase,
     buildDir: defaultConfig.buildDir || 'wrap/build',


### PR DESCRIPTION
#### Description

- the "Releases" link in "Help > About Wire" should link to medium instead of github by default https://wearezeta.atlassian.net/browse/WPB-5579
- End users should be able to set custom `URL-PATH` with environment variables https://wearezeta.atlassian.net/browse/WPB-4676

#### Changes

- make `aboutReleasesUrl` and `aboutUpdatesUrl` variables that can be determined with env variables in `getCommonConfig`
- the default env variables already exist here: https://github.com/wireapp/wire-web-config-wire/blob/master/wire-desktop/.env.defaults