### PR TITLE
Set up CI for E2E tests [WPB-26069]

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,6 +41,12 @@ jobs:
         # We use xvfb to simulate a virtual display in order for electron to work in CI
         run: xvfb-run yarn test:e2e
 
+      - name: Upload test report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: playwright-report
+          path: playwright-report/html
+
       - name: Generate report description
         id: generate-description
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install JS dependencies
         run: yarn --immutable
 
+      - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
+      - name: Generate env file
+        run: op inject -i e2e-tests/.env.tpl -o e2e-tests/.env
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
       - name: Build application
         run: yarn prestart
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,31 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Execute workflow every night throughout the week
+    - cron: '37 04 * * 1-5'
+
+jobs:
+  run_tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+
+      - name: Install JS dependencies
+        run: yarn --immutable
+
+      - name: Build application
+        run: yarn prestart
+
+      - name: Run E2E tests
+        run: yarn test:e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn --immutable
 
+      - name: Install Playwright browsers
+        run: yarn playwright install --only-shell --with-deps chromium
+
       - uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4
       - name: Generate env file
         run: op inject -i e2e-tests/.env.tpl -o e2e-tests/.env

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,5 +37,78 @@ jobs:
         run: yarn prestart
 
       - name: Run E2E tests
+        continue-on-error: true
         # We use xvfb to simulate a virtual display in order for electron to work in CI
         run: xvfb-run yarn test:e2e
+
+      - name: Generate report description
+        id: generate-description
+        run: |
+          REPORT_FILE="playwright-report/report.json"
+          if [ ! -f "$REPORT_FILE" ]; then
+              echo "Error: File '$REPORT_FILE' not found!"
+              exit 1
+          fi
+
+          FAILED=$(jq '.stats.unexpected' "$REPORT_FILE")
+          MESSAGE=$(jq -c '
+            # Recursively find all objects that have a non-empty "specs" array
+            # Capture the suite title and prepend it to the test title
+            [.. | objects | select(has("specs") and (.specs | length > 0)) | .title as $suite | .specs[] | .title as $title | .tests[] | {title: ($suite + " > " + $title), status: .status}] as $tests |
+            
+            # Calculate aggregates
+            ($tests | length) as $total |
+            ($tests | map(select(.status == "expected")) | length) as $passed |
+            ($tests | map(select(.status == "unexpected")) | length) as $failed |
+            ($tests | map(select(.status == "flaky")) | length) as $flaky |
+            ($tests | map(select(.status == "skipped")) | length) as $skipped |
+            
+            # Generate unique lists for failed and flaky tests
+            ($tests | map(select(.status == "unexpected")) | map("  ❌ " + .title) | unique | join("\n")) as $failed_list |
+            ($tests | map(select(.status == "flaky")) | map("  ⚠️ " + .title) | unique | join("\n")) as $flaky_list |
+            
+            # Construct the final formatted message
+            "📋 **Desktop E2E Test Run Summary**\n" +
+            "Build URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n" +
+            "======================================\n" +
+            "**Total Tests:** \($total)\n" +
+            "✅ **Passed:** \($passed)\n" +
+            "❌ **Failed:** \($failed)\n" +
+            "⚠️ **Flaky:** \($flaky)\n" +
+            (if $skipped > 0 then "⏭️ **Skipped:** \($skipped)\n" else "" end) +
+            "======================================\n" +
+            (if $failed > 0 then "\n❌ **Failed Tests:**\n\($failed_list)\n" else "" end) +
+            (if $flaky > 0 then "\n⚠️ **Flaky Tests:**\n\($flaky_list)\n" else "" end)
+          ' $REPORT_FILE)
+
+          echo "failed_tests=$FAILED" >> $GITHUB_OUTPUT
+          echo "report_message=$MESSAGE" >> $GITHUB_OUTPUT
+
+      - name: Upload report to Testiny
+        continue-on-error: true
+        env:
+          TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
+          TESTINY_TEST_PLAN_ID: 117 # 117 is the id of the "Regression" test plan within Testiny
+          DESCRIPTION: ${{ steps.generate-description.outputs.report_message }}
+        run: |
+          # Extract description from json format so it can be quoted correctly
+          RAW_DESCRIPTION=$(echo "$DESCRIPTION" | jq -r '.')
+
+          node ./e2e-tests/scripts/uploadTestReport.ts \
+          --runName="Regression $(date +'%m/%d/%Y - %H:%M')" \
+          --testPlanId="$TESTINY_TEST_PLAN_ID" \
+          --description="$RAW_DESCRIPTION" \
+          --reportPath="./playwright-report/report.json"
+
+      - name: Notify on Wire about failed tests
+        if: ${{ !cancelled() && steps.generate-description.outputs.failed_tests > 0 }}
+        uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WIRE_E2E_TEST_BOT_WEBHOOK_URL }}
+        with:
+          status: custom
+          custom_payload: |
+            {
+              "text": ${{ steps.generate-description.outputs.report_message }},
+            }

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,4 +37,5 @@ jobs:
         run: yarn prestart
 
       - name: Run E2E tests
