### PR TITLE
chore: Update deployment script to install AWS CLI if not present [WPB-22420]

### DIFF
--- a/jenkins/deployment.groovy
+++ b/jenkins/deployment.groovy
@@ -314,7 +314,19 @@ node('built-in') {
 
       def presignedFile
 
-      // Make sure we use Jenkins AWS plugin + local "aws" command
+      sh '''
+        if ! command -v aws >/dev/null 2>&1; then
+          echo "Installing AWS CLI locally..."
+          mkdir -p $HOME/bin
+          rm -rf aws awscliv2.zip
+          curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+          unzip -oq awscliv2.zip
+          ./aws/install --bin-dir $HOME/bin --install-dir $HOME/aws-cli --update
+          export PATH=$HOME/bin:$PATH
+        fi
+        aws --version
+      '''
+
       withAWS(region: 'eu-west-1', credentials: 'wire-taco') {
         if (params.Release == 'Custom') {
           // Custom (on-prem)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- What did I change and why?
The script adds a conditional installation of AWS CLI v2 in the user’s home directory ($HOME/bin) instead of assuming it’s already available on the system.
- Risks and how to roll out / roll back (e.g. feature flags):

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-desktop/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-desktop/tree/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
