### PR TITLE
fix(env): regression with prod env not being properly read

### DIFF
--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -26,7 +26,6 @@ import {SettingsType} from '../settings/SettingsType';
 const argv = minimist(process.argv.slice(1));
 const webappUrlSetting = settings.restore<string | undefined>(SettingsType.CUSTOM_WEBAPP_URL);
 const customWebappUrl: string | undefined = argv[config.ARGUMENT.ENV] || webappUrlSetting;
-const isProdEnvironment = !!customWebappUrl;
 
 export enum ServerType {
   PRODUCTION = 'PRODUCTION',
@@ -45,7 +44,6 @@ let currentEnvironment = settings.restore<ServerType | undefined>(SettingsType.E
 
 const URL_WEBSITE = {
   PRODUCTION: config.websiteUrl,
-  STAGING: 'https://wire-website-staging.zinfra.io',
 };
 
 const webappEnvironments = {
@@ -131,7 +129,7 @@ export function getAvailebleEnvironments(): AvailableEnvironment[] {
 export const web = {
   getWebappUrl,
   getWebsiteUrl: (path: string = ''): string => {
-    const baseUrl = isProdEnvironment ? URL_WEBSITE.PRODUCTION : URL_WEBSITE.STAGING;
+    const baseUrl = URL_WEBSITE.PRODUCTION;
     return `${baseUrl}${path}`;
   },
 };


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

fixes a regression introduced in #7106 

### Causes (Optional)

customWebappUrl is not an accurate way to determine if the app is productionEnv. Additionally, staging url has been deprecated.

