### PR TITLE
Fix dangling JS handle on page close [WPB-22420]

### DIFF
--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {test as baseTest, Page} from '@playwright/test';
+import {test as baseTest, BrowserContext, Page} from '@playwright/test';
 
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -130,10 +130,12 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
   },
 
   createPage: async ({browser}, use) => {
+    const contexts: BrowserContext[] = [];
     const pages: Page[] = [];
 
     await use(async () => {
       const context = await browser.newContext();
+      contexts.push(context);
 
       const page = await context.newPage();
       pages.push(page);
@@ -144,6 +146,7 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
 
     // Close all pages created throughout the tests and dismiss before unload dialogs
     await Promise.all(pages.map(page => page.close({runBeforeUnload: true})));
+    await Promise.all(contexts.map(ctx => ctx.close()));
   },
 });
 

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {test as baseTest, BrowserContext, Page} from '@playwright/test';
+import {test as baseTest, Page} from '@playwright/test';
 
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -104,8 +104,7 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
     await use(app.page);
   },
 
-  // The app fixture needs to be a dependency of createUser to ensure it is cleaned up after the team
-  createUser: async ({app: _app, publicApi, brigApi}, use) => {
+  createUser: async ({publicApi, brigApi}, use) => {
     const users: RegisteredUser[] = [];
 
     await use(async () => {
@@ -118,8 +117,7 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
     await Promise.all(users.map(user => publicApi.deleteUser(user)));
   },
 
-  // The app fixture needs to be a dependency of createTeam to ensure it is cleaned up after the team
-  createTeam: async ({app: _app, publicApi, brigApi, galleyApi}, use) => {
+  createTeam: async ({publicApi, brigApi, galleyApi}, use) => {
     const teamOwners: TeamOwner[] = [];
 
     await use(async (teamName, options) => {
@@ -132,20 +130,20 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
   },
 
   createPage: async ({browser}, use) => {
-    const contexts: BrowserContext[] = [];
+    const pages: Page[] = [];
 
     await use(async () => {
       const context = await browser.newContext();
-      contexts.push(context);
 
       const page = await context.newPage();
+      pages.push(page);
       await page.goto('/'); // Open the base url to ensure the page starts in the same state as the app
 
       return page;
     });
 
-    // Close all contexts created throughout the tests (will automatically close all pages associated with each context)
-    await Promise.all(contexts.map(ctx => ctx.close()));
+    // Close all pages created throughout the tests and dismiss before unload dialogs
+    await Promise.all(pages.map(page => page.close({runBeforeUnload: true})));
   },
 });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
So far it could happen that a JS handle for a dialog was left dangling on page close. This was caused by the before unload function displaying a dialog e.g. when attempting to close the page while a call was still ongoing. Playwright provides a flag to set which will have playwright take care of dismissing the dialogs while closing the page(s).

