### PR TITLE
chore: bump electron to the latest version 33.2.0 (WPB-11996) (#8352)

### DIFF
--- a/electron/src/menu/system.ts
+++ b/electron/src/menu/system.ts
@@ -34,7 +34,7 @@ import {config} from '../settings/config';
 import {settings} from '../settings/ConfigurationPersistence';
 import {SettingsType} from '../settings/SettingsType';
 import {WindowManager} from '../window/WindowManager';
-import {openExternal} from '../window/WindowUtil';
+import {openExternal, sendToWebContents} from '../window/WindowUtil';
 
 const launchCmd = process.env.APPIMAGE || process.execPath;
 
@@ -75,8 +75,8 @@ const aboutTemplate: MenuItemConstructorOptions = {
 };
 
 const signOutTemplate: MenuItemConstructorOptions = {
-  click: (_menuItem, browserWindow) =>
-    browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.ACTION.SIGN_OUT),
+  click: (_menuItem, baseWindow) =>
+    sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.ACTION.SIGN_OUT),
   label: locale.getText('menuSignOut'),
 };
 
@@ -92,55 +92,55 @@ const conversationTemplate: MenuItemConstructorOptions = {
   submenu: [
     {
       accelerator: 'CmdOrCtrl+N',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.START),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.START),
       label: locale.getText('menuStart'),
     },
     {
       accelerator: 'CmdOrCtrl+K',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SEARCH),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SEARCH),
       label: locale.getText('menuSearch'),
     },
     separatorTemplate,
     {
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.PING),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.PING),
       label: locale.getText('menuPing'),
     },
     {
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.CALL),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.CALL),
       label: locale.getText('menuCall'),
     },
     {
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.VIDEO_CALL),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.VIDEO_CALL),
       label: locale.getText('menuVideoCall'),
     },
     separatorTemplate,
     {
       accelerator: 'CmdOrCtrl+I',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.PEOPLE),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.PEOPLE),
       label: locale.getText('menuPeople'),
     },
     {
       accelerator: 'Shift+CmdOrCtrl+K',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.ADD_PEOPLE),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.ADD_PEOPLE),
       label: locale.getText('menuAddPeople'),
     },
     separatorTemplate,
     {
       accelerator: 'CmdOrCtrl+D',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.ARCHIVE),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.ARCHIVE),
       label: locale.getText('menuArchive'),
     },
     {
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.DELETE),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.DELETE),
       label: locale.getText('menuDelete'),
     },
   ],
@@ -188,34 +188,34 @@ const editTemplate: MenuItemConstructorOptions = {
   submenu: [
     {
       accelerator: 'CmdOrCtrl+Z',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.UNDO),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.UNDO),
       label: locale.getText('menuUndo'),
     },
     {
       accelerator: 'Shift+CmdOrCtrl+Z',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.REDO),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.REDO),
       label: locale.getText('menuRedo'),
     },
     separatorTemplate,
     {
       accelerator: 'CmdOrCtrl+X',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.CUT),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.CUT),
       label: locale.getText('menuCut'),
     },
     {
       accelerator: 'CmdOrCtrl+C',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.COPY),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.COPY),
       label: locale.getText('menuCopy'),
     },
     {
       accelerator: 'CmdOrCtrl+V',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.PASTE),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.PASTE),
       label: locale.getText('menuPaste'),
     },
     separatorTemplate,
     {
       accelerator: 'CmdOrCtrl+A',
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.SELECT_ALL),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.SELECT_ALL),
       label: locale.getText('menuSelectAll'),
     },
   ],
@@ -236,14 +236,14 @@ const windowTemplate: MenuItemConstructorOptions = {
     separatorTemplate,
     {
       accelerator: EnvironmentUtil.platform.IS_MAC_OS ? 'Alt+Cmd+Up' : 'Alt+Shift+Up',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SHOW_NEXT),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SHOW_NEXT),
       label: locale.getText('menuNextConversation'),
     },
     {
       accelerator: EnvironmentUtil.platform.IS_MAC_OS ? 'Alt+Cmd+Down' : 'Alt+Shift+Down',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SHOW_PREVIOUS),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.SHOW_PREVIOUS),
       label: locale.getText('menuPreviousConversation'),
     },
   ],
