### PR TITLE
runfix: don't clear cache by default when closing the app

### DIFF
--- a/electron/src/runtime/lifecycle.ts
+++ b/electron/src/runtime/lifecycle.ts
@@ -54,7 +54,7 @@ export const checkSingleInstance = async () => {
     logger.info('Checking if we are the first instance ...', isFirstInstance);
 
     if (!EnvironmentUtil.platform.IS_WINDOWS && !isFirstInstance) {
-      await quit(false);
+      await quit();
     } else {
       app.on('second-instance', () => WindowManager.showPrimaryWindow());
     }
@@ -83,7 +83,7 @@ export const addRelaunchListeners = (listener: () => void) => {
   relaunchListeners.push(listener);
 };
 
-export const quit = async (clearCache = true): Promise<void> => {
+export const quit = async (clearCache = false): Promise<void> => {
   logger.info('Initiating app quit ...');
   settings.persistToFile();
 

--- a/electron/src/update/squirrel.ts
+++ b/electron/src/update/squirrel.ts
@@ -122,24 +122,26 @@ async function scheduleUpdate(): Promise<void> {
 
 export async function handleSquirrelArgs(): Promise<void> {
   const squirrelEvent = process.argv[1];
+  // See https://github.com/Squirrel/Squirrel.Windows/blob/develop/docs/using/custom-squirrel-events-non-cs.md
 
   switch (squirrelEvent) {
     case SQUIRREL_EVENT.INSTALL:
     case SQUIRREL_EVENT.UPDATED: {
       logger.info(`Creating shortcuts for exe ${exePath}...`);
       await createShortcuts(exePath);
-      await lifecycle.quit();
+      await lifecycle.quit(true);
       return;
     }
 
     case SQUIRREL_EVENT.UNINSTALL: {
       await removeShortcuts();
-      await lifecycle.quit();
+      await lifecycle.quit(true);
       return;
     }
 
     case SQUIRREL_EVENT.OBSOLETE: {
-      await lifecycle.quit();
+      // This is called when the app is updated but the old version is still running
+      await lifecycle.quit(true);
       return;
     }
   }


### PR DESCRIPTION
# What's new in this PR?

We don't want to clear cache every time the app is closed. Because of that we had to download all the javascript every time the app was lunched.