### PR TITLE
ci: update dependabot action so its only making PRs for dev branch [WPB-22086]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 version: 2
 updates:
+  # NPM – root (all deps except the ones explicitly ignored)
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: daily
       time: '05:00'
       timezone: 'Europe/Berlin'
+    target-branch: dev
     open-pull-requests-limit: 99
     versioning-strategy: increase
     ignore:
@@ -41,53 +43,29 @@ updates:
       - dependency-name: eslint-plugin-no-unsanitized
         versions:
           - '> 4.0.x'
-  # perform electron updates on main
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-      time: '05:00'
-      timezone: 'Europe/Berlin'
-    open-pull-requests-limit: 99
-    versioning-strategy: increase
-    target-branch: main
-    allow:
-      - dependency-name: electron
-    ignore:
-      - dependency-name: electron
-        update-types: ['version-update:semver-major']
-  # perform electron updates on staging
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-      time: '05:00'
-      timezone: 'Europe/Berlin'
-    open-pull-requests-limit: 99
-    versioning-strategy: increase
-    target-branch: staging
-    allow:
-      - dependency-name: electron
-    ignore:
-      - dependency-name: electron
-        update-types: ['version-update:semver-major']
+
+  # NPM – app-config
   - package-ecosystem: npm
     directory: '/app-config'
     schedule:
       interval: weekly
       day: sunday
+    target-branch: dev
     open-pull-requests-limit: 99
     versioning-strategy: increase
 
-  # Github actions
-  - package-ecosystem: 'github-actions'
+  # GitHub Actions
+  - package-ecosystem: github-actions
     directory: '/'
+    target-branch: dev
     open-pull-requests-limit: 99
     schedule:
-      interval: 'daily'
+      interval: daily
+
   # Docker
-  - package-ecosystem: 'docker'
+  - package-ecosystem: docker
     directory: '/'
+    target-branch: dev
     open-pull-requests-limit: 99
     schedule:
-      interval: 'daily'
+      interval: daily


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22086" title="WPB-22086" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22086</a>  [Desktop] Update dependabot so its only making PRs for dev branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Dependabot was previously configured to open PRs against dev, staging, and main branches.
This caused problems during our release flow (preparing RC)

All automated updates (npm, GitHub Actions, Docker, app-config) now target only the dev branch.