### PR TITLE
ci: adjust github token syntax in auto-merge job [WPB-15058]

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
-          GITHUB_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}
+          GH_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
#### Description

Dependabot PRs have been failing to merge
[This thread](https://github.com/github/docs/issues/21930) mentions like github's cli would be expecting `GH_TOKEN` instead of `GITHUB_TOKEN`.
Unclear why it hasn't been an issue during testing the job.

#### Screenshots
Jobs currently failing
![image](https://github.com/user-attachments/assets/3436076b-ee6e-49fb-90bd-bea2075a8db4)

Jobs succeeding while merging to a test branch
![image](https://github.com/user-attachments/assets/f5eb8f53-1eeb-4b70-8b2c-d3c8782906b2)
