### PR TITLE
fix: contentMenu issues with inputs [WPB-14927]

### DIFF
--- a/electron/src/window/WindowUtil.ts
+++ b/electron/src/window/WindowUtil.ts
@@ -79,8 +79,12 @@ export const openExternal = async (url: string, httpsOnly: boolean = false): Pro
   }
 };
 
+const isBrowserWindow = (baseWindow: unknown): baseWindow is BrowserWindow => {
+  return baseWindow instanceof Object && 'webContents' in baseWindow;
+};
+
 export const sendToWebContents = (baseWindow: BaseWindow | undefined, channel: string, ...args: any[]) => {
-  if (baseWindow instanceof BrowserWindow) {
+  if (isBrowserWindow(baseWindow)) {
     try {
       baseWindow.webContents.send(channel, ...args);
     } catch (error) {


### PR DESCRIPTION
After the electron update, the ContentMenu stopped working in many circumstances because of a failing dependency check.

This is fixed now.