### PR TITLE
Revert "chore(deps-dev): bump eslint-plugin-no-unsanitized from 4.0.2 to 4.1.0 (#8174)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
       - dependency-name: electron-winstaller
         versions:
           - '> 4.x'
+      - dependency-name: eslint-plugin-no-unsanitized
+        versions:
+          - '> 4.0.x'
   - package-ecosystem: npm
     directory: '/app-config'
     schedule:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "eslint-plugin-jest-dom": "5.4.0",
     "eslint-plugin-jsdoc": "48.11.0",
     "eslint-plugin-jsx-a11y": "6.10.0",
-    "eslint-plugin-no-unsanitized": "4.1.0",
+    "eslint-plugin-no-unsanitized": "4.0.2",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.35.2",
     "eslint-plugin-react-hooks": "4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8987,16 +8987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-no-unsanitized@npm:4.1.0":
-  version: 4.1.0
-  resolution: "eslint-plugin-no-unsanitized@npm:4.1.0"
-  peerDependencies:
-    eslint: ^8 || ^9
-  checksum: 223ae216f3fa22612b3035e656e1861ab7ddd8bf26492ae38812306efc3991da91f4127b0884b5fa4c56ec3137d028d64e4ce8ee20ff50c055d1dc2e491fe580
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-no-unsanitized@npm:^4.0.1":
+"eslint-plugin-no-unsanitized@npm:4.0.2, eslint-plugin-no-unsanitized@npm:^4.0.1":
   version: 4.0.2
   resolution: "eslint-plugin-no-unsanitized@npm:4.0.2"
   peerDependencies:
@@ -18312,7 +18303,7 @@ __metadata:
     eslint-plugin-jest-dom: 5.4.0
     eslint-plugin-jsdoc: 48.11.0
     eslint-plugin-jsx-a11y: 6.10.0
-    eslint-plugin-no-unsanitized: 4.1.0
+    eslint-plugin-no-unsanitized: 4.0.2
     eslint-plugin-prettier: 4.2.1
     eslint-plugin-react: 7.35.2
     eslint-plugin-react-hooks: 4.6.2


### PR DESCRIPTION
This reverts commit 64ba59f2145eae0ddc0ba8d1029641b473de0370.

We're pulling the eslint config from a different repo, better revert https://github.com/wireapp/wire-desktop/pull/8174