### PR TITLE
fix(macOS): fix entitlements to remove server

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "wire-web-config-internal": "https://github.com/wireapp/wire-web-config-default#v0.34.1",
-    "wire-web-config-production": "https://github.com/wireapp/wire-web-config-wire#v0.34.1"
+    "wire-web-config-internal": "https://github.com/wireapp/wire-web-config-default#v0.34.3-0",
+    "wire-web-config-production": "https://github.com/wireapp/wire-web-config-wire#v0.34.3-0"
   }
 }

--- a/resources/macos/entitlements/parent.plist
+++ b/resources/macos/entitlements/parent.plist
@@ -4,8 +4,6 @@
   <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.device.camera</key>


### PR DESCRIPTION
The server entitlement seems to be unnecessary and Apple flagged it. To unblock a new release we remove it in this PR.