### PR TITLE
chore: fix the annoying dock bounce on macOS (WPB-14749)

### DIFF
--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -96,7 +96,7 @@ export class TrayHandler {
     this.trayIcon?.setToolTip(config.name);
   }
 
- private flashApplicationWindow(win: BrowserWindow, count?: number): void {
+  private flashApplicationWindow(win: BrowserWindow, count?: number): void {
     if (win.isFocused() || !count) {
       if (process.platform === 'win32') {
         win.flashFrame(false);
@@ -113,7 +113,7 @@ export class TrayHandler {
     } else if (process.platform === 'win32') {
       win.flashFrame(true);
     }
-}
+  }
 
   private updateBadgeCount(count?: number): void {
     if (typeof count !== 'undefined') {

--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -98,20 +98,18 @@ export class TrayHandler {
 
   private flashApplicationWindow(win: BrowserWindow, count?: number): void {
     if (win.isFocused() || !count) {
-      if (process.platform === 'win32') {
         win.flashFrame(false);
-      }
-      return;
-    }
+    } else if (count > this.lastUnreadCount) {
     /* After an Electron API change https://github.com/electron/electron/pull/41391
        flashFrame() leads to a constant bouncing of the dock icon on macOS.
        By calling the dock.bounce() directly, we avoid this behavior. the "informational"
        is optional (default), but makes it easier to read
     */
-    if (process.platform === 'darwin') {
-      app.dock.bounce('informational');
-    } else if (process.platform === 'win32') {
-      win.flashFrame(true);
+      if (process.platform === 'darwin') {
+        app.dock.bounce('informational');
+      } else {
+        win.flashFrame(true);
+      }
     }
   }
 

--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -98,9 +98,9 @@ export class TrayHandler {
 
   private flashApplicationWindow(win: BrowserWindow, count?: number): void {
     if (win.isFocused() || !count) {
-        win.flashFrame(false);
+      win.flashFrame(false);
     } else if (count > this.lastUnreadCount) {
-    /* After an Electron API change https://github.com/electron/electron/pull/41391
+      /* After an Electron API change https://github.com/electron/electron/pull/41391
        flashFrame() leads to a constant bouncing of the dock icon on macOS.
        By calling the dock.bounce() directly, we avoid this behavior. the "informational"
        is optional (default), but makes it easier to read

--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -96,13 +96,24 @@ export class TrayHandler {
     this.trayIcon?.setToolTip(config.name);
   }
 
-  private flashApplicationWindow(win: BrowserWindow, count?: number): void {
+ private flashApplicationWindow(win: BrowserWindow, count?: number): void {
     if (win.isFocused() || !count) {
-      win.flashFrame(false);
-    } else if (count > this.lastUnreadCount) {
+      if (process.platform === 'win32') {
+        win.flashFrame(false);
+      }
+      return;
+    }
+    /* After an Electron API change https://github.com/electron/electron/pull/41391
+       flashFrame() leads to a constant bouncing of the dock icon on macOS.
+       By calling the dock.bounce() directly, we avoid this behavior. the "informational"
+       is optional (default), but makes it easier to read
+    */
+    if (process.platform === 'darwin') {
+      app.dock.bounce('informational');
+    } else if (process.platform === 'win32') {
       win.flashFrame(true);
     }
-  }
+}
 
   private updateBadgeCount(count?: number): void {
     if (typeof count !== 'undefined') {


### PR DESCRIPTION
# What's new in this PR?

### Issues

After a recent electron update, the dock icon will bounce relentlessly until the focus is on the window again. Previously it bounced once


### Causes (Optional)

https://github.com/electron/electron/pull/41391
The change in electron was made to align behaviour across platforms. 

### Solutions

Added a platform check to preserve the current behaviour on windows, but change the behaviour on macos to bouncing once.

