### PR TITLE
fix: Address AppLock feature hiding the sidebar

### DIFF
--- a/electron/renderer/src/components/WebView/Webview.css
+++ b/electron/renderer/src/components/WebView/Webview.css
@@ -25,11 +25,7 @@
 }
 
 .Webview.hide {
-  /**
-   * Electron's recommended way of using 0px width and height was causing
-   * render issues when selecting a webview for the first time
-   */
-  z-index: var(--z-index-webview-hidden);
+  display: none;
 }
 
 .Webview-close {


### PR DESCRIPTION
## Description

When you have multiple accounts logged in in the same desktop version instance, then there could be conflicts with the `<webviews>` somehow. 

This causes the sidebar to flicker when the webapp applock modal is displayed on screen. 

## Solution

We used to rely on some `z-index` hack to hide all the webviews except the active one. This is probably due to the fact that `<webviews>` and `display: none` were not working properly together at some point in Electron (see https://github.com/electron/electron/issues/5110). 

We could now use the simple `display: none` to hide all the webviews that are not active anymore (and this fixes the sidebar issue, as well). 

## Screencasts

### Before


https://github.com/wireapp/wire-desktop/assets/1090716/56e92c37-d70c-4db3-8824-d17bcb350bfa



### After

https://github.com/wireapp/wire-desktop/assets/1090716/9d2418ba-f715-4c3f-841d-c88c9884ba48


 