### PR TITLE
chore: update electron from 33.3.1 to 34.0.0 [WPB-15057]

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "cross-env": "7.0.3",
     "css-loader": "7.1.2",
     "dotenv": "16.4.7",
-    "electron": "33.3.1",
+    "electron": "34.0.0",
     "electron-builder": "24.13.3",
     "electron-mocha": "12.3.1",
     "electron-packager": "17.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,16 +7684,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:33.3.1":
-  version: 33.3.1
-  resolution: "electron@npm:33.3.1"
+"electron@npm:34.0.0":
+  version: 34.0.0
+  resolution: "electron@npm:34.0.0"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^20.9.0
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 338b0ae0984b004ba9b387d27c39b146a04689b2afd7e19260599464c67f597a7ea87d0e46b86ffedafc5f66aa4423c0c0dddfa69873379608c447ea232a0acc
+  checksum: 0ee9a4bb3444cf13f8d0eeef928f9d8feee33d919c414672d794d6332d81fe3740c781060eba5374417742dd9f8159da2050c0fc14fac64d143be8ccb53e280c
   languageName: node
   linkType: hard
 
@@ -18638,7 +18638,7 @@ __metadata:
     cross-env: 7.0.3
     css-loader: 7.1.2
     dotenv: 16.4.7
-    electron: 33.3.1
+    electron: 34.0.0
     electron-builder: 24.13.3
     electron-dl: ^3.5.2
     electron-mocha: 12.3.1


### PR DESCRIPTION
### Description

Update Electron to the latest stable major version

See release notes [here](https://releases.electronjs.org/release/v34.0.0)