### PR TITLE
test: write critical flow test group calling [WPB-26217]

### DIFF
--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -32,7 +32,14 @@ export const createApp = async (options: {env?: string; lang?: string; dataDir: 
   }
 
   const app = await electron.launch({
-    args: ['.', `--env=${options.env}`, `--lang=${options.lang ?? 'en'}`, `--user-data-dir=${options.dataDir}`],
+    args: [
+      '.',
+      `--env=${options.env}`,
+      `--lang=${options.lang ?? 'en'}`,
+      `--user-data-dir=${options.dataDir}`,
+      '--use-fake-device-for-media-stream',
+      '--use-fake-ui-for-media-stream',
+    ],
   });
 
   // Forward all logs from the electron apps main thread to the terminal

--- a/e2e-tests/actions/createTeam.ts
+++ b/e2e-tests/actions/createTeam.ts
@@ -1,0 +1,86 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createUser, registerUser} from './createUser';
+
+import {BrigApiClient} from '../backend/BrigApiClient';
+import {PublicApiClient, RegisteredUser} from '../backend/PublicApiClient';
+
+export type Team = {
+  teamId: string;
+  owner: RegisteredUser;
+  /** Add a new member to the team after its initial creation */
+  addTeamMember: (member: RegisteredUser, options?: {role?: keyof typeof Role}) => Promise<void>;
+};
+
+export enum Role {
+  ADMIN = 'admin',
+  EXTERNAL = 'partner',
+  MEMBER = 'member',
+  OWNER = 'owner',
+}
+
+export const createTeam = async (
+  api: {publicApi: PublicApiClient; brigApi: BrigApiClient},
+  teamName: string,
+  options?: {
+    users?: (RegisteredUser | {user: RegisteredUser; role?: keyof typeof Role})[];
+    features?: {
+      conferenceCalling?: boolean;
+      channels?: boolean;
+      mls?: boolean;
+      cells?: boolean;
+    };
+  },
+) => {
+  const user = createUser();
+  const owner = await registerUser(user, {publicApi: api.publicApi, brigApi: api.brigApi});
+
+  const {teamId} = await api.publicApi.upgradeUserToTeamOwner(owner, teamName);
+  owner.teamId = teamId;
+
+  const addTeamMember: Team['addTeamMember'] = async (member, options) => {
+    const invitationId = await api.publicApi.sendTeamInvitation(member.email, owner, Role[options?.role ?? 'MEMBER']);
+    const invitationCode = await api.brigApi.getTeamActivationCode(owner.teamId, invitationId);
+    await api.publicApi.acceptTeamInvitation(invitationCode, member);
+  };
+
+  if (options?.users) {
+    await Promise.all(
+      options.users.map(user => {
+        if ('user' in user) {
+          return addTeamMember(user.user, {role: user.role});
+        }
+        return addTeamMember(user);
+      }),
+    );
+  }
+
+  if (options?.features && Object.values(options.features).some(Boolean)) {
+    // The team will be reset right after initialization, so we need to wait a short time for it to finish
+    // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    if (options.features.conferenceCalling) {
+      await api.brigApi.unlockConferenceCallingFeature(teamId);
+    }
+  }
+
+  return {teamId, owner, addTeamMember};
+};

--- a/e2e-tests/actions/createUser.ts
+++ b/e2e-tests/actions/createUser.ts
@@ -30,6 +30,7 @@ export type User = {
   fullName: string;
   email: string;
   password: string;
+  teamId: string;
 };
 
 export const createUser = (): User => {
@@ -49,6 +50,7 @@ export const createUser = (): User => {
     },
     email: faker.internet.email({firstName, lastName, provider: 'wire.engineering'}),
     password: generateValidPassword(),
+    teamId: '',
   };
 };
 

--- a/e2e-tests/actions/loginUser.ts
+++ b/e2e-tests/actions/loginUser.ts
@@ -21,6 +21,7 @@ import {Page} from '@playwright/test';
 
 import {User} from './createUser';
 
+import {confirmModal} from '../poms/webapp/confirm.modal';
 import {conversationsSidebar} from '../poms/webapp/conversationsSidebar.page';
 import {LOGIN_TIMEOUT, loginPage} from '../poms/webapp/login.page';
 import {ssoPage} from '../poms/webapp/sso.page';
