### PR TITLE
Prepare GitHub Actions for merge queues [WPB-22420]

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,16 +5,18 @@ on:
     branches: [main, staging, dev]
   pull_request:
     branches: [main, staging, dev]
+  merge_group:
+    branches: [main, staging, dev]
+
+concurrency:
+  group: build-test-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_test:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.1
-        with:
-          access_token: ${{github.token}}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,11 @@ name: Lint
 
 on:
   push:
-    branches: [main, dev, staging]
+    branches: [main, staging, dev]
   pull_request:
-    branches: [main, dev, staging]
+    branches: [main, staging, dev]
+  merge_group:
+    branches: [main, staging, dev]
 
 concurrency:
   group: lint-${{ github.ref }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add `merge_group` triggers to the required GitHub Actions workflows so `wire-desktop` can be used with GitHub merge queues.

GitHub merge queues validate queued pull requests through the `merge_group` event. This event is separate from `pull_request` and `push`, so required status checks must explicitly run for it.

This updates the required validation workflows:
- Build and Test
- Lint

Pull request metadata workflows are intentionally left unchanged because they do not validate merge queue groups.

