### PR TITLE
test: add e2e regression tests for multiple accounts [WPB-26365]

### DIFF
--- a/e2e-tests/actions/createGroup.ts
+++ b/e2e-tests/actions/createGroup.ts
@@ -28,6 +28,11 @@ export const createGroup = async (page: Page, conversationName: string, users: U
 
   const modal = groupCreationModal(page);
   await modal.setGroupName(conversationName);
-  await modal.selectGroupMembers(...users.map(user => user.username));
-  await modal.doneButton.click();
+  // Allows creation of empty group
+  if (users && users.length > 0) {
+    await modal.selectGroupMembers(...users.map(user => user.username));
+    await modal.doneButton.click();
+  } else {
+    await modal.getByRole('button', {name: 'Skip'}).click();
+  }
 };

--- a/e2e-tests/poms/app/accountsSidebar.page.ts
+++ b/e2e-tests/poms/app/accountsSidebar.page.ts
@@ -46,10 +46,16 @@ export const accountsSidebar = (app: App) => {
   };
 
   const removeAccount = async (index: number) => {
-    const newWindowPromise = app.waitForEvent('window');
-    await accountItems.nth(index).click({button: 'right'});
-    await sidebar.getByRole('button', {name: 'Remove Account'}).click();
-    app.page = await newWindowPromise;
+    if (app.windows().length <= 2) {
+      const newWindowPromise = app.waitForEvent('window');
+      await accountItems.nth(index).click({button: 'right'});
+      await sidebar.getByRole('button', {name: 'Remove Account'}).click();
+      app.page = await newWindowPromise;
+    } else {
+      await accountItems.nth(index).click({button: 'right'});
+      await sidebar.getByRole('button', {name: 'Remove Account'}).click();
+      app.page = app.windows().at(-1)!;
+    }
   };
 
   return Object.assign(sidebar, {

--- a/e2e-tests/poms/app/accountsSidebar.page.ts
+++ b/e2e-tests/poms/app/accountsSidebar.page.ts
@@ -48,7 +48,13 @@ export const accountsSidebar = (app: App) => {
   return Object.assign(sidebar, {
     accountItems,
     addAccountButton,
-    getAccount: (user: User) => sidebar.getByRole('button', {name: user.fullName}),
+    getAccount: (user: User) => {
+      const accountLocator = sidebar.getByRole('button', {name: user.fullName});
+
+      return Object.assign(accountLocator, {
+        notificationDot: accountLocator.getByText('New message or missed call'),
+      });
+    },
     addAccount,
     switchAccount,
   });

--- a/e2e-tests/poms/app/accountsSidebar.page.ts
+++ b/e2e-tests/poms/app/accountsSidebar.page.ts
@@ -45,6 +45,13 @@ export const accountsSidebar = (app: App) => {
     app.page = app.windows()[index + 1];
   };
 
+  const removeAccount = async (index: number) => {
+    const newWindowPromise = app.waitForEvent('window');
+    await accountItems.nth(index).click({button: 'right'});
+    await sidebar.getByRole('button', {name: 'Remove Account'}).click();
+    app.page = await newWindowPromise;
+  };
+
   return Object.assign(sidebar, {
     accountItems,
     addAccountButton,
@@ -57,5 +64,6 @@ export const accountsSidebar = (app: App) => {
     },
     addAccount,
     switchAccount,
+    removeAccount,
   });
 };

--- a/e2e-tests/poms/app/accountsSidebar.page.ts
+++ b/e2e-tests/poms/app/accountsSidebar.page.ts
@@ -47,6 +47,7 @@ export const accountsSidebar = (app: App) => {
 
   return Object.assign(sidebar, {
     accountItems,
+    addAccountButton,
     getAccount: (user: User) => sidebar.getByRole('button', {name: user.fullName}),
     addAccount,
     switchAccount,

--- a/e2e-tests/poms/webapp/connectionRequest.page.ts
+++ b/e2e-tests/poms/webapp/connectionRequest.page.ts
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Page} from '@playwright/test';
+
+export const connectionRequestPage = (page: Page) => {
+  return {
+    connectButton: page.getByRole('button', {name: 'Connect'}),
+  };
+};

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -19,8 +19,11 @@
 
 import {createGroup} from '../../actions/createGroup';
 import {loginUser} from '../../actions/loginUser';
+import {sendConnectionRequest} from '../../actions/sendConnectionRequest';
 import {expect, test} from '../../fixtures';
 import {accountsSidebar} from '../../poms/app/accountsSidebar.page';
+import {connectionRequestPage} from '../../poms/webapp/connectionRequest.page';
+import {conversation} from '../../poms/webapp/conversation.page';
 import {conversationsList} from '../../poms/webapp/conversationList.page';
 import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
 
@@ -152,6 +155,62 @@ test.describe('Multiple Accounts', async () => {
     await test.step('Verify `+` is no longer visible', async () => {
       await accountsSidebar(app).getAccount(userB).hover();
       await expect(accountsSidebar(app).addAccountButton).not.toBeVisible();
+    });
+  });
+
+  test('Verify correct account gets notified', {tag: ['@TC-11006', '@regression']}, async ({app, createUser}) => {
+    const userA = await createUser();
+    const userB = await createUser();
+    const conversationName = 'MultiAcc';
+
+    await test.step('UserA logs in', async () => {
+      await loginUser(app.page, userA);
+    });
+
+    await test.step('UserA connects with UserB', async () => {
+      await sendConnectionRequest(app.page, userB);
+    });
+
+    await test.step('UserA adds account for UserB and UserB accepts connection request', async () => {
+      await accountsSidebar(app).addAccount();
+      await loginUser(app.page, userB);
+      await connectionRequestPage(app.page).connectButton.click();
+      await accountsSidebar(app).switchAccount(0);
+      await expect(conversationsSidebar(app.page).userAvatar).toContainText(userA.initials);
+    });
+
+    await test.step('UserA creates group conversation with UserB', async () => {
+      await createGroup(app.page, conversationName, [userB]);
+    });
+
+    await test.step('UserA sends message to group conversation', async () => {
+      await conversationsList(app.page).getConversation(conversationName).open();
+      await conversation(app.page).sendMessage('Papaya');
+    });
+
+    await test.step('Notification Dot on UserB profile in sidebar is visible', async () => {
+      await expect(accountsSidebar(app).getAccount(userB).notificationDot).toBeVisible();
+    });
+
+    await test.step('UserA switches to UserB account, reads message and notification dot vanishes', async () => {
+      await accountsSidebar(app).switchAccount(1);
+      await conversationsList(app.page).getConversation(conversationName).open();
+      await expect(accountsSidebar(app).getAccount(userB).notificationDot).toBeHidden();
+    });
+
+    await test.step('UserB sends message to group conversation', async () => {
+      await conversationsList(app.page).getConversation(conversationName).open();
+      await conversation(app.page).sendMessage('Guava');
+    });
+
+    await test.step('Notification Dot on UserA profile in sidebar is visible', async () => {
+      await expect(accountsSidebar(app).getAccount(userA).notificationDot).toBeVisible();
+    });
+
+    await test.step('UserB switches to UserA account, reads message and notification dot vanishes', async () => {
+      await accountsSidebar(app).switchAccount(0);
+      await conversationsList(app.page).getConversation(conversationName).open();
+      await expect(accountsSidebar(app).getAccount(userA).notificationDot).toBeHidden();
     });
   });
 });

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {createGroup} from '../../actions/createGroup';
+import {loginUser} from '../../actions/loginUser';
+import {expect, test} from '../../fixtures';
+import {accountsSidebar} from '../../poms/app/accountsSidebar.page';
+import {conversationsList} from '../../poms/webapp/conversationList.page';
+import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
+
+test.describe('Multiple Accounts', async () => {
+  test(
+    'I want to switch between multiple accounts and see correct conversation',
+    {tag: ['@TC-11002', '@regression']},
+    async ({app, createTeam}) => {
+      const userATeam = await createTeam('Multiple Accounts A', {users: []});
+      const [userA, userAPage] = [userATeam.owner, app.page];
+      const userAGroup = 'User A Group';
+
+      const userBTeam = await createTeam('Multiple Accounts B', {users: []});
+      const userB = userBTeam.owner;
+      const userBGroup = 'User B Group';
+
+      await test.step('UserA logs in', async () => {
+        await loginUser(userAPage, userA);
+        await expect(conversationsSidebar(userAPage).userAvatar).toContainText(userA.initials);
+      });
+
+      await test.step('UserA creates empty group', async () => {
+        await createGroup(userAPage, userAGroup, []);
+      });
+
+      await test.step('UserA adds new Account', async () => {
+        await accountsSidebar(app).addAccount();
+        await loginUser(app.page, userB);
+        await expect(conversationsSidebar(app.page).userAvatar).toContainText(userB.initials);
+      });
+
+      await test.step('UserB does not see group conversation of UserA', async () => {
+        await expect(conversationsList(app.page).getConversation(userAGroup)).not.toBeVisible();
+      });
+
+      await test.step('UserB creates empty group', async () => {
+        await createGroup(app.page, userBGroup, []);
+      });
+
+      await test.step('UserB switches account back to A', async () => {
+        await accountsSidebar(app).switchAccount(0);
+      });
+
+      await test.step('UserA does not see group conversation of UserA', async () => {
+        await expect(conversationsList(userAPage).getConversation(userBGroup)).not.toBeVisible();
+      });
+    },
+  );
+});

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -26,6 +26,7 @@ import {connectionRequestPage} from '../../poms/webapp/connectionRequest.page';
 import {conversation} from '../../poms/webapp/conversation.page';
 import {conversationsList} from '../../poms/webapp/conversationList.page';
 import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
+import {ssoPage} from '../../poms/webapp/sso.page';
 
 test.describe('Multiple Accounts', async () => {
   test(
@@ -72,6 +73,23 @@ test.describe('Multiple Accounts', async () => {
       });
     },
   );
+
+  test('I want to remove the only account I have', {tag: ['@TC-11070', '@regression']}, async ({app, createUser}) => {
+    const userA = await createUser();
+
+    await test.step('UserA logs in', async () => {
+      await loginUser(app.page, userA);
+    });
+
+    await test.step('UserA removes account', async () => {
+      await accountsSidebar(app).removeAccount(0);
+    });
+
+    await test.step('UserA gets redirected to SSO-Page', async () => {
+      await expect(ssoPage(app.page).loginButton).toBeVisible();
+      await expect(app.page.getByText('Welcome to Wire!')).toBeVisible();
+    });
+  });
 
   test('I want to remove my secondary account', {tag: ['@TC-11003', '@regression']}, async ({app, createUser}) => {
     const userA = await createUser();

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -127,4 +127,31 @@ test.describe('Multiple Accounts', async () => {
       await expect(accountsSidebar(app).accountItems).toHaveCount(1);
     });
   });
+
+  test('Verify max account limit of three accounts', {tag: ['@TC-11005', '@regression']}, async ({app, createUser}) => {
+    const userA = await createUser();
+    const userB = await createUser();
+    const userC = await createUser();
+
+    await test.step('Preconditions: UserA and UserB are already logged in', async () => {
+      await loginUser(app.page, userA);
+      await accountsSidebar(app).addAccount();
+      await loginUser(app.page, userB);
+    });
+
+    await test.step('Verify `+` is still visible', async () => {
+      await accountsSidebar(app).getAccount(userB).hover();
+      await expect(accountsSidebar(app).addAccountButton).toBeVisible();
+    });
+
+    await test.step('UserA adds third account', async () => {
+      await accountsSidebar(app).addAccount();
+      await loginUser(app.page, userC);
+    });
+
+    await test.step('Verify `+` is no longer visible', async () => {
+      await accountsSidebar(app).getAccount(userB).hover();
+      await expect(accountsSidebar(app).addAccountButton).not.toBeVisible();
+    });
+  });
 });

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -69,4 +69,37 @@ test.describe('Multiple Accounts', async () => {
       });
     },
   );