@@ -33,5 +34,6 @@ export const loginUser = async (page: Page, user: User) => {
   await loginPage(page).passwordInput.fill(user.password);
   await loginPage(page).loginButton.click();
 
-  await conversationsSidebar(page).userAvatar.waitFor({state: 'visible', timeout: LOGIN_TIMEOUT});
+  await confirmModal(page).actionButton.click({timeout: LOGIN_TIMEOUT});
+  await conversationsSidebar(page).userAvatar.waitFor({state: 'visible'});
 };

--- a/e2e-tests/actions/userActions.ts
+++ b/e2e-tests/actions/userActions.ts
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {conversationsSidebar} from './../poms/webapp/conversationsSidebar.page';
+import {User} from './createUser';
+
+import {Page} from '../fixtures';
+import {conversationsList} from '../poms/webapp/conversationList.page';
+import {groupCreationPage} from '../poms/webapp/groupCreation.page';
+import {startUIPage} from '../poms/webapp/startUI.page';
+import {userProfileModal} from '../poms/webapp/userProfile.modal';
+
+export const createGroup = async (page: Page, conversationName: string, users: User[]) => {
+  await conversationsList(page).clickCreateGroup();
+  await groupCreationPage(page).setGroupName(conversationName);
+  await groupCreationPage(page).selectGroupMembers(...users.map(user => user.username));
+  await groupCreationPage(page).clickCreateGroupButton();
+};
+
+export async function sendConnectionRequest(sender: Page, receiver: User) {
+  await conversationsSidebar(sender).clickConnectButton();
+
+  await startUIPage(sender).searchInput.fill(receiver.username);
+  await startUIPage(sender).searchResults.filter({hasText: receiver.username}).click();
+  await userProfileModal(sender).connectButton.click();
+}
+
+export async function connectWithUser(sender: Page, receiver: User) {
+  await conversationsSidebar(sender).clickConnectButton();
+
+  await startUIPage(sender).searchInput.fill(receiver.username);
+  await startUIPage(sender).searchResults.filter({hasText: receiver.username}).click();
+  await userProfileModal(sender).startConversationButton.click();
+}

--- a/e2e-tests/backend/BrigApiClient.ts
+++ b/e2e-tests/backend/BrigApiClient.ts
@@ -18,6 +18,7 @@
  */
 
 import {type RequestOpts} from '@oazapfts/runtime';
+import axios from 'axios';
 
 import * as brigApi from './generated/brigApi';
 
@@ -44,5 +45,23 @@ export class BrigApiClient {
   async getUserActivationCode(email: string) {
     const res = await brigApi.iGetUserActivationCode({email}, this.requestOptions);
     return res.code;
+  }
+
+  async getTeamActivationCode(team: string, invitationId: string) {
+    const res = await brigApi.getInvitationCode({team, invitationId}, this.requestOptions);
+    return res.code;
+  }
+
+  async unlockConferenceCallingFeature(teamId: string) {
+    const {baseUrl, headers} = this.requestOptions;
+
+    await axios.put(`${baseUrl}i/teams/${teamId}/features/conferenceCalling/unlocked`, {}, {headers});
+    await axios.patch(
+      `${baseUrl}i/teams/${teamId}/features/conferenceCalling`,
+      {
+        status: 'enabled',
+      },
+      {headers},
+    );
   }
 }

--- a/e2e-tests/backend/PublicApiClient.ts
+++ b/e2e-tests/backend/PublicApiClient.ts
@@ -21,6 +21,7 @@ import {ok, type RequestOpts} from '@oazapfts/runtime';
 
 import * as publicApiClient from './generated/publicApi';
 
+import {Role} from '../actions/createTeam';
 import {User} from '../actions/createUser';
 
 export type RegisteredUser = User & {token: string};
