### PR TITLE
runfix: Disable hardware acceleration earlier in the boot process

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -171,25 +171,14 @@ app.setAppUserModelId(config.appUserModelId);
 // do not use mdns for local ip obfuscation to prevent windows firewall prompt
 app.commandLine.appendSwitch('disable-features', 'WebRtcHideLocalIpsWithMdns');
 
-app.on('gpu-info-update', () => {
-  try {
-    logger.info('GPUFeatureStatus:', app.getGPUFeatureStatus());
-    const has2dCanvas = app.getGPUFeatureStatus()?.['2d_canvas']?.startsWith('enabled');
-
-    if (!has2dCanvas) {
-      /*
-       * If the 2D canvas is unavailable, and we rely on hardware acceleration,
-       * Electron can't render anything and will only display a white screen. Thus
-       * we disable hardware acceleration completely.
-       */
-      logger.warn('2D canvas unavailable, disabling hardware acceleration');
-      app.disableHardwareAcceleration();
-    }
-  } catch (error) {
-    logger.warn(`Can't read GPUFeatureStatus, disabling hardware acceleration`);
+app.getGPUInfo('basic').then((info: any) => {
+  const gpuDevices = 'gpuDevice' in info ? info.gpuDevice : [];
+  if (gpuDevices.length > 0) {
+    logger.info('No GPU device found, disabling hardware acceleration');
     app.disableHardwareAcceleration();
   }
 });
+
 // IPC events
 const bindIpcEvents = (): void => {
   ipcMain.on(EVENT_TYPE.ACTION.SAVE_PICTURE, (_event, bytes: Uint8Array, timestamp?: string) => {


### PR DESCRIPTION
## Description 

Using the `gpu-info-update` event to detect if we should disable the hardware acceleration is not a good idea since the hardware acceleration needs to be disabled **before** the app has booted. 

With this PR, we are using another technique to know whether the system has access to a GPU or not. 
This promise is resolved before the app has fully booted and it's still time to call the `app.disableHardwareAcceleration`. 