### PR TITLE
chore: Upgrade to electron 29

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cross-env": "7.0.3",
     "css-loader": "6.10.0",
     "dotenv": "16.4.5",
-    "electron": "27.3.7",
+    "electron": "29.1.4",
     "electron-builder": "24.13.3",
     "electron-mocha": "12.2.0",
     "electron-packager": "17.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,10 +3680,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.11.18":
-  version: 18.17.15
-  resolution: "@types/node@npm:18.17.15"
-  checksum: eed11d4398ccdb999a4c65658ee75de621a4ad57aece48ed2fb8803b1e2711fadf58d8aefbdb0a447d69cf3cba602ca32fe0fc92077575950a796e1dc13baa0f
+"@types/node@npm:^20.9.0":
+  version: 20.11.30
+  resolution: "@types/node@npm:20.11.30"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 7597767aa3e44b0f1bf62efa522dd17741135f283c11de6a20ead8bb7016fb4999cc30adcd8f2bb29ebb216906c92894346ccd187de170927dc1e212d2c07c81
   languageName: node
   linkType: hard
 
@@ -7343,16 +7345,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:27.3.7":
-  version: 27.3.7
-  resolution: "electron@npm:27.3.7"
+"electron@npm:29.1.4":
+  version: 29.1.4
+  resolution: "electron@npm:29.1.4"
   dependencies:
     "@electron/get": ^2.0.0
-    "@types/node": ^18.11.18
+    "@types/node": ^20.9.0
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 0fcc65ff33872948288d0f97594a6be2df7e48d5a5f8f1bc6504e5c49594ce77bab85714f11ea15c09820e527af24f4fc748f645379fc5a926fc56b56057da02
+  checksum: d7a6db0f3bcd497f150ff492a6d085ce8ccf03af77f10b12f42213daee2ef81986ac8a2cdee3414184f5aed76d2ce758a6529520bbf339c44630206026a451c1
   languageName: node
   linkType: hard
 
@@ -17187,7 +17189,7 @@ __metadata:
     cross-env: 7.0.3
     css-loader: 6.10.0
     dotenv: 16.4.5
-    electron: 27.3.7
+    electron: 29.1.4
     electron-builder: 24.13.3
     electron-dl: ^3.5.2
     electron-mocha: 12.2.0


### PR DESCRIPTION
see breaking changes for:
- electron 29 https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-290
- electron 28 https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-280
