### PR TITLE
ci: bump max upload size to 300MB [WPB-16532]

### DIFF
--- a/bin/deploy-tools/lib/GitHubDraftDeployer.ts
+++ b/bin/deploy-tools/lib/GitHubDraftDeployer.ts
@@ -20,7 +20,7 @@ import axios, {AxiosError, AxiosRequestConfig} from 'axios';
 import fs from 'fs-extra';
 import logdown from 'logdown';
 
-import {logDry, TWO_HUNDRED_MB_IN_BYTES} from './deploy-utils';
+import {logDry, THREE_HUNDRED_MB_IN_BYTES} from './deploy-utils';
 
 /** @see https://developer.github.com/v3/repos/releases/#create-a-release */
 export interface GitHubAPIDraftData {
@@ -159,15 +159,15 @@ export class GitHubDraftDeployer {
     const url = `${uploadUrl}?name=${fileName}`;
 
     if (this.options.dryRun) {
-      logDry('uploadAsset', {file, headers, maxContentLength: TWO_HUNDRED_MB_IN_BYTES, url});
+      logDry('uploadAsset', {file, headers, maxContentLength: THREE_HUNDRED_MB_IN_BYTES, url});
       return;
     }
 
     try {
       const requestConfig: AxiosRequestConfig = {
         headers,
-        maxBodyLength: TWO_HUNDRED_MB_IN_BYTES,
-        maxContentLength: TWO_HUNDRED_MB_IN_BYTES,
+        maxBodyLength: THREE_HUNDRED_MB_IN_BYTES,
+        maxContentLength: THREE_HUNDRED_MB_IN_BYTES,
       };
       await axios.post(url, file, requestConfig);
     } catch (uploadError: any) {

--- a/bin/deploy-tools/lib/HockeyDeployer.ts
+++ b/bin/deploy-tools/lib/HockeyDeployer.ts
@@ -22,7 +22,7 @@ import fs from 'fs-extra';
 import logdown from 'logdown';
 import path from 'path';
 
-import {logDry, TWO_HUNDRED_MB_IN_BYTES} from './deploy-utils';
+import {logDry, THREE_HUNDRED_MB_IN_BYTES} from './deploy-utils';
 
 const HOCKEY_API_URL = 'https://rink.hockeyapp.net/api/2/apps';
 
@@ -162,7 +162,7 @@ export class HockeyDeployer {
     }
 
     try {
-      await axios.put<void>(hockeyUrl, formData, {headers, maxContentLength: TWO_HUNDRED_MB_IN_BYTES});
+      await axios.put<void>(hockeyUrl, formData, {headers, maxContentLength: THREE_HUNDRED_MB_IN_BYTES});
     } catch (error) {
       this.logger.error(error);
       const {status, statusText} = (error as AxiosError).response || {};

--- a/bin/deploy-tools/lib/deploy-utils.ts
+++ b/bin/deploy-tools/lib/deploy-utils.ts
@@ -43,7 +43,7 @@ export enum FileExtension {
   SIG = '.sig',
 }
 
-export const TWO_HUNDRED_MB_IN_BYTES = 209715200;
+export const THREE_HUNDRED_MB_IN_BYTES = 314572800;
 
 export async function find(fileGlob: string, options: {cwd?: string; safeGuard: false}): Promise<FindResult | null>;
 export async function find(fileGlob: string, options: {cwd?: string; safeGuard?: boolean}): Promise<FindResult>;


### PR DESCRIPTION
### Description

We limit the upload size of binaries to 200MB

The MacOS binary exceeds that limit with the latest release, the `.pkg` is 207MB

This bump the maximum allowed upload size to 300MB