### PR TITLE
fix: Set always on top to false for calling popup (WPB-10464)

### DIFF
--- a/electron/src/calling/PictureInPictureCall.ts
+++ b/electron/src/calling/PictureInPictureCall.ts
@@ -32,5 +32,7 @@ export const getPictureInPictureCallWindowOptions = (): Electron.BrowserWindowCo
     resizable: true,
     fullscreenable: true,
     maximizable: true,
+    alwaysOnTop: false,
+    minimizable: true,
   });
 };

--- a/electron/src/window/WindowUtil.ts
+++ b/electron/src/window/WindowUtil.ts
@@ -87,6 +87,8 @@ export const getNewWindowOptions = ({
   resizable = false,
   fullscreenable = false,
   maximizable = false,
+  alwaysOnTop = true,
+  minimizable = false,
 }: {
   title?: string;
   parent?: Electron.BrowserWindow;
@@ -95,15 +97,17 @@ export const getNewWindowOptions = ({
   resizable?: boolean;
   fullscreenable?: boolean;
   maximizable?: boolean;
+  alwaysOnTop?: boolean;
+  minimizable?: boolean;
 }): Electron.BrowserWindowConstructorOptions => ({
-  alwaysOnTop: true,
+  alwaysOnTop,
   width,
   height,
   backgroundColor: '#FFFFFF',
   fullscreen: false,
   fullscreenable,
   maximizable,
-  minimizable: false,
+  minimizable,
   modal: false,
   movable: true,
   parent,


### PR DESCRIPTION
## Description

Product team does not want the always on top feature of our calling pop out window and it was removed on web app in https://github.com/wireapp/wire-webapp/pull/17900 

On Desktop we had alwaysOnTop set to true which this PR changes to false.