### PR TITLE
fix(run): Use correct installer name for hashing in Jenkins pipeline

### DIFF
--- a/jenkins/windows.groovy
+++ b/jenkins/windows.groovy
@@ -87,7 +87,7 @@ node('windows') {
       stage('Print hash') {
         try {
           if (production) {
-            bat 'certUtil -hashfile "wrap\\dist\\Wire-Setup.exe" SHA256'
+            bat 'certUtil -hashfile "wrap\\dist\\WireInternal-Setup.exe" SHA256'
           }
     } catch (e) {
           currentBuild.result = 'FAILED'


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
- Fixed incorrect filename used in Jenkins pipeline when calculating SHA256 hash with 'certUtil'
- The pipeline was filing in the "print hash" stage because of the file 'Wire-Setup.exe' was referenced instead of the actual generated file 'WireInternal-Setup.exe'
