### PR TITLE
Chore/wpb 7228 migrate away from appcenter

### DIFF
--- a/bin/build-tools/lib/build-macos.ts
+++ b/bin/build-tools/lib/build-macos.ts
@@ -94,7 +94,7 @@ export async function buildMacOSConfig(
     },
     out: commonConfig.buildDir,
     overwrite: true,
-    platform: 'mas',
+    platform: 'mas', //  Mac App Store 
     protocols: [{name: `${commonConfig.name} Core Protocol`, schemes: [commonConfig.customProtocolName]}],
     prune: true,
     quiet: false,

--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -6,13 +6,13 @@ jobs = jenkins.getAllItems()
 jobs.each { job ->
   name = job.fullName
   if (name.contains('Windows Internal') || name.contains('Wrapper_Linux') || name.contains('Wrapper_macOS')) {
-  builds = job.builds
-  for (i = 0; i <5; i++) {
-    lastbuild = job.builds[i]
-    if (lastbuild) {
-    list << name + '#' + lastbuild.displayName
+    builds = job.builds
+    for (i = 0; i <5; i++) {
+      lastbuild = job.builds[i]
+      if (lastbuild) {
+        list << name + '#' + lastbuild.displayName
+      }
     }
-  }
   }
 }
 return list
@@ -35,24 +35,25 @@ node('built-in') {
 
   def projectName = env.WRAPPER_BUILD.tokenize('#')[0]
   def version = env.WRAPPER_BUILD.tokenize('#')[1]
-  echo('version: ' + version)
+  echo("version: ${version}")
   def buildNumber = version.tokenize('.')[2]
   def NODE = tool name: 'node-v20.10.0', type: 'nodejs'
   env.DRY_RUN = params.DRY_RUN ? "--dry-run" : ""
 
   stage('Get build artifacts') {
     try {
-      step ([
+      step([
         $class: 'CopyArtifact',
-        filter: 'wrap/build/**,wrap/dist/**',
+        filter: 'wrap/build/**,wrap/dist/**,**/*.pkg',
         projectName: "$projectName",
         selector: [
           $class: 'SpecificBuildSelector',
           buildNumber: "$version"
         ]
-      ]);
+      ])
     } catch (e) {
-      wireSend secret: "$jenkinsbot_secret", message: "**Could not get build artifacts from of ${version} from ${projectName}** see: ${JOB_URL}"
+      wireSend secret: "$jenkinsbot_secret",
+               message: "**Could not get build artifacts from ${version} of ${projectName}** see: ${JOB_URL}"
       throw e
     }
   }
@@ -68,7 +69,8 @@ node('built-in') {
         sh 'yarn'
       }
     } catch (e) {
-      wireSend secret: "$jenkinsbot_secret", message: "**Could not get build artifacts of ${version} from ${projectName}** see: ${JOB_URL}"
+      wireSend secret: "$jenkinsbot_secret",
+               message: "**Could not get build artifacts of ${version} from ${projectName}** see: ${JOB_URL}"
       throw e
     }
   }
