### PR TITLE
runfix: make avs version optional

### DIFF
--- a/electron/src/preload/menu/preload-about.ts
+++ b/electron/src/preload/menu/preload-about.ts
@@ -42,7 +42,7 @@ interface Details {
   electronVersion: string;
   productName: string;
   webappVersion: string;
-  webappAVSVersion: string;
+  webappAVSVersion?: string;
 }
 
 export function loadedAboutScreen(_event: unknown, details: Details): void {
@@ -61,9 +61,11 @@ export function loadedAboutScreen(_event: unknown, details: Details): void {
     webappVersionElement.textContent = details.webappVersion;
   }
 
-  const webappAVSVersionElement = document.getElementById('webappAVSVersion');
-  if (webappAVSVersionElement) {
-    webappAVSVersionElement.textContent = details.webappAVSVersion;
+  if (details.webappAVSVersion) {
+    const webappAVSVersionElement = document.getElementById('webappAVSVersion');
+    if (webappAVSVersionElement) {
+      webappAVSVersionElement.textContent = details.webappAVSVersion;
+    }
   }
 
   const copyrightElement = document.getElementById('copyright');

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -237,7 +237,10 @@ function reportWebappVersion(): void {
   ipcRenderer.send(EVENT_TYPE.UI.WEBAPP_VERSION, window.z.util.Environment.version(false));
 }
 function reportWebappAVSVersion(): void {
-  ipcRenderer.send(EVENT_TYPE.UI.WEBAPP_AVS_VERSION, window.z.util.Environment.avsVersion());
+  const avsVersion = window.z.util.Environment.avsVersion?.();
+  if (avsVersion) {
+    ipcRenderer.send(EVENT_TYPE.UI.WEBAPP_AVS_VERSION, avsVersion);
+  }
 }
 
 // https://github.com/electron/electron/issues/2984

--- a/electron/src/types/globals.d.ts
+++ b/electron/src/types/globals.d.ts
@@ -72,7 +72,7 @@ export declare global {
       util: {
         Environment: {
           version(showWrapperVersion: boolean): string;
-          avsVersion(): string;
+          avsVersion?: () => string;
         };
       };
     };

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -29,7 +29,7 @@ import {config} from '../settings/config';
 import * as WindowUtil from '../window/WindowUtil';
 
 let webappVersion: string;
-let webappAVSVersion: string;
+let webappAVSVersion: string | undefined;
 
 // Paths
 const APP_PATH = path.join(app.getAppPath(), config.electronDirectory);


### PR DESCRIPTION
Makes avs version optional in case the wrapper is somehow running some old version of webapp that does not share the avs version yet.