### PR TITLE
ci: perform electron dependency updates on main, staging and dev [WPB-15058]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,36 @@ updates:
       - dependency-name: eslint-plugin-no-unsanitized
         versions:
           - '> 4.0.x'
+  # perform electron updates on main
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '05:00'
+      timezone: 'Europe/Berlin'
+    open-pull-requests-limit: 99
+    versioning-strategy: increase
+    target-branch: main
+    allow:
+      - dependency-name: electron
+    ignore:
+      - dependency-name: electron
+        update-types: ['version-update:semver-major']
+  # perform electron updates on staging
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '05:00'
+      timezone: 'Europe/Berlin'
+    open-pull-requests-limit: 99
+    versioning-strategy: increase
+    target-branch: staging
+    allow:
+      - dependency-name: electron
+    ignore:
+      - dependency-name: electron
+        update-types: ['version-update:semver-major']
   - package-ecosystem: npm
     directory: '/app-config'
     schedule:


### PR DESCRIPTION
### Description
allow Dependabot to perform dependencies updates for Electron on main and staging as well as dev

this is an alternative to cherry-picking Electron bumps to all 3 branch (backpedaling from the reverted commit from [this PR](https://github.com/wireapp/wire-desktop/pull/8533/files#diff-61c0d56ab06ca0109392dffccd6cf28b542b40fe66cdc5db85f8b6da53e9395d))