### PR TITLE
Setup e2e tests [WPB-25890]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,7 @@
     }
   ],
   "parserOptions": {
-    "project": ["./tsconfig.json", "./tsconfig.mocha.json", "./tsconfig.bin.json"]
+    "project": ["./tsconfig.json", "./tsconfig.mocha.json", "./tsconfig.bin.json", "./tsconfig.playwright.json"]
   },
   "plugins": ["jasmine"],
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ resources
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 *.log
 *.pkg
+.env
 coverage
 .nyc_output
 /config
@@ -35,6 +36,7 @@ resources
 !.yarn/versions
 
 # Playwright
+!e2e-tests/.env.tpl
 /test-results/
 /playwright-report/
 /blob-report/

--- a/e2e-tests/.env.tpl
+++ b/e2e-tests/.env.tpl
@@ -1,0 +1,2 @@
+WEBAPP_URL=op://Test Automation/BackendConnection staging/webappUrl
+BACKEND_URL=op://Test Automation/BackendConnection staging/backendUrl

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,21 @@
+# Wire Desktop E2E Tests
+
+This readme serves as documentation for the E2E tests which are part of this repository. All necessary setup instructions as well as architecture decisions will be documented in here.
+
+## Getting started
+
+Make sure you already followed the instructions of the [README.md](../README.md) in the root of this repository e.g. for installing dependencies.
+
+### Setting up environment variables
+
+The E2E tests depend on configs / secrets which need to be provided as environment variables in order to run them. These secrets are stored within 1Password. To create a `.env` file containing the actual values follow these steps:
+
+1. Make sure you have the [1Password CLI](https://www.1password.dev/cli/get-started) installed and set up with the 1PW desktop app
+2. Run `op inject -i e2e-tests/.env.tpl -o e2e-tests/.env` to create the .env file within the `e2e-tests` folder
+3. Re-run the command in case the `.env.tpl` file was updated or the secrets changed
+
+### Running the E2E tests
+
+Before attempting to execute the E2E tests make sure to run the script `yarn run prestart` once. It will generate the outputs needed for launching the application within the tests.
+
+To then execute the e2e tests run `yarn run test:e2e` which will execute all of them. To only run specific tests you can pass the file containing them e.g. `yarn run test:e2e e2e-tests/specs/example.spec.ts`.

--- a/e2e-tests/example.spec.ts
+++ b/e2e-tests/example.spec.ts
@@ -1,0 +1,22 @@
+import {test, expect, _electron as electron} from '@playwright/test';
+
+test('starts the app', async () => {
+  const app = await electron.launch({
+    args: ['.', '--env=https://wire-webapp-dev.zinfra.io'],
+    locale: 'en', // ToDo: The locale isn't respected by the mounted webview
+  });
+
+  // Wait for main window to be opened and the embedded webview to be loaded
+  const window = await app.firstWindow();
+  await window.waitForLoadState('networkidle');
+
+  /**
+   * The webview element isn't treated as a regular webcomponent / iframe by electron but as individual window.
+   * So in order to access the contents of the application we need to use the second window.
+   */
+  const webview = app.windows()[1];
+
+  await expect(webview.getByText('Wire')).toBeVisible();
+
+  await app.close();
+});

--- a/e2e-tests/example.spec.ts
+++ b/e2e-tests/example.spec.ts
@@ -20,5 +20,5 @@
 import {test, expect} from './fixtures';
 
 test('starts the app', async ({page}) => {
-  await expect(page.getByText('Wire')).toBeVisible();
+  await expect(page.getByText('Welcome to Wire!')).toBeVisible();
 });

--- a/e2e-tests/example.spec.ts
+++ b/e2e-tests/example.spec.ts
@@ -1,3 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 import {test, expect, _electron as electron} from '@playwright/test';
 
 test('starts the app', async () => {

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -17,8 +17,27 @@
  *
  */
 
-import {test, expect} from './fixtures';
+import {test as baseTest} from '@playwright/test';
 
-test('starts the app', async ({page}) => {
-  await expect(page.getByText('Wire')).toBeVisible();
+import {createApp, type App} from './utils/createApp';
+
+type FixtureOptions = {appOptions: {env: string}};
+
+type Fixtures = {app: App};
+
+export const test = baseTest.extend<FixtureOptions & Fixtures>({
+  appOptions: {env: 'https://wire-webapp-dev.zinfra.io'},
+
+  app: async ({appOptions}, use) => {
+    const app = await createApp(appOptions);
+    await use(app);
+    await app.close();
+  },
+
+  // Overwrite of the default page fixture to reference the apps page instead
+  page: async ({app}, use) => {
+    await use(app.page);
+  },
 });
+
+export * from '@playwright/test';

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -19,9 +19,13 @@
 
 import {test as baseTest} from '@playwright/test';
 
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 import {createApp, type App} from './utils/createApp';
 
-type FixtureOptions = {appOptions: {env: string}};
+type FixtureOptions = {appOptions: {env: string; lang?: string}};
 
 type Fixtures = {app: App};
 
@@ -29,9 +33,14 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
   appOptions: {env: 'https://wire-webapp-dev.zinfra.io'},
 
   app: async ({appOptions}, use) => {
-    const app = await createApp(appOptions);
+    // Always use a fresh temporary directory for the user data to ensure test isolation
+    const tempUserDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wire-desktop-e2e-tests-'));
+    const app = await createApp({...appOptions, dataDir: tempUserDataDir});
+
     await use(app);
+
     await app.close();
+    await fs.rm(tempUserDataDir, {recursive: true});
   },
 
   // Overwrite of the default page fixture to reference the apps page instead

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -25,12 +25,12 @@ import path from 'node:path';
 
 import {createApp, type App} from './utils/createApp';
 
-type FixtureOptions = {appOptions: {env: string; lang?: string}};
+type FixtureOptions = {appOptions: {env?: string; lang?: string}};
 
 type Fixtures = {app: App};
 
 export const test = baseTest.extend<FixtureOptions & Fixtures>({
-  appOptions: {env: 'https://wire-webapp-dev.zinfra.io'},
+  appOptions: {env: process.env.WEBAPP_URL, lang: 'en'},
 
   app: async ({appOptions}, use) => {
     // Always use a fresh temporary directory for the user data to ensure test isolation

--- a/e2e-tests/specs/example.spec.ts
+++ b/e2e-tests/specs/example.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {test, expect} from './fixtures';
+import {test, expect} from '../fixtures';
 
 test('starts the app', async ({page}) => {
   await expect(page.getByText('Welcome to Wire!')).toBeVisible();

--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -19,6 +19,10 @@
 
 import {_electron as electron, ElectronApplication, Page} from '@playwright/test';
 
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 export type App = ElectronApplication & {
   /* The playwright page for the main electron window wrapping the webapp */
   wrapper: Page;
@@ -27,8 +31,17 @@ export type App = ElectronApplication & {
 };
 
 export const createApp = async (options: {env: string}): Promise<App> => {
+  const tempUserDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wire-desktop-e2e-test-'));
+
   const app = await electron.launch({
-    args: ['.', `--env=${options.env}`, '--lang=en'],
+    args: [
+      '.',
+      `--env=${options.env}`,
+      // All tests should launch the app in english by default no matter the local systems language
+      '--lang=en',
+      // Always use a new temp dir to store the application data so no state is shared between tests
+      `--user-data-dir=${tempUserDataDir}`,
+    ],
   });
 
   /**

--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {_electron as electron, ElectronApplication, Page} from '@playwright/test';
+
+export type App = ElectronApplication & {
+  /* The playwright page for the main electron window wrapping the webapp */
+  wrapper: Page;
+  /* The playwright page for the currently shown webapp */
+  page: Page;
+};
+
+export const createApp = async (options: {env: string}): Promise<App> => {
+  const app = await electron.launch({
+    args: ['.', `--env=${options.env}`],
+    locale: 'en', // ToDo: The locale isn't respected by the mounted webview
+  });
+
+  /**
+   * The webview element isn't treated as a regular webcomponent / iframe by electron but as individual window.
+   * So in order to access the contents of the application we need to use the second window.
+   */
+  const wrapper = await app.waitForEvent('window');
+  const page = await app.waitForEvent('window');
+
+  return Object.assign(app, {wrapper, page});
+};

--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -26,7 +26,11 @@ export type App = ElectronApplication & {
   page: Page;
 };
 
-export const createApp = async (options: {env: string; lang?: string; dataDir: string}): Promise<App> => {
+export const createApp = async (options: {env?: string; lang?: string; dataDir: string}): Promise<App> => {
+  if (!options.env) {
+    throw new Error(`Can't create app without environment, make sure the env var "WEBAPP_URL" is set`);
+  }
+
   const app = await electron.launch({
     args: ['.', `--env=${options.env}`, `--lang=${options.lang ?? 'en'}`, `--user-data-dir=${options.dataDir}`],
   });

--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -19,10 +19,6 @@
 
 import {_electron as electron, ElectronApplication, Page} from '@playwright/test';
 
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
 export type App = ElectronApplication & {
   /* The playwright page for the main electron window wrapping the webapp */
   wrapper: Page;
@@ -30,18 +26,9 @@ export type App = ElectronApplication & {
   page: Page;
 };
 
-export const createApp = async (options: {env: string}): Promise<App> => {
-  const tempUserDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wire-desktop-e2e-test-'));
-
+export const createApp = async (options: {env: string; lang?: string; dataDir: string}): Promise<App> => {
   const app = await electron.launch({
-    args: [
-      '.',
-      `--env=${options.env}`,
-      // All tests should launch the app in english by default no matter the local systems language
-      '--lang=en',
-      // Always use a new temp dir to store the application data so no state is shared between tests
-      `--user-data-dir=${tempUserDataDir}`,
-    ],
+    args: ['.', `--env=${options.env}`, `--lang=${options.lang ?? 'en'}`, `--user-data-dir=${options.dataDir}`],
   });
 
   /**

--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -28,8 +28,7 @@ export type App = ElectronApplication & {
 
 export const createApp = async (options: {env: string}): Promise<App> => {
   const app = await electron.launch({
-    args: ['.', `--env=${options.env}`],
-    locale: 'en', // ToDo: The locale isn't respected by the mounted webview
+    args: ['.', `--env=${options.env}`, '--lang=en'],
   });
 
   /**

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@
 const jestConfig = {
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['<rootDir>/electron/dist'],
+  testPathIgnorePatterns: ['<rootDir>/electron/dist', '<rootDir>/e2e-tests'],
 };
 
 module.exports = jestConfig;

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "start:fed": "yarn start --env=https://webapp.${FED}.wire.link/ ",
     "test": "yarn test:types && yarn prestart && yarn build:ts:tests && yarn test:react && yarn test:main && yarn test:renderer && yarn test:bin",
     "test:bin": "mocha --require .babel-register.js \"bin/**/*.test?(.main).ts\"",
+    "test:e2e": "playwright test",
     "test:main": "electron-mocha --require .babel-register.js \"electron/src/**/*.test?(.main).ts\" --no-sandbox",
     "test:renderer": "electron-mocha --renderer --require .babel-register.js \"electron/src/**/*.test?(.renderer).ts\" --no-sandbox --window-config electron/test/mocha-window-config.json",
     "test:types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/register": "7.28.6",
     "@electron/fuses": "1.8.0",
     "@electron/osx-sign": "1.3.3",
+    "@playwright/test": "1.60.0",
     "@types/adm-zip": "0.5.8",
     "@types/amplify": "1.1.28",
     "@types/auto-launch": "5.0.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests */
+  /* Opt out of parallel tests because there can only be one running instance of the app at a time */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ import dotenv from 'dotenv';
 
 import path from 'node:path';
 
-dotenv.config({path: path.resolve(__dirname, '.env')});
+dotenv.config({path: path.resolve(__dirname, './e2e-tests/.env')});
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import {defineConfig, devices} from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+import dotenv from 'dotenv';
+import path from 'node:path';
+dotenv.config({path: path.resolve(__dirname, '.env')});
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e-tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests */
+  workers: 1,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,27 @@
-import {defineConfig, devices} from '@playwright/test';
-
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
  */
+
+import {defineConfig, devices} from '@playwright/test';
 import dotenv from 'dotenv';
+
 import path from 'node:path';
+
 dotenv.config({path: path.resolve(__dirname, '.env')});
 
 /**

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext"]
+  },
+  "include": ["e2e-tests/**/*.ts", "playwright.config.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
+  dependencies:
+    playwright: 1.60.0
+  bin:
+    playwright: cli.js
+  checksum: 29176a1fcf016a06299353f01de7f35817d78731294bfca62bfa44f18e2ad3a9b5f8a8480cf55046b597ee28c5c5340a4dd03a268f8fb853522ddd96a437204a
+  languageName: node
+  linkType: hard
+
 "@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/aspromise@npm:1.1.2"
@@ -11421,7 +11432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+"fsevents@npm:2.3.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -11431,7 +11442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
@@ -16546,6 +16557,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 8afc6ce9b3fc2f17ebbc671555b1d982a6e1b554c9215ba92d843e9ced8ebdd66c25996debcf1773c15b449c5fa8a42e6bc8ec0b1d96c5b5b759214c3a54c80f
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.60.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 07b893cfe34fed7039910f6bb9ecabac29888578b42ea54026815c3642989efdf9b9480184ce097c6f49cade3e8addcb026afcaf58800b639dc572ed3487ee42
+  languageName: node
+  linkType: hard
+
 "please-upgrade-node@npm:^3.2.0":
   version: 3.2.0
   resolution: "please-upgrade-node@npm:3.2.0"
@@ -20757,6 +20792,7 @@ __metadata:
     "@electron/osx-sign": 1.3.3
     "@electron/remote": 2.1.3
     "@hapi/joi": 17.1.1
+    "@playwright/test": 1.60.0
     "@types/adm-zip": 0.5.8
     "@types/amplify": 1.1.28
     "@types/auto-launch": 5.0.5


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25890" title="WPB-25890" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-25890</a>  [Desktop/QA] Start Desktop app via Playwright and try interacting with it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

# Pull Request

## Summary

Add basic setup for e2e tests for the desktop app, including:
- Launching the app
- `.env` setup + docs
- Ensuring the app uses a specified language instead of the system locale
- Isolating the data stored by the app per test to avoid cross test state pollution

This is the first PR for the new goal of fully automated e2e tests for desktop.

Duplicate for: https://github.com/wireapp/wire-desktop/pull/9643

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-desktop/tree/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-desktop/tree/docs/tech-radar.md).

---

## Notes for reviewers

- 