### PR TITLE
ci(macOS): add automated App Store Connect upload for production builds [WPB-22009]

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -405,7 +405,26 @@ node('built-in') {
           string(credentialsId: 'MACOS_NOTARIZATION_ASC_PROVIDER', variable: 'MACOS_NOTARIZATION_ASC_PROVIDER'),
         ]) {
           if (params.DRY_RUN) {
+            // DRY RUN: log useful info
+            def size = sh(script: "stat -f%z '${pkgPath}'", returnStdout: true).trim()
+            def sha  = sh(script: "shasum -a 256 '${pkgPath}' | awk '{print \$1}'", returnStdout: true).trim()
+
             echo "DRY RUN enabled – skipping upload to App Store Connect"
+            echo "Would have uploaded pkg: ${pkgPath}"
+            echo "Package size: ${size} bytes"
+            echo "Package SHA-256: ${sha}"
+
+            echo """
+            DRY RUN – would run:
+            xcrun altool \\
+              --upload-package "${pkgPath}" \\
+              --type macos \\
+              --username "\$MACOS_NOTARIZATION_APPLE_ID" \\
+              --password ***hidden*** \\
+              --asc-provider "\$MACOS_NOTARIZATION_ASC_PROVIDER"
+            """
+
+            echo "DRY RUN — simulated result: SUCCESS (upload skipped)"
           } else {
             // Run altool
             def status = sh(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22009" title="WPB-22009" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22009</a>  [Desktop] Add automatic mac OS prod app upload to App Connect
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
To avoid manual upload of Mac OS build through Transporter app, this PR automates the upload through Jenkins job.