### PR TITLE
fix: remove gconf2 and libappindicator dependencies from linux build [WPB-11392]

### DIFF
--- a/bin/build-tools/lib/build-linux.ts
+++ b/bin/build-tools/lib/build-linux.ts
@@ -77,8 +77,8 @@ export async function buildLinuxConfig(
     fpm: ['--name', linuxConfig.executableName],
   };
 
-  const rpmDepends = ['alsa-lib', 'GConf2', 'libappindicator', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'];
-  const debDepends = ['libappindicator1', 'libasound2', 'libgconf-2-4', 'libnotify-bin', 'libnss3', 'libxss1'];
+  const rpmDepends = ['alsa-lib', 'libnotify', 'libXScrnSaver', 'libXtst', 'nss'];
+  const debDepends = ['libasound2', 'libnotify-bin', 'libnss3', 'libxss1'];
 
   const builderConfig: electronBuilder.Configuration = {
     afterPack: afterPackLinux,


### PR DESCRIPTION
### Description

Gconf2 and libappindicator are currently dependencies of our Linux build.

Those 2 libraries are deprecated and no longer present in most up-to-date distributions, preventing users from installing our app.

The functionality of those libraries have long been integrated into newer versions of Electron, and are no longer required as extra dependencies