### PR TITLE
Add fixture to create pages in the web app [WPB-26068]

### DIFF
--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {test as baseTest} from '@playwright/test';
+import {test as baseTest, BrowserContext, Page} from '@playwright/test';
 
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -36,6 +36,7 @@ type Fixtures = {
   brigApi: BrigApiClient;
 
   createUser: () => Promise<RegisteredUser>;
+  createPage: () => Promise<Page>;
 };
 
 export const test = baseTest.extend<FixtureOptions & Fixtures>({
@@ -89,6 +90,23 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
     });
 
     await Promise.all(users.map(user => publicApi.deleteUser(user)));
+  },
+
+  createPage: async ({browser}, use) => {
+    const contexts: BrowserContext[] = [];
+
+    await use(async () => {
+      const context = await browser.newContext();
+      contexts.push(context);
+
+      const page = await context.newPage();
+      await page.goto('/'); // Open the base url to ensure the page starts in the same state as the app
+
+      return page;
+    });
+
+    // Close all contexts created throughout the tests (will automatically close all pages associated with each context)
+    await Promise.all(contexts.map(ctx => ctx.close()));
   },
 });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     testIdAttribute: 'data-uie-name',
+    baseURL: process.env.WEBAPP_URL,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26068" title="WPB-26068" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26068</a>  [Desktop/QA] Create critical flow test for calling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Since the desktop app can only be launched once per system we need to use web pages as additional clients for some test cases. This migrates the `createPage` fixture from Web to also be available on desktop.