### PR TITLE
Forward logs from electron main process to playwright [WPB-25890]

### DIFF
--- a/e2e-tests/utils/createApp.ts
+++ b/e2e-tests/utils/createApp.ts
@@ -35,6 +35,13 @@ export const createApp = async (options: {env?: string; lang?: string; dataDir: 
     args: ['.', `--env=${options.env}`, `--lang=${options.lang ?? 'en'}`, `--user-data-dir=${options.dataDir}`],
   });
 
+  // Forward all logs from the electron apps main thread to the terminal
+  app.on('console', async msg => {
+    const args = await Promise.all(msg.args().map(arg => arg.jsonValue()));
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  });
+
   /**
    * The webview element isn't treated as a regular webcomponent / iframe by electron but as individual window.
    * So in order to access the contents of the application we need to use the second window.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25890" title="WPB-25890" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-25890</a>  [Desktop/QA] Start Desktop app via Playwright and try interacting with it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Since the electron main process runs as its own isolated process logs from it won't be visible in the terminal running the e2e tests by default. We forward them to gain insights into what's happening in case we need to debug e.g. CI runs.