### PR TITLE
chore: clean unnecessary code for macos refresh

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -390,7 +390,7 @@ const showRestartMessageBox = async () => {
     type: 'info',
   });
   if (response === 1) {
-    await (EnvironmentUtil.platform.IS_MAC_OS ? lifecycle.quit() : lifecycle.relaunch());
+    await lifecycle.relaunch();
   }
 };
 

--- a/electron/src/runtime/lifecycle.ts
+++ b/electron/src/runtime/lifecycle.ts
@@ -103,15 +103,6 @@ export const quit = async (clearCache = true): Promise<void> => {
 
 export const relaunch = async () => {
   logger.info('Relaunching the app ...');
-  if (EnvironmentUtil.platform.IS_MAC_OS) {
-    /*
-     * on MacOS, it is not possible to relaunch the app, so just fallback
-     * to reloading all the webviews
-     * see: https://github.com/electron/electron/issues/13696
-     */
-    relaunchListeners.forEach(listener => listener());
-  } else {
-    app.relaunch();
-    await quit();
-  }
+  app.relaunch();
+  await quit();
 };


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
 Previously macos restart was not working correctly in an old version of electron, from my testing it has since been rectified and macos can now restart correctly. we should remove the old hack now. 

### Reference
 https://github.com/electron/electron/issues/13696