+
+  test(
+    'I want to remove my secondary account',
+    {tag: ['@TC-11003', '@crit-flow-desktop']},
+    async ({app, createUser}) => {
+      const userA = await createUser();
+      const userB = await createUser();
+
+      await test.step('UserA logs in', async () => {
+        await loginUser(app.page, userA);
+      });
+
+      await test.step('UserA logs in with second account', async () => {
+        await accountsSidebar(app).addAccount();
+        await loginUser(app.page, userB);
+        await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+        await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
+        await expect(accountsSidebar(app).accountItems).toHaveCount(2);
+      });
+
+      await test.step('UserA switches back to main account', async () => {
+        await accountsSidebar(app).switchAccount(0);
+      });
+
+      await test.step('UserA removes secondary account', async () => {
+        await accountsSidebar(app).getAccount(userB).click({button: 'right'});
+        await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
+        await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+        await expect(accountsSidebar(app).getAccount(userB)).not.toBeVisible();
+        await expect(accountsSidebar(app).accountItems).toHaveCount(1);
+      });
+    },
+  );
 });

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -70,36 +70,61 @@ test.describe('Multiple Accounts', async () => {
     },
   );
 
-  test(
-    'I want to remove my secondary account',
-    {tag: ['@TC-11003', '@crit-flow-desktop']},
-    async ({app, createUser}) => {
-      const userA = await createUser();
-      const userB = await createUser();
+  test('I want to remove my secondary account', {tag: ['@TC-11003', '@regression']}, async ({app, createUser}) => {
+    const userA = await createUser();
+    const userB = await createUser();
 
-      await test.step('UserA logs in', async () => {
-        await loginUser(app.page, userA);
-      });
+    await test.step('UserA logs in', async () => {
+      await loginUser(app.page, userA);
+    });
 
-      await test.step('UserA logs in with second account', async () => {
-        await accountsSidebar(app).addAccount();
-        await loginUser(app.page, userB);
-        await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
-        await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
-        await expect(accountsSidebar(app).accountItems).toHaveCount(2);
-      });
+    await test.step('UserA logs in with second account', async () => {
+      await accountsSidebar(app).addAccount();
+      await loginUser(app.page, userB);
+      await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+      await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
+      await expect(accountsSidebar(app).accountItems).toHaveCount(2);
+    });
 
-      await test.step('UserA switches back to main account', async () => {
-        await accountsSidebar(app).switchAccount(0);
-      });
+    await test.step('UserA switches back to main account', async () => {
+      await accountsSidebar(app).switchAccount(0);
+    });
 
-      await test.step('UserA removes secondary account', async () => {
-        await accountsSidebar(app).getAccount(userB).click({button: 'right'});
-        await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
-        await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
-        await expect(accountsSidebar(app).getAccount(userB)).not.toBeVisible();
-        await expect(accountsSidebar(app).accountItems).toHaveCount(1);
-      });
-    },
-  );
+    await test.step('UserA removes secondary account', async () => {
+      await accountsSidebar(app).getAccount(userB).click({button: 'right'});
+      await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
+      await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+      await expect(accountsSidebar(app).getAccount(userB)).not.toBeVisible();
+      await expect(accountsSidebar(app).accountItems).toHaveCount(1);
+    });
+  });
+
+  test('I want to remove my active account', {tag: ['@TC-11004', '@regression']}, async ({app, createUser}) => {
+    const userA = await createUser();
+    const userB = await createUser();
+
+    await test.step('UserA logs in', async () => {
+      await loginUser(app.page, userA);
+    });
+
+    await test.step('UserA logs in with second account', async () => {
+      await accountsSidebar(app).addAccount();
+      await loginUser(app.page, userB);
+      await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+      await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
+      await expect(accountsSidebar(app).accountItems).toHaveCount(2);
+    });
+
+    await test.step('UserA switches back to main account', async () => {
+      await accountsSidebar(app).switchAccount(0);
+    });
+
+    await test.step('UserA removes active main account', async () => {
+      await accountsSidebar(app).getAccount(userA).click({button: 'right'});
+      await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
+      await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
+      await expect(accountsSidebar(app).getAccount(userA)).not.toBeVisible();
+      await expect(accountsSidebar(app).accountItems).toHaveCount(1);
+    });
+  });
 });

