### PR TITLE
chore: push correct lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -93,13 +93,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.25.2":
-  version: 7.25.2
-  resolution: "@babel/compat-data@npm:7.25.2"
-  checksum: b61bc9da7cfe249f19d08da00f4f0c20550cd9ad5bffcde787c2bf61a8a6fa5b66d92bbd89031f3a6e5495a799a2a2499f2947b6cc7964be41979377473ab132
-  languageName: node
-  linkType: hard
-
 "@babel/core@npm:7.25.2":
   version: 7.25.2
   resolution: "@babel/core@npm:7.25.2"


### PR DESCRIPTION
The last couple dependabot PRs introduced a conflict in the lockfile that this would solve

Problem introduced here https://github.com/wireapp/wire-desktop/pull/8073 (running `yarn install` on that commit 4f5e02c43a8074f8b093a256287d526d0ff6d012 results on the modified `yarn.lock`)