### PR TITLE
chore: add flag indicating if popout calling is enabled

### DIFF
--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -270,7 +270,7 @@ process.once('loaded', () => {
     version: 1,
   };
   global.environment = EnvironmentUtil;
-  global.desktopAppConfig = {version: EnvironmentUtil.app.DESKTOP_VERSION};
+  global.desktopAppConfig = {version: EnvironmentUtil.app.DESKTOP_VERSION, supportsCallingPopoutWindow: true};
   global.openGraphAsync = getOpenGraphDataViaChannel;
   global.setImmediate = _setImmediate;
 });

--- a/electron/src/types/globals.d.ts
+++ b/electron/src/types/globals.d.ts
@@ -45,6 +45,7 @@ export declare global {
   var openGraphAsync: (url: string) => Promise<OpenGraphResult>;
   var desktopAppConfig: {
     version: string;
+    supportsCallingPopoutWindow?: boolean;
   };
   /* eslint-enable no-var */
 


### PR DESCRIPTION
Adds a config flag indicating whether calling popout view is supported by the desktop version,. It will be read by the webapp to decide whether to open the fullscreen view in the new window or keep it in the same window in case the new version of webapp (with calling popout view) runs in old version of the wrapper (without calling popout window support).