@@ -296,8 +296,8 @@ const darwinTemplate: MenuItemConstructorOptions = {
     separatorTemplate,
     {
       accelerator: 'Command+,',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
       label: locale.getText('menuPreferences'),
     },
     separatorTemplate,
@@ -337,8 +337,8 @@ const win32Template: MenuItemConstructorOptions = {
   submenu: [
     {
       accelerator: 'Ctrl+,',
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
       label: locale.getText('menuSettings'),
     },
     localeTemplate,
@@ -429,8 +429,8 @@ export const createMenu = (isFullScreen: boolean): Menu => {
 
     const muteShortcut: MenuItemConstructorOptions = {
       accelerator: muteAccelerator,
-      click: (_menuItem, browserWindow) =>
-        browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
+      click: (_menuItem, baseWindow) =>
+        sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.CONVERSATION.TOGGLE_MUTE),
       label: 'Toggle mute',
       visible: false,
     };
@@ -442,7 +442,7 @@ export const createMenu = (isFullScreen: boolean): Menu => {
 
         return {
           accelerator: switchAccelerator,
-          click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.ACTION.SWITCH_ACCOUNT, index),
+          click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.ACTION.SWITCH_ACCOUNT, index),
           label: `Switch to Account ${index + 1}`,
           visible: false,
         };
@@ -455,8 +455,8 @@ export const createMenu = (isFullScreen: boolean): Menu => {
     if (Array.isArray(editTemplate.submenu)) {
       editTemplate.submenu.push(separatorTemplate, {
         accelerator: 'Ctrl+,',
-        click: (_menuItem, browserWindow) =>
-          browserWindow?.webContents.send(EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
+        click: (_menuItem, baseWindow) =>
+          sendToWebContents(baseWindow, EVENT_TYPE.UI.SYSTEM_MENU, EVENT_TYPE.PREFERENCES.SHOW),
         label: locale.getText('menuPreferences'),
       });
     }

--- a/electron/src/preload/menu/preload-context.ts
+++ b/electron/src/preload/menu/preload-context.ts
@@ -30,6 +30,7 @@ import {
 import {EVENT_TYPE} from '../../lib/eventType';
 import * as locale from '../../locale';
 import {config} from '../../settings/config';
+import {sendToWebContents} from '../../window/WindowUtil';
 
 const remote = require('@electron/remote');
 
@@ -72,17 +73,17 @@ const createTextMenu = (params: ContextMenuParams, webContents: WebContents): El
 
   const template: MenuItemConstructorOptions[] = [
     {
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.CUT),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.CUT),
       enabled: editFlags.canCut,
       label: locale.getText('menuCut'),
     },
     {
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.COPY),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.COPY),
       enabled: editFlags.canCopy,
       label: locale.getText('menuCopy'),
     },
     {
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.PASTE),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.PASTE),
       enabled: editFlags.canPaste,
       label: locale.getText('menuPaste'),
     },
@@ -90,7 +91,7 @@ const createTextMenu = (params: ContextMenuParams, webContents: WebContents): El
       type: 'separator',
     },
     {
-      click: (_menuItem, browserWindow) => browserWindow?.webContents.send(EVENT_TYPE.EDIT.SELECT_ALL),
+      click: (_menuItem, baseWindow) => sendToWebContents(baseWindow, EVENT_TYPE.EDIT.SELECT_ALL),
       enabled: editFlags.canSelectAll,
       label: locale.getText('menuSelectAll'),
     },

--- a/electron/src/window/WindowUtil.ts
+++ b/electron/src/window/WindowUtil.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {BrowserWindow, screen, shell} from 'electron';
+import {BaseWindow, BrowserWindow, screen, shell} from 'electron';
 
 import * as path from 'path';
 import {URL} from 'url';
@@ -76,6 +76,18 @@ export const openExternal = async (url: string, httpsOnly: boolean = false): Pro
     await shell.openExternal(url);
   } catch (error) {
     logger.error(error);
+  }
+};
+
+export const sendToWebContents = (baseWindow: BaseWindow | undefined, channel: string, ...args: any[]) => {
+  if (baseWindow instanceof BrowserWindow) {
+    try {
+      baseWindow.webContents.send(channel, ...args);
+    } catch (error) {
+      logger.error('Failed to send event to webContents', error);
+    }
+  } else {
+    logger.error("This action's target is not an instance of BrowserWindow.");
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "cross-env": "7.0.3",
     "css-loader": "7.1.2",
     "dotenv": "16.4.5",
-    "electron": "29.4.6",
+    "electron": "33.2.0",
     "electron-builder": "24.13.3",
     "electron-mocha": "12.3.1",
     "electron-packager": "17.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7527,16 +7527,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:29.4.6":
-  version: 29.4.6
-  resolution: "electron@npm:29.4.6"
+"electron@npm:33.2.0":
+  version: 33.2.0
+  resolution: "electron@npm:33.2.0"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^20.9.0
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 14f4ae506032227083e59db3188863c71cd89c9df9490cc4bb014af55c9d93bd585093e06db4f221e897aea5b01805d4ad11e5f6ae7b41cbe493d84d55e5ffbf
+  checksum: 4feacc8923fe4ab45da45d34823f949231da425c83ea2db2e483c2531f0320a1279a5b65913f447e145ab0a3f4e190bc192ed3a63ebe17a06347156e2ec52081
   languageName: node
   linkType: hard
 
@@ -17883,7 +17883,7 @@ __metadata:
     cross-env: 7.0.3
     css-loader: 7.1.2
     dotenv: 16.4.5
-    electron: 29.4.6
+    electron: 33.2.0
     electron-builder: 24.13.3
     electron-dl: ^3.5.2
     electron-mocha: 12.3.1


### PR DESCRIPTION
* chore: bump electron to 33.2.0

* chore: create helper function to send menu events to web content

* runfix: use helper function to address electron api type change

* chore: log helper function errors

### Description
- cherry-pick of the latest electron upgrade to `main`