### PR TITLE
chore: Replace `uuidjs` with `uuid` WPB-7240

### DIFF
--- a/bin/bin-utils.ts
+++ b/bin/bin-utils.ts
@@ -23,7 +23,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
-import UUID from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 interface BackupResult {
   backupPaths: string[];
@@ -51,7 +51,7 @@ export async function restoreFiles({originalPaths, backupPaths, tempDir}: Backup
   await fs.remove(tempDir);
 }
 
-export const generateUUID = () => UUID.genV4().toString();
+export const generateUUID = () => uuidv4();
 
 export const getLogger = (namespace: string, name: string): Logger =>
   LogFactory.getLogger(name, {forceEnable: true, namespace: `@wireapp/${namespace}`, separator: '/'});

--- a/electron/renderer/src/lib/util.ts
+++ b/electron/renderer/src/lib/util.ts
@@ -19,7 +19,7 @@
 
 import React from 'react';
 
-import UUID from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 export const noop = () => {};
 
@@ -31,4 +31,4 @@ export const preventFocus = (fn: (event: React.MouseEvent<Element, MouseEvent>) 
   };
 };
 
-export const generateUUID = () => UUID.genV4().toString();
+export const generateUUID = () => uuidv4();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "redux": "4.2.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.4.2",
-    "uuidjs": "4.2.12"
+    "uuid": "9.0.1"
   },
   "description": "The most secure collaboration platform.",
   "devDependencies": {
@@ -64,6 +64,7 @@
     "@types/redux-logger": "^3.0.12",
     "@types/sinon": "17.0.3",
     "@types/sort-json": "2.0.3",
+    "@types/uuid": "9.0.8",
     "@typescript-eslint/eslint-plugin": "7.10.0",
     "@typescript-eslint/parser": "7.10.0",
     "@wireapp/copy-config": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,6 +4043,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:9.0.8":
+  version: 9.0.8
+  resolution: "@types/uuid@npm:9.0.8"
+  checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
+  languageName: node
+  linkType: hard
+
 "@types/verror@npm:^1.10.3":
   version: 1.10.6
   resolution: "@types/verror@npm:1.10.6"
@@ -16959,6 +16966,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.3.2":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
@@ -16974,15 +16990,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
-  languageName: node
-  linkType: hard
-
-"uuidjs@npm:4.2.12":
-  version: 4.2.12
-  resolution: "uuidjs@npm:4.2.12"
-  bin:
-    uuidjs: bin/cli.js
-  checksum: 2c837144b097ead20b27573334a00150453522e08149665844ef3e14a54290a2b46883923c5f1a380c2bd1646151c8f2ffc2363b1b603b6034155bbbee6457aa
   languageName: node
   linkType: hard
 
@@ -17386,6 +17393,7 @@ __metadata:
     "@types/redux-logger": ^3.0.12
     "@types/sinon": 17.0.3
     "@types/sort-json": 2.0.3
+    "@types/uuid": 9.0.8
     "@typescript-eslint/eslint-plugin": 7.10.0
     "@typescript-eslint/parser": 7.10.0
     "@wireapp/certificate-check": 0.7.13
@@ -17469,7 +17477,7 @@ __metadata:
     style-loader: 4.0.0
     ts-node: 10.9.2
     typescript: 5.4.5
-    uuidjs: 4.2.12
+    uuid: 9.0.1
     webpack: 5.91.0
     webpack-cli: 5.1.4
   languageName: unknown


### PR DESCRIPTION
Motivation: bump `uuidjs` from v 4.2.13 to v 5.1.0 causes problems with `jest` that are hard to resolve.
And since `uuid` has 103,276,467 weekly downloads vs `uuidjs` - 9,841, it makes sense to use `uuid`.