--- a/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
+++ b/e2e-tests/specs/multipleAccounts/multipleAccountsSuite.spec.ts
@@ -26,6 +26,7 @@ import {connectionRequestPage} from '../../poms/webapp/connectionRequest.page';
 import {conversation} from '../../poms/webapp/conversation.page';
 import {conversationsList} from '../../poms/webapp/conversationList.page';
 import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
+import {LOGIN_TIMEOUT} from '../../poms/webapp/login.page';
 import {ssoPage} from '../../poms/webapp/sso.page';
 
 test.describe('Multiple Accounts', async () => {
@@ -86,7 +87,7 @@ test.describe('Multiple Accounts', async () => {
     });
 
     await test.step('UserA gets redirected to SSO-Page', async () => {
-      await expect(ssoPage(app.page).loginButton).toBeVisible();
+      await expect(ssoPage(app.page).loginButton).toBeVisible({timeout: LOGIN_TIMEOUT});
       await expect(app.page.getByText('Welcome to Wire!')).toBeVisible();
     });
   });
@@ -112,9 +113,8 @@ test.describe('Multiple Accounts', async () => {
     });
 
     await test.step('UserA removes secondary account', async () => {
-      await accountsSidebar(app).getAccount(userB).click({button: 'right'});
-      await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
-      await expect(accountsSidebar(app).getAccount(userA)).toBeVisible();
+      await accountsSidebar(app).removeAccount(1);
+      await expect(accountsSidebar(app).getAccount(userA)).toBeVisible({timeout: LOGIN_TIMEOUT});
       await expect(accountsSidebar(app).getAccount(userB)).not.toBeVisible();
       await expect(accountsSidebar(app).accountItems).toHaveCount(1);
     });
@@ -141,8 +141,7 @@ test.describe('Multiple Accounts', async () => {
     });
 
     await test.step('UserA removes active main account', async () => {
-      await accountsSidebar(app).getAccount(userA).click({button: 'right'});
-      await accountsSidebar(app).getByRole('button', {name: 'Remove Account'}).click();
+      await accountsSidebar(app).removeAccount(0);
       await expect(accountsSidebar(app).getAccount(userB)).toBeVisible();
       await expect(accountsSidebar(app).getAccount(userA)).not.toBeVisible();
       await expect(accountsSidebar(app).accountItems).toHaveCount(1);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26365" title="WPB-26365" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26365</a>  [Desktop/QA] Write Multiple Accounts regression tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR adds a new test suite for multiple accounts.