### PR TITLE
runfix: provide correct node docker image for linux automation

### DIFF
--- a/jenkins/linux.Dockerfile
+++ b/jenkins/linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-bullseye
 
 ENV USE_HARD_LINKS false
 


### PR DESCRIPTION
### Description

Our building scripts are written for a Debian distribution, Alpine is a different distro that uses a different package manager, so our automation cannot run on the Alpine docker image for node.

Bullseye is the Debian release we were using previously (we actually can't move to Bookworm at the moment).

See bump to a new node version PR here https://github.com/wireapp/wire-desktop/pull/7077/