@@ -116,6 +117,92 @@ export class PublicApiClient {
         headers: {
           ...this.requestOptions.headers,
           Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+  }
+
+  async upgradeUserToTeamOwner(owner: RegisteredUser, teamName: string) {
+    const response = await ok(
+      publicApiClient.upgradePersonalToTeam(
+        {
+          bindingNewTeamUser: {
+            name: teamName,
+            icon: 'default',
+          },
+        },
+        {
+          ...this.requestOptions,
+          headers: {
+            ...this.requestOptions.headers,
+            Authorization: `Bearer ${owner.token}`,
+          },
+        },
+      ),
+    );
+
+    return {teamId: response.team_id, teamName: response.team_name};
+  }
+
+  async sendTeamInvitation(
+    emailOfInvitee: string,
+    teamOwner: RegisteredUser,
+    role: publicApiClient.Role = Role.MEMBER,
+  ) {
+    const response = await ok(
+      publicApiClient.sendTeamInvitation(
+        {
+          tid: teamOwner.teamId,
+          invitationRequest: {
+            email: emailOfInvitee,
+            role,
+            allow_existing: true,
+          },
+        },
+        {
+          ...this.requestOptions,
+          headers: {
+            ...this.requestOptions.headers,
+            Authorization: `Bearer ${teamOwner.token}`,
+          },
+        },
+      ),
+    );
+
+    return response.id;
+  }
+
+  async acceptTeamInvitation(teamInvitationCode: string, user: Pick<RegisteredUser, 'password' | 'token'>) {
+    await publicApiClient.acceptTeamInvitation(
+      {
+        acceptTeamInvitation: {
+          code: teamInvitationCode,
+          password: user.password,
+        },
+      },
+      {
+        ...this.requestOptions,
+        headers: {
+          ...this.requestOptions.headers,
+          Authorization: `Bearer ${user.token}`,
+        },
+      },
+    );
+  }
+
+  async deleteTeam(user: RegisteredUser, teamId: string) {
+    await publicApiClient.deleteTeam(
+      {
+        tid: teamId,
+        teamDeleteData: {
+          password: user.password,
+        },
+      },
+      {
+        ...this.requestOptions,
+        headers: {
+          ...this.requestOptions.headers,
+          Authorization: `Bearer ${user.token}`,
         },
       },
     );

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -24,6 +24,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {createApp, type App} from './actions/createApp';
+import {createTeam, Team} from './actions/createTeam';
 import {createUser, registerUser} from './actions/createUser';
 import {BrigApiClient} from './backend/BrigApiClient';
 import {PublicApiClient, RegisteredUser} from './backend/PublicApiClient';
@@ -37,6 +38,7 @@ type Fixtures = {
 
   createUser: () => Promise<RegisteredUser>;
   createPage: () => Promise<Page>;
+  createTeam: (...args: Parameters<typeof createTeam> extends [any, ...infer Args] ? Args : never) => Promise<Team>;
 };
 
 export const test = baseTest.extend<FixtureOptions & Fixtures>({
@@ -110,13 +112,25 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
       contexts.push(context);
 
       const page = await context.newPage();
-      await page.goto('/'); // Open the base url to ensure the page starts in the same state as the app
+      await page.goto('/', {waitUntil: 'networkidle'}); // Open the base url to ensure the page starts in the same state as the app
 
       return page;
     });
 
     // Close all contexts created throughout the tests (will automatically close all pages associated with each context)
     await Promise.all(contexts.map(ctx => ctx.close()));
+  },
+
+  createTeam: async ({publicApi, brigApi}, use) => {
+    const teamOwners: RegisteredUser[] = [];
+
+    await use(async (teamName, options) => {
+      const team = await createTeam({publicApi, brigApi}, teamName, options);
+      teamOwners.push(team.owner);
+      return team;
+    });
+
+    await Promise.all(teamOwners.map(owner => publicApi.deleteTeam(owner, owner.teamId)));
   },
 });
 

--- a/e2e-tests/poms/webapp/calling.page.ts
+++ b/e2e-tests/poms/webapp/calling.page.ts
@@ -19,13 +19,12 @@
 
 import {Page} from '@playwright/test';
 
