### PR TITLE
feat: Added the ablity to select target architecture for linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ export ENABLE_ASAR="false"
 yarn build:linux
 ```
 
+### Other architectures
+
+To build for another architecture such as `arm64` run the following command:
+
+```shell
+export ARCH=<target>
+yarn build:linux
+```
+
+Replace `<target>` with your desired target (e.g. `arm64`). Have a look at the [documentation for `electron-builder`](https://www.electron.build/electron-builder.enumeration.arch) for the available target architectures. Only one architecture may be specified at a time.
+
 ### Troubleshooting
 
 If you are having troubles building Wire for Desktop, then [our troubleshooting page](https://github.com/wireapp/wire-desktop/wiki/Troubleshooting) might be of help.

--- a/bin/build-tools/lib/build-linux.ts
+++ b/bin/build-tools/lib/build-linux.ts
@@ -130,7 +130,15 @@ export async function buildLinuxWrapper(
   packageJsonPath: string,
   wireJsonPath: string,
   envFilePath: string,
-  architecture: electronBuilder.Arch = electronBuilder.Arch.x64,
+  architecture: electronBuilder.Arch = (() => {
+    const archMap: { [key: string]: electronBuilder.Arch } = {
+      'arm64': electronBuilder.Arch.arm64,
+      'armv7l': electronBuilder.Arch.armv7l,
+      'ia32': electronBuilder.Arch.ia32,
+      'x64': electronBuilder.Arch.x64
+    };
+    return archMap[process.env.ARCH?.toLowerCase() || 'x64'];
+  })(),
 ): Promise<void> {
   const wireJsonResolved = path.resolve(wireJsonPath);
   const packageJsonResolved = path.resolve(packageJsonPath);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Cannot select build architecture for Linux builds.

### Causes (Optional)

Build script does not allow for setting of the build architecture, it is hard-coded to "x64"

### Solutions

Allow architecture to be specified at the command-line via a new variable `$ARCH`. Possible values for ARCH are documented here: https://www.electron.build/electron-builder.enumeration.arch