-        run: yarn test:e2e
+        # We use xvfb to simulate a virtual display in order for electron to work in CI
+        run: xvfb-run yarn test:e2e

--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -42,6 +42,12 @@ export const createApp = async (options: {env?: string; lang?: string; dataDir: 
     console.log(...args);
   });
 
+  // Mock safeStorage API of electron as it doesn't work for the headless linux used in CI
+  app.evaluate(({safeStorage}) => {
+    safeStorage.encryptString = (plainText: string) => Buffer.from(plainText, 'utf-8');
+    safeStorage.decryptString = (encrypted: Buffer) => Buffer.from(encrypted).toString('utf-8');
+  });
+
   /**
    * The webview element isn't treated as a regular webcomponent / iframe by electron but as individual window.
    * So in order to access the contents of the application we need to use the second window.

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -63,12 +63,22 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
     await use(new BrigApiClient({baseUrl: process.env.BACKEND_URL, basicAuth: process.env.BACKEND_BASIC_AUTH}));
   },
 
-  app: async ({appOptions}, use) => {
+  app: async ({appOptions}, use, testInfo) => {
     // Always use a fresh temporary directory for the user data to ensure test isolation
     const tempUserDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wire-desktop-e2e-tests-'));
     const app = await createApp({...appOptions, dataDir: tempUserDataDir});
 
+    // Traces for the electron app need to be collected manually as it uses a non default context
+    await app.page.context().tracing.start({screenshots: true, snapshots: true});
+
     await use(app);
+
+    // Add the trace of the first run as attachment if it failed
+    if (testInfo.status === 'failed' && testInfo.retry === 0) {
+      const tracePath = testInfo.outputPath('app-trace.zip');
+      await app.page.context().tracing.stop({path: tracePath});
+      await testInfo.attach('app-trace.zip', {path: tracePath});
+    }
 
     await app.close();
     await fs.rm(tempUserDataDir, {recursive: true});

--- a/e2e-tests/scripts/uploadTestReport.ts
+++ b/e2e-tests/scripts/uploadTestReport.ts
@@ -1,0 +1,205 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+/* eslint-disable no-console --- This script is expected to log to the console */
+
+import type {JSONReport, JSONReportSpec, JSONReportSuite, JSONReportTest} from '@playwright/test/reporter';
+
+import * as fs from 'node:fs';
+import path from 'node:path';
+import {parseArgs} from 'node:util';
+
+const TESTINY_PROJECT_ID = 9; // 9 is the id of the "Wire Desktop" project in Testiny
+
+const {values: args} = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    testinyApiKey: {
+      type: 'string',
+      description: 'API key to connect to testiny',
+      default: process.env.TESTINY_API_KEY,
+    },
+    reportPath: {
+      type: 'string',
+      description: 'Path to the playright report in json format',
+    },
+    runName: {
+      type: 'string',
+      description: 'Name of the test run',
+    },
+    testPlanId: {
+      type: 'string',
+      description: 'ID of the test plan this run should be associated with',
+    },
+    description: {
+      type: 'string',
+      description: 'Description to add to the run, supports markdown',
+    },
+  },
+});
+
+const getTests = (suite: JSONReportSuite): (JSONReportTest & Pick<JSONReportSpec, 'tags'>)[] => {
+  return [
+    ...(suite.specs.flatMap(spec => spec.tests.map(test => ({...test, tags: spec.tags}))) ?? []),
+    ...(suite.suites?.flatMap(suite => getTests(suite)) ?? []),
+  ];
+};
+
+type TestRun = {id: number};
+async function createTestRun(options?: {testPlanId?: number; description?: string}): Promise<TestRun> {
+  const body = {
+    title: args.runName,
+    project_id: TESTINY_PROJECT_ID,
+    testplan_id: options?.testPlanId,
+    description: options?.description,
+  };
+  console.log(`Creating test run with title: ${body.title}`, body);
+
+  const res = await fetch('https://app.testiny.io/api/v1/testrun', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to create test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+
+  return await res.json();
+}
+
+async function closeTestRun(testRun: TestRun) {
+  const res = await fetch(`https://app.testiny.io/api/v1/testrun/${testRun.id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({...testRun, is_closed: true}),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to close test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+}
+
+async function deleteTestRun(runId: number) {
+  const res = await fetch(`https://app.testiny.io/api/v1/testrun/${runId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Couldn't delete test run ${runId}`);
+  }
+}
+
+type TestinyTestCaseMapping = {
+  ids: {testcase_id: number; testrun_id: number};
+  mapped: {assigned_to: 'ANY'; result_status: 'NOTRUN' | 'PASSED' | 'FAILED' | 'BLOCKED' | 'SKIPPED'};
+};
+
+function transformReportToTestinyMappings(report: JSONReport, runId: number) {
+  // Mapping from playwrights status to the result expected by Testiny
+  const resultMap: Record<JSONReportTest['status'], TestinyTestCaseMapping['mapped']['result_status']> = {
+    expected: 'PASSED',
+    unexpected: 'FAILED',
+    flaky: 'PASSED',
+    skipped: 'SKIPPED',
+  };
+
+  return report.suites
+    .flatMap(suite => getTests(suite))
+    .reduce<TestinyTestCaseMapping[]>((acc, test) => {
+      const testIds = test.tags
+        .filter(tag => tag.startsWith('TC-'))
+        .map(tag => Number(tag.replace('TC-', '')))
+        .filter(Number.isInteger);
+
+      for (const testId of testIds) {
+        acc.push({
+          ids: {testrun_id: runId, testcase_id: testId},
+          mapped: {assigned_to: 'ANY', result_status: resultMap[test.status]},
+        });
+      }
+
+      return acc;
+    }, []);
+}
+
+async function addTestResultsToRun(testCaseMappings: TestinyTestCaseMapping[]) {
+  const res = await fetch('https://app.testiny.io/api/v1/testrun/mapping/bulk/testcase:testrun?op=add', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.testinyApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(testCaseMappings),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to add test results to test run ${JSON.stringify(await res.json(), undefined, 2)}`);
+  }
+}
+
+async function main() {
+  if (args.testinyApiKey === undefined) {
+    throw new Error('Missing required arg testinyApiKey');
+  }
+  if (args.reportPath === undefined) {
+    throw new Error('Missing required arg reportPath');
+  }
+  if (args.runName === undefined) {
+    throw new Error('Missing required arg runName');
+  }
+
+  const reportAbsPath = path.resolve(args.reportPath);
+  if (!fs.existsSync(reportAbsPath)) {
+    throw new Error(`Report file not found: ${reportAbsPath}`);
+  }
+
+  const report: JSONReport = JSON.parse(fs.readFileSync(reportAbsPath, 'utf-8'));
+  const testRun = await createTestRun({
+    testPlanId: args.testPlanId !== undefined && Number.isInteger(+args.testPlanId) ? +args.testPlanId : undefined,
+    description: `<!--markdown-->\n${args.description}\n`,
+  });
+  console.log(`Created test run with id: ${testRun.id}`);
+
+  try {
+    const testResults = transformReportToTestinyMappings(report, testRun.id);
+
+    await addTestResultsToRun(testResults);
+    console.log(`Added ${testResults.length} test results to test run`);
+
+    await closeTestRun(testRun);
+    console.log('Successfully imported test results');
+  } catch (e) {
+    console.error('Failed to add test results to run, deleting test run');
+    // In case adding the results failed delete the whole test run
+    await deleteTestRun(testRun.id);
+    throw e;
+  }
+}
+main();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,8 +43,8 @@ export default defineConfig({
   expect: {timeout: 10_000},
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    // Behavior for tracing the web browser, for traces of the electron app see its fixture in `e2e-tests/fixtures.ts`
+    trace: 'retain-on-first-failure',
     testIdAttribute: 'data-uie-name',
     baseURL: process.env.WEBAPP_URL,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,8 +37,14 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests because there can only be one running instance of the app at a time */
   workers: 1,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  // Only generate reports on CI
+  reporter: process.env.CI
+    ? [
+        ['html', {outputFolder: 'playwright-report/html', open: 'never'}],
+        ['json', {outputFile: 'playwright-report/report.json'}],
+        ['line'],
+      ]
+    : 'line',
   timeout: 90_000,
   expect: {timeout: 10_000},
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26069" title="WPB-26069" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26069</a>  [Desktop/QA] Set up nightly CI for E2E tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Set up to run the e2e tests every night and report results / failures to testiny and into the E2E tests group chat.

**Notes for reviewers**
- The file `uploadTestReport.ts` was copied over from web to re-use the same logic for uploading the test results like manual imports.
- The workflow was tested as part of this PR to ensure all secrets and configs work as expected.