### PR TITLE
fix: allow the webview to navigate outside of the baseURL

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -657,13 +657,14 @@ class ElectronWrapperInit {
       }
     };
 
+    // Keeping this Function for future use
     const willNavigateInWebview = (event: ElectronEvent, url: string, baseUrl: string): void => {
       // Ensure navigation is to an allowed domain
       if (OriginValidator.isMatchingHost(url, baseUrl)) {
         this.logger.log(`Navigating inside <webview>. URL: ${url}`);
       } else {
-        this.logger.log(`Preventing navigation inside <webview>. URL: ${url}`);
-        event.preventDefault();
+        // ToDo: Add a back button to the webview to navigate back to the main app
+        this.logger.log(`Navigating outside <webview>. URL: ${url}`);
       }
     };
 


### PR DESCRIPTION
This is a needed fix to allow the user to be redirected to their IDP Provider (in the case of End-2-End-Identity).