### PR TITLE
feat: Enhance log directory name

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -41,7 +41,7 @@ import minimist from 'minimist';
 import * as path from 'path';
 import {URL, pathToFileURL} from 'url';
 
-import {LogFactory} from '@wireapp/commons';
+import {DateUtil, LogFactory} from '@wireapp/commons';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import * as ProxyAuth from './auth/ProxyAuth';
@@ -672,6 +672,7 @@ class ElectronWrapperInit {
             const colorCodeRegex = /%c(.+?)%c/gm;
             const stylingRegex = /(color:#|font-weight:)[^;]+; /gm;
             const accessTokenRegex = /access_token=[^ &]+/gm;
+            const {date, time} = DateUtil.isoFormat(new Date());
 
             contents.on('console-message', async (_event, _level, message) => {
               const webViewId = lifecycle.getWebViewId(contents);
@@ -682,7 +683,11 @@ class ElectronWrapperInit {
               const accountIndex = contents.id - 2;
 
               if (webViewId) {
-                const logFilePath = path.join(LOG_DIR, `${accountIndex}_${webViewId}`, config.logFileName);
+                const logFilePath = path.join(
+                  LOG_DIR,
+                  `${accountIndex}_${date.replaceAll('-', '_')}_${time.replaceAll(':', '_')}_${webViewId}`,
+                  config.logFileName,
+                );
                 try {
                   await LogFactory.writeMessage(
                     message.replace(colorCodeRegex, '$1').replace(stylingRegex, '').replace(accessTokenRegex, ''),


### PR DESCRIPTION
## Description:

This change improves the naming convention for log directories by including a human-readable date and time in the folder name.

## Why it's useful:
Previously, the directories were named using non-descriptive identifiers like webViewId, which made it difficult to quickly identify when logs were created. This becomes especially problematic when users download debug logs and send a zip file containing numerous directories. The lack of context in the folder names forces extra effort to match logs to their respective events or timelines.

By including a clear timestamp, each folder now provides immediate insight into when it was created, making it easier to navigate, analyze, and debug issues effectively.

Before:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/5035c170-2517-49ac-8c73-8788ae679f9a">


After (date & time added):
<img width="478" alt="image" src="https://github.com/user-attachments/assets/250729db-66cf-40b2-ab2f-f7524d4b0862">