@@ -78,131 +80,245 @@ node('built-in') {
       env.SEARCH_PATH = './wrap/dist/'
 
       if (projectName.contains('Windows')) {
+        // -----------------------------
+        // 1) Windows S3 Upload
+        // -----------------------------
         env.S3_PATH = ''
         def AWS_ACCESS_KEY_CREDENTIALS_ID = ''
         def AWS_SECRET_CREDENTIALS_ID = ''
 
-          if (params.Release.equals('Production')) {
-            env.S3_PATH = 'win/prod'
-            AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
-            AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
-          } else if (params.Release.equals('Internal')) {
-            env.S3_PATH = 'win/internal'
-            AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
-            AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
-          } else if (params.Release.equals('Custom')) {
-            env.S3_BUCKET = params.WIN_S3_BUCKET
-            env.S3_PATH = params.WIN_S3_PATH
-            AWS_ACCESS_KEY_CREDENTIALS_ID = params.AWS_CUSTOM_ACCESS_KEY_ID
-            AWS_SECRET_CREDENTIALS_ID = params.AWS_CUSTOM_SECRET_ACCESS_KEY
-          }
+        if (params.Release.equals('Production')) {
+          env.S3_PATH = 'win/prod'
+          AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
+        } else if (params.Release.equals('Internal')) {
+          env.S3_PATH = 'win/internal'
+          AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
+        } else if (params.Release.equals('Custom')) {
+          env.S3_BUCKET = params.WIN_S3_BUCKET
+          env.S3_PATH = params.WIN_S3_PATH
+          AWS_ACCESS_KEY_CREDENTIALS_ID = params.AWS_CUSTOM_ACCESS_KEY_ID
+          AWS_SECRET_CREDENTIALS_ID = params.AWS_CUSTOM_SECRET_ACCESS_KEY
+        }
 
         try {
           withCredentials([
             string(credentialsId: AWS_ACCESS_KEY_CREDENTIALS_ID, variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: AWS_SECRET_CREDENTIALS_ID, variable: 'AWS_SECRET_ACCESS_KEY')
           ]) {
-            sh 'jenkins/ts-node.sh ./bin/deploy-tools/s3-cli.ts --bucket \"$S3_BUCKET\" --s3path \"$S3_PATH\" --key-id \"$AWS_ACCESS_KEY_ID\" --secret-key \"$AWS_SECRET_ACCESS_KEY\" --wrapper-build \"$WRAPPER_BUILD\" --path \"$SEARCH_PATH\" $DRY_RUN'
+            sh '''
+              jenkins/ts-node.sh ./bin/deploy-tools/s3-cli.ts \
+                --bucket "$S3_BUCKET" \
+                --s3path "$S3_PATH" \
+                --key-id "$AWS_ACCESS_KEY_ID" \
+                --secret-key "$AWS_SECRET_ACCESS_KEY" \
+                --wrapper-build "$WRAPPER_BUILD" \
+                --path "$SEARCH_PATH" \
+                $DRY_RUN
+            '''
           }
         } catch(e) {
           currentBuild.result = 'FAILED'
-          wireSend secret: "$jenkinsbot_secret", message: "**Deploying to S3 failed for ${version}** see: ${JOB_URL}"
+          wireSend secret: "$jenkinsbot_secret",
+                   message: "**Deploying to S3 failed for ${version}** see: ${JOB_URL}"
           throw e
         }
 
-        if (params.Release.equals('Internal')) {
-          def appName = 'Wire-Windows-Internal'
-          def distributionGroups = 'All-users-of-Wire-Windows-Internal, Collaborators'
-          try {
-            withCredentials([string(credentialsId: 'APPCENTER_TOKEN_WINDOWS', variable: 'APP_CENTER_TOKEN')]) {
-              zip dir: 'wrap/dist/', glob: '**/*.exe', zipFile: 'WireInternal-Setup.zip'
-              files = findFiles(glob: '*.zip')
-              echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
-              // Windows uploads require build version to be set
-              withEnv(["PATH+NODE=${NODE}/bin"]) {
-                sh 'npm install -g appcenter-cli'
-                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
-              }
-              wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
-            }
-          } catch(e) {
-            currentBuild.result = 'FAILED'
-            wireSend secret: "$jenkinsbot_secret", message: "**Deploying to appcenter.ms failed for ${version}** see: ${JOB_URL}"
-            throw e
-          }
-        }
       } else if (projectName.contains('macOS')) {
+        // -----------------------------
+        // 2) macOS S3 Upload
+        // -----------------------------
+        def AWS_ACCESS_KEY_CREDENTIALS_ID = ''
+        def AWS_SECRET_CREDENTIALS_ID = ''
+
+        // Decide the s3path based on release
+        if (params.Release.equals('Production')) {
+          env.S3_PATH = 'mac/prod'
+          env.S3_BUCKET = 'wire-taco'
+          AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
+        } else if (params.Release.equals('Internal')) {
+          env.S3_PATH = 'mac/internal'
+          env.S3_BUCKET = 'wire-taco'
+          AWS_ACCESS_KEY_CREDENTIALS_ID = 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_CREDENTIALS_ID = 'AWS_SECRET_ACCESS_KEY'
+        } else if (params.Release.equals('Custom')) {
+          env.S3_BUCKET = params.MAC_S3_BUCKET
+          env.S3_PATH = params.MAC_S3_PATH
+          AWS_ACCESS_KEY_CREDENTIALS_ID = params.AWS_CUSTOM_ACCESS_KEY_ID
+          AWS_SECRET_CREDENTIALS_ID = params.AWS_CUSTOM_SECRET_ACCESS_KEY
+        }
+
         try {
-          def appName
-          def distributionGroups
+          withCredentials([
+            string(credentialsId: AWS_ACCESS_KEY_CREDENTIALS_ID, variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: AWS_SECRET_CREDENTIALS_ID, variable: 'AWS_SECRET_ACCESS_KEY')
+          ]) {
+            // Use Jenkins AWS plugin to authenticate
+            withAWS(region: 'eu-west-1', credentials: 'wire-taco') {
+              echo('Uploading macOS .pkg file manually to S3')
 
-          if (params.Release.equals('Production')) {
-            appName = 'Wire-macOS-Production'
-            echo('Production build creates a Wire.pkg but we need a zip on appcenter.ms to upload')
-          } else if (params.Release.equals('Custom')) {
-            error('Please set appName and distributionGroups for custom build uploads to appcenter.ms')
-          } else if (params.Release.equals('Internal')) {
-            appName = 'Wire-macOS-Internal'
-            distributionGroups = 'All-users-of-Wire-macOS-Internal, Collaborators'
-          }
-
-          if (!params.Release.equals('Production')) {
-            withCredentials([string(credentialsId: 'APPCENTER_TOKEN_MACOS', variable: 'APP_CENTER_TOKEN')]) {
-              files = findFiles(glob: 'wrap/dist/*.pkg')
-              echo("Upload " + files[0].path + " as " + appName + " to appcenter.ms...")
-              // pkg uploads require build version and build number to be set
-              withEnv(["PATH+NODE=${NODE}/bin"]) {
-                sh 'npm install -g appcenter-cli'
-                sh 'appcenter distribute release --token=$APP_CENTER_TOKEN -a "Wire/' + appName + '" -f ' + files[0].path + ' -b ' + version + ' -n ' + buildNumber + ' -r "Uploaded by Jenkins deploy job" -g "' + distributionGroups + '"'
+              def macosFiles = findFiles(glob: 'wrap/dist/*.pkg')
+              if (macosFiles.length == 0) {
+                error("No .pkg file found in wrap/dist")
               }
-              wireSend secret: "$jenkinsbot_secret", message: "**Uploaded ${files[0].path} as ${appName} ${version} to appcenter.ms**"
+
+              // Always pick the first .pkg we found
+              def pkgFilePath = macosFiles[0].path
+              def pkgFileName = macosFiles[0].name
+              def s3DestinationPath = "${env.S3_PATH}/${pkgFileName}"
+
+              echo "Uploading ${pkgFilePath} to s3://${env.S3_BUCKET}/${s3DestinationPath}"
+
+              // Upload file
+              s3Upload(
+                acl: 'Private',
+                bucket: env.S3_BUCKET,
+                file: pkgFilePath,
+                path: s3DestinationPath
+              )
             }
           }
         } catch(e) {
           currentBuild.result = 'FAILED'
-          wireSend secret: "$jenkinsbot_secret", message: "**Deploying to appcenter.ms failed for ${version}** see: ${JOB_URL}"
+          wireSend secret: "$jenkinsbot_secret",
+                   message: "**Deploying macOS to S3 failed for ${version}** see: ${JOB_URL}"
           throw e
         }
+
       } else if (projectName.contains('Linux')) {
+        // -----------------------------
+        // 3) Linux S3 Upload
+        // -----------------------------
         try {
           if (params.Release.equals('Production')) {
             S3_NAME = 'linux'
 
             withAWS(region:'eu-west-1', credentials: 'wire-taco') {
               echo('Upload repository files')
-              s3Upload acl: 'PublicRead', bucket: S3_BUCKET, workingDir: 'wrap/dist/', includePathPattern: 'debian/**', path: S3_NAME + '/'
+              s3Upload acl: 'PublicRead',
+                       bucket: S3_BUCKET,
+                       workingDir: 'wrap/dist/',
+                       includePathPattern: 'debian/**',
+                       path: S3_NAME + '/'
 
               echo('Upload files for download page')
               files = findFiles(glob: 'wrap/dist/*.deb,wrap/dist/*.AppImage')
               files.each {
-                s3Upload acl: 'PublicRead', bucket: S3_BUCKET, file: it.path, path: S3_NAME + '/' + it.name
+                s3Upload acl: 'PublicRead',
+                         bucket: S3_BUCKET,
+                         file: it.path,
+                         path: S3_NAME + '/' + it.name
               }
             }
           } else if (params.Release.equals('Custom')) {
-            error('Please set S3_NAME')
+            error('Please set S3_NAME for custom Linux')
           } else if (params.Release.equals('Internal')) {
             S3_NAME = 'linux-internal'
 
             withAWS(region:'eu-west-1', credentials: 'wire-taco') {
               echo('Upload repository files')
-              s3Upload acl: 'PublicRead', bucket: S3_BUCKET, workingDir: 'wrap/dist/', includePathPattern: 'debian/**', path: S3_NAME + '/'
+              s3Upload acl: 'PublicRead',
+                       bucket: S3_BUCKET,
+                       workingDir: 'wrap/dist/',
+                       includePathPattern: 'debian/**',
+                       path: S3_NAME + '/'
 
               echo('Upload files for download page')
               files = findFiles(glob: 'wrap/dist/*.deb,wrap/dist/*.AppImage')
               files.each {
-                s3Upload acl: 'PublicRead', bucket: S3_BUCKET, file: it.path, path: S3_NAME + '/' + it.name
+                s3Upload acl: 'PublicRead',
+                         bucket: S3_BUCKET,
+                         file: it.path,
+                         path: S3_NAME + '/' + it.name
               }
             }
           }
         } catch(e) {
           currentBuild.result = 'FAILED'
-          wireSend secret: "$jenkinsbot_secret", message: "**Deploying to S3 failed for ${version}** see: ${JOB_URL}"
+          wireSend secret: "$jenkinsbot_secret",
+                   message: "**Deploying to S3 failed for ${version}** see: ${JOB_URL}"
           throw e
         }
       }
     }
   }
 
+  // ------------------------------------------------------------------------
+  // STAGE: Generate & Store Presigned URLs
+  // (Separate handling for custom vs. internal/production)
+  // ------------------------------------------------------------------------
+  stage('Generate & Store Presigned URLs') {
+    script {
+      def artifacts = findFiles(glob: 'wrap/dist/*.*')
+      if (!artifacts || artifacts.size() == 0) {
+        error "No artifacts found in wrap/dist/*.*"
+      }
+
+      def presignedFile
+
+      // Make sure we use Jenkins AWS plugin + local "aws" command
+      withAWS(region: 'eu-west-1', credentials: 'wire-taco') {
+        if (params.Release.equals('Custom')) {
+          // Custom (on-prem)
+          presignedFile = 'custom-presigned-urls.txt'
+          sh "rm -f ${presignedFile}"
+
+          artifacts.each { fileObj ->
+            def presignedUrl = sh(
+              script: """
+                aws s3 presign s3://${env.S3_BUCKET}/${env.S3_PATH}/${fileObj.name} --expires-in 604800
+              """,
+              returnStdout: true
+            ).trim()
+            sh "echo '${fileObj.name}: ${presignedUrl}' >> ${presignedFile}"
+          }
+
+          // Upload to private on-prem or specialized bucket, no Jenkins archiving
+          s3Upload(
+            acl: 'Private',
+            bucket: S3_BUCKET,
+            file: presignedFile,
+            path: "${env.S3_PATH}/${presignedFile}"
+          )
+
+          // We do NOT want this file in Jenkins artifacts -> removing local file
+          sh "rm -f ${presignedFile}"
+
+        } else {
+          // Internal or Production
+          def fileSuffix = params.Release.equals('Production') ? 'prod' : 'internal'
+          presignedFile = "${fileSuffix}-presigned-urls.txt"
+          sh "rm -f ${presignedFile}"
+
+          artifacts.each { fileObj ->
+            def presignedUrl = sh(
+              script: """
+                aws s3 presign s3://${env.S3_BUCKET}/${env.S3_PATH}/${fileObj.name} --expires-in 604800
+              """,
+              returnStdout: true
+            ).trim()
+            sh "echo '${fileObj.name}: ${presignedUrl}' >> ${presignedFile}"
+          }
+
+          s3Upload(
+            acl: 'Private',
+            bucket: S3_BUCKET,
+            file: presignedFile,
+            path: "${env.S3_PATH}/${presignedFile}"
+          )
+
+          // Archive in Jenkins so teammates can see the URLs
+          archiveArtifacts artifacts: presignedFile, fingerprint: true
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------------
+  // Windows-specific stage: Update RELEASES file for Squirrel auto-updates
+  // ------------------------------------------------------------------------
   if (projectName.contains('Windows')) {
     stage('Update RELEASES file') {
       try {
@@ -236,24 +352,40 @@ node('built-in') {
           ]) {
             withAWS(region:'eu-west-1', credentials: 'wire-taco') {
               echo('Delete old RELEASE file and setup executable')
-              s3Delete bucket: S3_BUCKET, path: S3_PATH + '/RELEASES'
               files = findFiles(glob: 'wrap/dist/*Setup.exe')
+
+              // Remove old RELEASES
+              s3Delete bucket: S3_BUCKET, path: S3_PATH + '/RELEASES'
+              // Remove old Setup
               s3Delete bucket: S3_BUCKET, path: S3_PATH + '/' + files[0].name
 
               echo('Copy new RELEASE file and setup executable to default position')
-              s3Copy acl: 'PublicRead', fromBucket: S3_BUCKET, fromPath: S3_PATH + '/' + S3_NAME + '-RELEASES',toBucket: S3_BUCKET, toPath: S3_PATH + '/RELEASES'
-              s3Copy acl: 'PublicRead', fromBucket: S3_BUCKET, fromPath: S3_PATH + '/' + S3_NAME + '.exe',toBucket: S3_BUCKET, toPath: S3_PATH + '/' + files[0].name
+              s3Copy acl: 'PublicRead',
+                     fromBucket: S3_BUCKET,
+                     fromPath: S3_PATH + '/' + S3_NAME + '-RELEASES',
+                     toBucket: S3_BUCKET,
+                     toPath: S3_PATH + '/RELEASES'
+
+              s3Copy acl: 'PublicRead',
+                     fromBucket: S3_BUCKET,
+                     fromPath: S3_PATH + '/' + S3_NAME + '.exe',
+                     toBucket: S3_BUCKET,
+                     toPath: S3_PATH + '/' + files[0].name
             }
           }
         }
       } catch(e) {
         currentBuild.result = 'FAILED'
-        wireSend secret: "$jenkinsbot_secret", message: "**Changing RELEASES file failed for ${version}** see: ${JOB_URL}"
+        wireSend secret: "$jenkinsbot_secret",
+                 message: "**Changing RELEASES file failed for ${version}** see: ${JOB_URL}"
         throw e
       }
     }
   }
 
+  // ------------------------------------------------------------------------
+  // If Release == Production, do a draft GitHub release
+  // ------------------------------------------------------------------------
   if (params.Release.equals('Production')) {
     stage('Upload build as draft to GitHub') {
       try {
@@ -261,12 +393,19 @@ node('built-in') {
           env.SEARCH_PATH = './wrap/dist/'
 
           withCredentials([string(credentialsId: 'GITHUB_ACCESS_TOKEN', variable: 'GITHUB_ACCESS_TOKEN')]) {
-            sh 'jenkins/ts-node.sh ./bin/deploy-tools/github-draft-cli.ts --github-token \"$GITHUB_ACCESS_TOKEN\" --wrapper-build \"$WRAPPER_BUILD\" --path \"$SEARCH_PATH\" $DRY_RUN'
+            sh '''
+              jenkins/ts-node.sh ./bin/deploy-tools/github-draft-cli.ts \
+                --github-token "$GITHUB_ACCESS_TOKEN" \
+                --wrapper-build "$WRAPPER_BUILD" \
+                --path "$SEARCH_PATH" \
+                $DRY_RUN
+            '''
           }
         }
       } catch(e) {
         currentBuild.result = 'FAILED'
-        wireSend secret: "$jenkinsbot_secret", message: "**Upload build as draft to GitHub failed for ${version}** see: ${JOB_URL}"
+        wireSend secret: "$jenkinsbot_secret",
+                 message: "**Upload build as draft to GitHub failed for ${version}** see: ${JOB_URL}"
         throw e
       }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ x] contains a reference JIRA issue number like `SQPIT-764`
  - [ x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR removes upload of build artifacts to AppCenter. Artifacts are now uploaded to S3 wire-taco bucket and are also available in Jenkins build. For each artifact AWS pre-signed URL is created and stored in .txt file which is also uploaded to S3 bucket and available in Jenkins.
