### PR TITLE
Mock set- & getBadgeCount apis of Electron [WPB-26554]

### DIFF
--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -52,10 +52,17 @@ export const createApp = async (options: {env?: string; lang?: string; dataDir: 
     console.log(...args);
   });
 
-  // Mock safeStorage API of electron as it doesn't work for the headless linux used in CI
-  app.evaluate(({safeStorage}) => {
+  // Mock safeStorage and badge APIs of electron as they don't work for the headless linux used in CI
+  app.evaluate(({safeStorage, app}) => {
     safeStorage.encryptString = (plainText: string) => Buffer.from(plainText, 'utf-8');
     safeStorage.decryptString = (encrypted: Buffer) => Buffer.from(encrypted).toString('utf-8');
+
+    let badgeCount = 0;
+    app.setBadgeCount = (count: number) => {
+      badgeCount = count;
+      return true;
+    };
+    app.getBadgeCount = () => badgeCount;
   });
 
   /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26554" title="WPB-26554" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26554</a>  [Desktop/QA] Write Notification regression tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is necessary to allow the tests to run in our headless linux CI which doesn't feature the required gnome setup for badge icons to work on linux.