### PR TITLE
Add utils for working with multiple accounts [WPB-26046]

### DIFF
--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -99,11 +99,6 @@ export const test = baseTest.extend<FixtureOptions & Fixtures>({
     await fs.rm(tempUserDataDir, {recursive: true});
   },
 
-  // Overwrite of the default page fixture to reference the apps page instead
-  page: async ({app}, use) => {
-    await use(app.page);
-  },
-
   createUser: async ({publicApi, brigApi}, use) => {
     const users: RegisteredUser[] = [];
 

--- a/e2e-tests/poms/app/accountsSidebar.page.ts
+++ b/e2e-tests/poms/app/accountsSidebar.page.ts
@@ -22,9 +22,33 @@ import {User} from '../../actions/createUser';
 
 export const accountsSidebar = (app: App) => {
   const sidebar = app.wrapper.getByRole('navigation', {name: 'Accounts Sidebar'});
+
+  const accountItems = sidebar.getByTestId('account-cell');
+  const addAccountButton = sidebar.getByTestId('do-open-plus-menu');
+
+  /* Trigger the flow to add a new account, replacing the currenly shown page with the page for adding the new account */
+  const addAccount = async () => {
+    await sidebar.hover();
+
+    const newWindowPromise = app.waitForEvent('window');
+    await addAccountButton.click();
+
+    // Set the current page to the now visible one
+    app.page = await newWindowPromise;
+  };
+
+  /* Switch to the account at the given index, replacing the currently shown page with the page of the other account */
+  const switchAccount = async (index: number) => {
+    await accountItems.nth(index).click();
+
+    // Set the current page to the new active one. The first index in the windows list is always the wrapper
+    app.page = app.windows()[index + 1];
+  };
+
   return Object.assign(sidebar, {
+    accountItems,
     getAccount: (user: User) => sidebar.getByRole('button', {name: user.fullName}),
-    addAccountButton: sidebar.getByTestId('do-open-plus-menu'),
-    accountItems: sidebar.getByTestId('account-cell'),
+    addAccount,
+    switchAccount,
   });
 };

--- a/e2e-tests/specs/criticalFlow/1on1Call.spec.ts
+++ b/e2e-tests/specs/criticalFlow/1on1Call.spec.ts
@@ -27,9 +27,10 @@ import {conversationsList} from '../../poms/webapp/conversationList.page';
 test(
   'I want to call someone directly',
   {tag: ['@TC-10926', '@crit-flow-desktop']},
-  async ({page: userAPage, createUser, createTeam, createPage}) => {
+  async ({app, createUser, createTeam, createPage}) => {
     const userB = await createUser();
     const {owner: userA} = await createTeam('Test Team', {users: [userB]});
+    const userAPage = app.page;
     const userBPage = await createPage();
 
     await Promise.all([loginUser(userAPage, userA), loginUser(userBPage, userB)]);

--- a/e2e-tests/specs/criticalFlow/groupCall.spec.ts
+++ b/e2e-tests/specs/criticalFlow/groupCall.spec.ts
@@ -28,22 +28,22 @@ import {conversationsList} from '../../poms/webapp/conversationList.page';
 test(
   'I want to have a group call',
   {tag: ['@TC-11071', '@crit-flow-web']},
-  async ({page, createUser, createTeam, createPage}) => {
+  async ({app, createUser, createTeam, createPage}) => {
     const [member, memberPage] = await Promise.all([createUser(), createPage()]);
     const team = await createTeam('Calling', {users: [member], features: {conferenceCalling: true}});
-    const owner = team.owner;
+    const [owner, ownerPage] = [team.owner, app.page];
     const conversationName = 'Calling';
 
-    await Promise.all([loginUser(memberPage, member), loginUser(page, owner)]);
+    await Promise.all([loginUser(memberPage, member), loginUser(ownerPage, owner)]);
 
     await test.step('Owner creates group and adds the member', async () => {
-      await createGroup(page, conversationName, [member]);
+      await createGroup(ownerPage, conversationName, [member]);
     });
 
     await test.step('Owner starts call', async () => {
-      await conversationsList(page).getConversation(conversationName).open();
-      await conversation(page).startCallButton.click();
-      await expect(callCell(page)).toBeVisible();
+      await conversationsList(ownerPage).getConversation(conversationName).open();
+      await conversation(ownerPage).startCallButton.click();
+      await expect(callCell(ownerPage)).toBeVisible();
     });
 
     await test.step('Member accepts call', async () => {
@@ -51,7 +51,7 @@ test(
       await callCell(memberPage).acceptCallButton.click();
 
       await expect(callCell(memberPage).goFullScreen).toBeVisible();
-      await expect(callCell(page).goFullScreen).toBeVisible();
+      await expect(callCell(ownerPage).goFullScreen).toBeVisible();
     });
   },
 );

--- a/e2e-tests/specs/criticalFlow/login.spec.ts
+++ b/e2e-tests/specs/criticalFlow/login.spec.ts
@@ -25,15 +25,15 @@ import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page'
 test(
   'I want to log in with my existing Wire account',
   {tag: ['@TC-10923', '@crit-flow-desktop']},
-  async ({app, page, createUser}) => {
+  async ({app, createUser}) => {
     const user = await createUser();
 
     await test.step('User logs in', async () => {
-      await loginUser(page, user);
+      await loginUser(app.page, user);
     });
 
     await test.step("User verifies he's now logged in with his new account", async () => {
-      await expect(conversationsSidebar(page).userAvatar).toContainText(user.initials);
+      await expect(conversationsSidebar(app.page).userAvatar).toContainText(user.initials);
       await expect(accountsSidebar(app).getAccount(user)).toBeVisible();
     });
   },

--- a/e2e-tests/specs/criticalFlow/multipleAccounts.spec.ts
+++ b/e2e-tests/specs/criticalFlow/multipleAccounts.spec.ts
@@ -39,29 +39,23 @@ test(
       await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
     });
 
-    const newPage = await test.step('UserA clicks on `+` button to add new account', async () => {
-      await accountsSidebar(app).hover();
+    await test.step('UserA clicks on `+` button to add new account', async () => {
+      await accountsSidebar(app).addAccount();
 
-      const windowPromise = app.waitForEvent('window');
-      await accountsSidebar(app).addAccountButton.click();
-      const newPage = await windowPromise;
-
-      await expect(ssoPage(newPage).loginButton).toBeVisible();
-      await expect(newPage.getByText('Welcome to Wire!')).toBeVisible();
-
-      return newPage;
+      await expect(ssoPage(app.page).loginButton).toBeVisible();
+      await expect(app.page.getByText('Welcome to Wire!')).toBeVisible();
     });
 
     await test.step('UserA logs in with second account', async () => {
-      await loginUser(newPage, userA2);
-      await expect(conversationsSidebar(newPage).userAvatar).toContainText(userA2.initials);
+      await loginUser(app.page, userA2);
+      await expect(conversationsSidebar(app.page).userAvatar).toContainText(userA2.initials);
       await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
       await expect(accountsSidebar(app).getAccount(userA2)).toBeVisible();
       await expect(accountsSidebar(app).accountItems).toHaveCount(2);
     });
 
     await test.step('UserA clicks on first account in the accounts list', async () => {
-      await accountsSidebar(app).getAccount(userA).click();
+      await accountsSidebar(app).switchAccount(0);
       await expect(conversationsSidebar(app.page).userAvatar).toContainText(userA.initials);
     });
   },

--- a/e2e-tests/specs/criticalFlow/register.spec.ts
+++ b/e2e-tests/specs/criticalFlow/register.spec.ts
@@ -28,65 +28,61 @@ import {setAccountTypePage} from '../../poms/webapp/setAccountType.page';
 import {setHandlePage} from '../../poms/webapp/setHandle.page';
 import {ssoPage} from '../../poms/webapp/sso.page';
 
-test(
-  'I want to register a new Wire account',
-  {tag: ['@TC-10924', '@crit-flow-desktop']},
-  async ({app, page, brigApi}) => {
-    const user = createUser();
+test('I want to register a new Wire account', {tag: ['@TC-10924', '@crit-flow-desktop']}, async ({app, brigApi}) => {
+  const user = createUser();
 
-    await test.step('User initiates the registration from the log in page', async () => {
-      await ssoPage(page).codeEmailInput.fill(user.email);
-      await ssoPage(page).loginButton.click();
-      await expect(loginPage(page).createAccountButton).toBeVisible();
+  await test.step('User initiates the registration from the log in page', async () => {
+    await ssoPage(app.page).codeEmailInput.fill(user.email);
+    await ssoPage(app.page).loginButton.click();
+    await expect(loginPage(app.page).createAccountButton).toBeVisible();
 
-      await loginPage(page).createAccountButton.click();
+    await loginPage(app.page).createAccountButton.click();
 
-      await setAccountTypePage(page).createPersonalAccountButton.click();
-    });
+    await setAccountTypePage(app.page).createPersonalAccountButton.click();
+  });
 
-    await test.step('User completes the signup', async () => {
-      const {nameInput, emailInput, passwordInput, confirmPasswordInput, termsAndConditionsCheckbox, submitButton} =
-        registrationPage(page);
+  await test.step('User completes the signup', async () => {
+    const {nameInput, emailInput, passwordInput, confirmPasswordInput, termsAndConditionsCheckbox, submitButton} =
+      registrationPage(app.page);
 
-      await nameInput.fill(user.fullName);
-      await emailInput.fill(user.email);
-      await passwordInput.fill(user.password);
-      await confirmPasswordInput.fill(user.password);
-      await termsAndConditionsCheckbox.check({force: true});
+    await nameInput.fill(user.fullName);
+    await emailInput.fill(user.email);
+    await passwordInput.fill(user.password);
+    await confirmPasswordInput.fill(user.password);
+    await termsAndConditionsCheckbox.check({force: true});
 
-      await submitButton.click();
-    });
+    await submitButton.click();
+  });
 
-    await test.step('User enters activation code from email', async () => {
-      const {verificationCodeInput, enterVerificationCode} = emailVerificationPage(page);
-      await expect(verificationCodeInput).toBeVisible();
+  await test.step('User enters activation code from email', async () => {
+    const {verificationCodeInput, enterVerificationCode} = emailVerificationPage(app.page);
+    await expect(verificationCodeInput).toBeVisible();
 
-      const verificationCode = await brigApi.getUserActivationCode(user.email);
-      await enterVerificationCode(verificationCode);
-    });
+    const verificationCode = await brigApi.getUserActivationCode(user.email);
+    await enterVerificationCode(verificationCode);
+  });
 
-    await test.step('User does not want to receive news and updates via email', async () => {
-      const modal = page.getByRole('dialog');
-      await expect(modal).toContainText('Do you want to receive news and product updates from Wire via email?');
-      await modal.getByRole('button', {name: 'No, thanks'}).click();
-    });
+  await test.step('User does not want to receive news and updates via email', async () => {
+    const modal = app.page.getByRole('dialog');
+    await expect(modal).toContainText('Do you want to receive news and product updates from Wire via email?');
+    await modal.getByRole('button', {name: 'No, thanks'}).click();
+  });
 
-    await test.step('User checks the automatically generated username', async () => {
-      const {pageTitle, handleInput, continueButton} = setHandlePage(page);
-      await expect(pageTitle).toBeVisible();
-      await expect(handleInput).not.toHaveValue('');
-      await continueButton.click();
-    });
+  await test.step('User checks the automatically generated username', async () => {
+    const {pageTitle, handleInput, continueButton} = setHandlePage(app.page);
+    await expect(pageTitle).toBeVisible();
+    await expect(handleInput).not.toHaveValue('');
+    await continueButton.click();
+  });
 
-    await test.step('User declines sending usage data', async () => {
-      const modal = page.getByRole('dialog');
-      await expect(modal).toContainText('Consent to share user data', {timeout: LOGIN_TIMEOUT});
-      await modal.getByRole('button', {name: 'Decline'}).click();
-    });
+  await test.step('User declines sending usage data', async () => {
+    const modal = app.page.getByRole('dialog');
+    await expect(modal).toContainText('Consent to share user data', {timeout: LOGIN_TIMEOUT});
+    await modal.getByRole('button', {name: 'Decline'}).click();
+  });
 
-    await test.step("User verifies he's now logged in with his new account", async () => {
-      await expect(conversationsSidebar(page).userAvatar).toContainText(user.initials);
-      await expect(accountsSidebar(app).getAccount(user)).toBeVisible();
-    });
-  },
-);
+  await test.step("User verifies he's now logged in with his new account", async () => {
+    await expect(conversationsSidebar(app.page).userAvatar).toContainText(user.initials);
+    await expect(accountsSidebar(app).getAccount(user)).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26046" title="WPB-26046" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26046</a>  [Desktop/QA] Create critical flow test for using multiple accounts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Add utils to the accountsSidebar POM to add and switch between accounts of the desktop app. Every account in the desktop app is treated as its own window so we need to capture them during creation or when switching to keep the reference to the page object. To make this seamless the utils will replace the `page` property of the app fixture with the currently active accounts page. 

Only downside with this is that the `page` fixture can no longer be used as it would hold an outdated reference after adding or switching. Also note that `app.page` needs to be used for the automatic reference update to work. If the reference to the page object is copied into a variable it won't receive the update.