### PR TITLE
fix: make popped out calling view resizable [WPB-16029]

### DIFF
--- a/electron/src/window/WindowUtil.ts
+++ b/electron/src/window/WindowUtil.ts
@@ -130,8 +130,6 @@ export const getNewWindowOptions = ({
   movable: true,
   parent,
   resizable,
-  minHeight: height,
-  minWidth: width,
   title: title,
   titleBarStyle: 'default',
   useContentSize: true,


### PR DESCRIPTION
# What's new in this PR?

### Issues

Cannot resize popped out calling view in the desktop wrapper but in web app it is possible.

### Solutions

Remove the `minHeight` and `minWidth` constraints . This change allows popped out windows to be resized to smaller sizes.

https://github.com/user-attachments/assets/bf597106-956d-4bba-9ce8-43df32ddb24a