-export const conversationsSidebar = (page: Page) => {
-  const sidebar = page.getByRole('complementary').getByRole('navigation');
+export const callingPage = (page: Page) => {
+  const callCell = page.locator('[data-uie-name="item-call"]');
 
   return {
-    userAvatar: sidebar.getByTestId('element-avatar-user'),
-    clickConnectButton: async () => {
-      await page.getByTestId('go-people').click();
-    },
+    callCell,
+    acceptCallButton: callCell.getByRole('button', {name: 'Accept'}),
+    goFullScreen: page.locator('[data-uie-name="do-maximize-call"]'),
   };
 };

--- a/e2e-tests/poms/webapp/confirm.modal.ts
+++ b/e2e-tests/poms/webapp/confirm.modal.ts
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+export const confirmModal = (page: Page) => {
+  const modal = page.getByTestId('modal-template-confirm');
+  return {
+    actionButton: modal.getByTestId('do-action'),
+  };
+};

--- a/e2e-tests/poms/webapp/connectRequest.page.ts
+++ b/e2e-tests/poms/webapp/connectRequest.page.ts
@@ -19,13 +19,11 @@
 
 import {Page} from '@playwright/test';
 
-export const conversationsSidebar = (page: Page) => {
-  const sidebar = page.getByRole('complementary').getByRole('navigation');
-
+export const connectRequestPage = (page: Page) => {
+  const clickConnectButton = async () => {
+    await page.locator('[data-uie-name="connect-request"] [data-uie-name="do-accept"]').click();
+  };
   return {
-    userAvatar: sidebar.getByTestId('element-avatar-user'),
-    clickConnectButton: async () => {
-      await page.getByTestId('go-people').click();
-    },
+    clickConnectButton,
   };
 };

--- a/e2e-tests/poms/webapp/conversation.page.ts
+++ b/e2e-tests/poms/webapp/conversation.page.ts
@@ -19,13 +19,12 @@
 
 import {Page} from '@playwright/test';
 
-export const conversationsSidebar = (page: Page) => {
-  const sidebar = page.getByRole('complementary').getByRole('navigation');
+export const conversationPage = (page: Page) => {
+  const startCall = async () => {
+    await page.locator('[data-uie-name="do-call"]').click();
+  };
 
   return {
-    userAvatar: sidebar.getByTestId('element-avatar-user'),
-    clickConnectButton: async () => {
-      await page.getByTestId('go-people').click();
-    },
+    startCall,
   };
 };

--- a/e2e-tests/poms/webapp/conversationList.page.ts
+++ b/e2e-tests/poms/webapp/conversationList.page.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+export const conversationsList = (page: Page) => {
+  const getConversation = (conversationName: string, options?: {protocol?: 'mls' | 'proteus'}) => {
+    let conversation = page.getByTestId('item-conversation').filter({hasText: conversationName});
+
+    if (options?.protocol) {
+      conversation = conversation.and(page.locator(`[data-protocol="${options.protocol}"]`));
+    }
+    const enhancedLocator = Object.assign(conversation, {
+      // This is just syntactic sugar to allow capturing the enhanced locator from the open function
+      open: async () => {
+        await conversation.click();
+        return enhancedLocator;
+      },
+    });
+    return enhancedLocator;
+  };
+
+  return {
+    getConversation,
+    clickCreateGroup: async () => {
+      await page.getByTestId('conversation-list-header').getByTestId('go-create-group').click();
+    },
+  };
+};

--- a/e2e-tests/poms/webapp/groupCreation.page.ts
+++ b/e2e-tests/poms/webapp/groupCreation.page.ts
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+export const groupCreationPage = (page: Page) => {
+  const searchPeopleList = page.getByRole('dialog').getByRole('list');
+  const setGroupName = async (name: string) => {
+    await page.getByRole('textbox', {name: 'Group name'}).fill(name);
+    await page.getByRole('button', {name: 'Next'}).click();
+  };
+
+  const selectGroupMembers = async (...usernames: string[]) => {
+    for (const username of usernames) {
+      await page.getByRole('dialog').getByLabel('Search by name').fill(username);
+      await searchPeopleList.getByRole('listitem').filter({hasText: username}).click();
+    }
+  };
+
+  const clickCreateGroupButton = async () => {
+    await page.locator('[data-uie-name="do-create-group"]').click();
+  };
+
+  return {
+    setGroupName,
+    selectGroupMembers,
+    clickCreateGroupButton,
+  };
+};

--- a/e2e-tests/poms/webapp/startUI.page.ts
+++ b/e2e-tests/poms/webapp/startUI.page.ts
@@ -19,13 +19,11 @@
 
 import {Page} from '@playwright/test';
 
-export const conversationsSidebar = (page: Page) => {
-  const sidebar = page.getByRole('complementary').getByRole('navigation');
+export const startUIPage = (page: Page) => {
+  const component = page.locator('#start-ui');
 
   return {
-    userAvatar: sidebar.getByTestId('element-avatar-user'),
-    clickConnectButton: async () => {
-      await page.getByTestId('go-people').click();
-    },
+    searchInput: component.getByLabel('Search people'),
+    searchResults: component.getByRole('list', {name: 'Conversation List'}).getByRole('listitem'),
   };
 };

--- a/e2e-tests/poms/webapp/userProfile.modal.ts
+++ b/e2e-tests/poms/webapp/userProfile.modal.ts
@@ -19,13 +19,9 @@
 
 import {Page} from '@playwright/test';
 
-export const conversationsSidebar = (page: Page) => {
-  const sidebar = page.getByRole('complementary').getByRole('navigation');
-
+export const userProfileModal = (page: Page) => {
   return {
-    userAvatar: sidebar.getByTestId('element-avatar-user'),
-    clickConnectButton: async () => {
-      await page.getByTestId('go-people').click();
-    },
+    connectButton: page.getByTestId('modal-user-profile').getByTestId('do-send-request'),
+    startConversationButton: page.getByTestId('modal-user-profile').getByTestId('start-conversation'),
   };
 };

--- a/e2e-tests/specs/criticalFlow/groupCall.spec.ts
+++ b/e2e-tests/specs/criticalFlow/groupCall.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {loginUser} from './../../actions/loginUser';
+import {callingPage} from './../../poms/webapp/calling.page';
+import {conversationPage} from './../../poms/webapp/conversation.page';
+
+import {createGroup} from '../../actions/userActions';
+import {test, expect} from '../../fixtures';
+import {conversationsList} from '../../poms/webapp/conversationList.page';
+
+test(
+  'I want to have a group call',
+  {tag: ['@TC-11071', '@crit-flow-web']},
+  async ({page, createUser, createTeam, createPage}) => {
+    const [member, memberPage] = await Promise.all([createUser(), createPage()]);
+    const team = await createTeam('Calling', {users: [member], features: {conferenceCalling: true}});
+    const owner = team.owner;
+    const conversationName = 'Calling';
+
+    await Promise.all([loginUser(memberPage, member), loginUser(page, owner)]);
+
+    await test.step('Owner creates group and adds the member', async () => {
+      await createGroup(page, conversationName, [member]);
+    });
+
+    await test.step('Owner starts call', async () => {
+      await conversationsList(page).getConversation(conversationName).open();
+      await conversationPage(page).startCall();
+      await expect(callingPage(page).callCell).toBeVisible();
+    });
+
+    await test.step('Member accepts call', async () => {
+      await conversationsList(memberPage).getConversation(conversationName).open();
+      await callingPage(memberPage).acceptCallButton.click();
+
+      await expect(callingPage(memberPage).goFullScreen).toBeVisible();
+      await expect(callingPage(page).goFullScreen).toBeVisible();
+    });
+  },
+);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,13 +53,23 @@ export default defineConfig({
     trace: 'retain-on-first-failure',
     testIdAttribute: 'data-uie-name',
     baseURL: process.env.WEBAPP_URL,
+    permissions: ['camera', 'microphone'],
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
-      use: {...devices['Desktop Chrome']},
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--use-fake-device-for-media-stream', // Provide fake devices for audio & video device input
+            '--use-fake-ui-for-media-stream', // Bypasses the popup to grant permission and select video / audio input device by automatically selecting the default one
+            '--mute-audio', // Mute all audio output from the test browser because e.g. the ringtone of a call can be annoying during testing
+          ],
+        },
+      },
     },
   ],
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26217" title="WPB-26217" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26217</a>  [Desktop/QA] Create Critical Flow test for group calling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR introduces the critical end-to-end flow test for group calling (TC-11071) along with the necessary backend API extensions, fixtures, and device permission configurations required to support it.

- Added CreateTeam Fixture: Simplifies test setup by handling automated team creation and scoping for group calling test.
- Group Calling Test Case (TC-11071): Implemented the core flow for initiating and maintaining group calls.

API Client Extensions

- brigApiClient: Added new methods to handle required backend configurations for group calls and test-user management.
- publicApiClient: Added helper methods to support public-facing data fetching needed during the test setup/teardown.