### PR TITLE
Chore: Add Mac build and deployment params for notarization and App Store upload [WPB-22088]

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -442,7 +442,7 @@ node('built-in') {
   // ------------------------------------------------------------------------
   // If this is macOS Production: upload .pkg to App Store Connect
   // ------------------------------------------------------------------------
-  if (projectName.contains('macOS') && params.Release == 'Production') {
+  if (projectName.contains('macOS') && params.Release == 'Production' && params.UPLOAD_TO_APP_STORE == true) {
     stage('Upload macOS pkg to App Store Connect') {
       try {
         // Find the .pkg that was copied from the build job

--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -6,6 +6,7 @@ def parseJson(def text) {
 node('built-in') {
   def production = params.PRODUCTION
   def custom = params.CUSTOM
+  def skipNotarization = params.containsKey('SKIP_NOTARIZATION') ? params.SKIP_NOTARIZATION : true  
   def NODE = tool name: 'node-v18.18.0', type: 'nodejs'
   def privateAPIResult = ''
 
@@ -69,7 +70,7 @@ node('built-in') {
   // ------------------------------------------------------------------------
   // Notarize & staple macOS pkg (internal only)
   // ------------------------------------------------------------------------
-  if (!production && !custom) {
+  if (!production && !custom && !skipNotarization) {
     stage('Notarize macOS pkg') {
       // Only run if a .pkg exists (macOS builds)
       def pkgExists = (sh(script: 'ls wrap/dist/*.pkg >/dev/null 2>&1', returnStatus: true) == 0)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22088" title="WPB-22088" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22088</a>  [Desktop] Notarize Internal Mac app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

- Added params for enabling/disabling Mac build notarization and automatic upload to App Store during build and deployment pipelines

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ x ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-desktop/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-desktop/tree/docs/tech-radar.md).

---
 