### PR TITLE
Set timeout of assertion after verification code was entered [WPB-26045]

### DIFF
--- a/e2e-tests/specs/criticalFlow/register.spec.ts
+++ b/e2e-tests/specs/criticalFlow/register.spec.ts
@@ -21,7 +21,7 @@ import {expect, test} from '../../fixtures';
 import {accountsSidebar} from '../../poms/app/accountsSidebar.page';
 import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
 import {emailVerificationPage} from '../../poms/webapp/emailVerification.page';
-import {loginPage} from '../../poms/webapp/login.page';
+import {LOGIN_TIMEOUT, loginPage} from '../../poms/webapp/login.page';
 import {registrationPage} from '../../poms/webapp/registration.page';
 import {setAccountTypePage} from '../../poms/webapp/setAccountType.page';
 import {setHandlePage} from '../../poms/webapp/setHandle.page';
@@ -80,7 +80,7 @@ test(
 
     await test.step('User declines sending usage data', async () => {
       const modal = page.getByRole('dialog');
-      await expect(modal).toContainText('Consent to share user data');
+      await expect(modal).toContainText('Consent to share user data', {timeout: LOGIN_TIMEOUT});
       await modal.getByRole('button', {name: 'Decline'}).click();
     });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   timeout: 90_000,
+  expect: {timeout: 10_000},
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26045" title="WPB-26045" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26045</a>  [Desktop/QA] Create critical flow test for registration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Small fixup for the registration e2e test. After the username was set the login will take place which might take some time depending on the backend performance.