### PR TITLE
feat: update Electron to 38.2.0 for Chromium 140 (SAP SSO compatibility) [WPB-20719]

### DIFF
--- a/electron/src/menu/TrayHandler.ts
+++ b/electron/src/menu/TrayHandler.ts
@@ -106,7 +106,7 @@ export class TrayHandler {
        is optional (default), but makes it easier to read
     */
       if (process.platform === 'darwin') {
-        app.dock.bounce('informational');
+        app.dock?.bounce('informational');
       } else {
         win.flashFrame(true);
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cross-env": "7.0.3",
     "css-loader": "7.1.2",
     "dotenv": "16.6.0",
-    "electron": "35.0.2",
+    "electron": "38.2.0",
     "electron-builder": "24.13.3",
     "electron-mocha": "12.3.1",
     "electron-packager": "17.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7071,16 +7071,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:35.0.2":
-  version: 35.0.2
-  resolution: "electron@npm:35.0.2"
+"electron@npm:38.2.0":
+  version: 38.2.0
+  resolution: "electron@npm:38.2.0"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^22.7.7
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: e0bd4e5299f09a860815b72ca7e4087147c762a79e3fed8f431e40f6369d244b65f554d6882f9ef379891929368a7010a062a3ca54676ab1cedb023caec9e102
+  checksum: 115a6e2b73a404b090c808ef67832111ddd305338aafbe6b22f8e0c58be079255b438c7ab8d9e579db5418edcba7990336ae51b6896e50b999cdbc3fa3ca573d
   languageName: node
   linkType: hard
 
@@ -16346,7 +16346,7 @@ __metadata:
     cross-env: 7.0.3
     css-loader: 7.1.2
     dotenv: 16.6.0
-    electron: 35.0.2
+    electron: 38.2.0
     electron-builder: 24.13.3
     electron-dl: ^3.5.2
     electron-mocha: 12.3.1


### PR DESCRIPTION
- Update Electron from 35.0.2 to 38.2.0
- Chromium version now 140.0.7339.133 (was 134.0.6998.88)
- Fixes SAP SSO authentication issue requiring Chromium 139+
- Add optional chaining for app.dock to fix TypeScript strictness

