### PR TITLE
feat: Desktop app respect operating system's language setting by default(WPB-21019)

### DIFF
--- a/electron/src/locale/index.ts
+++ b/electron/src/locale/index.ts
@@ -146,17 +146,23 @@ export const SUPPORTED_LANGUAGES = {
 let current: SupportedI18nLanguage | undefined;
 
 export const getCurrent = (): SupportedI18nLanguage => {
-  const savedLocale = settings.restore<SupportedI18nLanguage | undefined>(SettingsType.LOCALE);
-  const savedOverride = settings.restore<boolean | undefined>(SettingsType.LOCALE_OVERRIDE);
-
-  // If the override flag is missing, assume the user wanted an override only when the saved value differs
-  // from the current system locale. This keeps existing manual choices intact while allowing auto language
-  // to track OS changes.
   const systemLocale = getSystemLocale();
-  const hasUserOverride =
-    typeof savedOverride === 'boolean' ? savedOverride : Boolean(savedLocale && savedLocale !== systemLocale);
 
-  current = savedLocale && hasUserOverride ? parseLocale(savedLocale) : systemLocale;
+  if (!current) {
+    const savedLocale = settings.restore<SupportedI18nLanguage | undefined>(SettingsType.LOCALE);
+    const savedOverride = settings.restore<boolean | undefined>(SettingsType.LOCALE_OVERRIDE);
+    const hasUserOverride =
+      typeof savedOverride === 'boolean' ? savedOverride : Boolean(savedLocale && savedLocale !== systemLocale);
+
+    current = savedLocale && hasUserOverride ? parseLocale(savedLocale) : systemLocale;
+    return current;
+  }
+
+  // If there’s no override and the system locale changed, update the cache
+  const hasOverride = settings.restore<boolean | undefined>(SettingsType.LOCALE_OVERRIDE) === true;
+  if (!hasOverride && current !== systemLocale) {
+    current = systemLocale;
+  }
   return current;
 };
 
@@ -188,7 +194,7 @@ export const getText = (
 
 export const setLocale = (locale: string): void => {
   current = parseLocale(locale);
-  settings.save(SettingsType.LOCALE, current);
+
   const systemLocale = getSystemLocale();
   const isOverride = current !== systemLocale;
 

--- a/electron/src/locale/index.ts
+++ b/electron/src/locale/index.ts
@@ -55,6 +55,13 @@ export type SupportedI18nLanguageObject = Record<SupportedI18nLanguage, i18nStri
 
 const app = Electron.app || require('@electron/remote').app;
 
+const parseLocale = (locale: string): SupportedI18nLanguage => {
+  const languageKeys = Object.keys(SUPPORTED_LANGUAGES) as SupportedI18nLanguage[];
+  return languageKeys.find(languageKey => languageKey === locale) || languageKeys[0];
+};
+
+const getSystemLocale = (): SupportedI18nLanguage => parseLocale(app.getLocale().substring(0, 2));
+
 export const LANGUAGES: SupportedI18nLanguageObject = {
   cs,
   da,
@@ -139,17 +146,18 @@ export const SUPPORTED_LANGUAGES = {
 let current: SupportedI18nLanguage | undefined;
 
 export const getCurrent = (): SupportedI18nLanguage => {
-  if (!current) {
-    // We care only about the language part and not the country (en_US, de_DE)
-    const defaultLocale = parseLocale(app.getLocale().substring(0, 2));
-    current = settings.restore(SettingsType.LOCALE, defaultLocale);
-  }
-  return current;
-};
+  const savedLocale = settings.restore<SupportedI18nLanguage | undefined>(SettingsType.LOCALE);
+  const savedOverride = settings.restore<boolean | undefined>(SettingsType.LOCALE_OVERRIDE);
 
-const parseLocale = (locale: string): SupportedI18nLanguage => {
-  const languageKeys = Object.keys(SUPPORTED_LANGUAGES) as SupportedI18nLanguage[];
-  return languageKeys.find(languageKey => languageKey === locale) || languageKeys[0];
+  // If the override flag is missing, assume the user wanted an override only when the saved value differs
+  // from the current system locale. This keeps existing manual choices intact while allowing auto language
+  // to track OS changes.
+  const systemLocale = getSystemLocale();
+  const hasUserOverride =
+    typeof savedOverride === 'boolean' ? savedOverride : Boolean(savedLocale && savedLocale !== systemLocale);
+
+  current = savedLocale && hasUserOverride ? parseLocale(savedLocale) : systemLocale;
+  return current;
 };
 
 const customReplacements: Record<string, string> = {
@@ -181,4 +189,14 @@ export const getText = (
 export const setLocale = (locale: string): void => {
   current = parseLocale(locale);
   settings.save(SettingsType.LOCALE, current);
+  const systemLocale = getSystemLocale();
+  const isOverride = current !== systemLocale;
+
+  if (isOverride) {
+    settings.save(SettingsType.LOCALE_OVERRIDE, true);
+    settings.save(SettingsType.LOCALE, current);
+  } else {
+    settings.delete(SettingsType.LOCALE_OVERRIDE);
+    settings.delete(SettingsType.LOCALE);
+  }
 };

--- a/electron/src/settings/SettingsType.ts
+++ b/electron/src/settings/SettingsType.ts
@@ -46,6 +46,8 @@ export enum SettingsType {
   FULL_SCREEN = 'fullscreen',
   /** Which language (ISO 639-1) should be used to load our web app (de, en, fr, etc.)? */
   LOCALE = 'locale',
+  /** Whether the locale has been explicitly set by the user instead of using the system default. */
+  LOCALE_OVERRIDE = 'localeOverride',
   /** Defines the proxy server url (e.g. http://127.0.0.1:3128)
    *
    * https://github.com/wireapp/wire-desktop/wiki/Start-Parameters#use-authenticated-proxy-server


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21019" title="WPB-21019" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21019</a>  [Web] Make Desktop app respect operating system's language setting by default
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- If I start the Desktop app for the first time or any other subsequent time, I want the language to be set to the operating system’s set language

- In case the language of the operating system gets updated, this should also be reflected in the Desktop app’s language setting

- A user can still manually change the language of the desktop app

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-desktop/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-desktop/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
