### PR TITLE
Refresh About dialog versions without restarting desktop [WPB-26554]

### DIFF
--- a/electron/src/preload/menu/preload-about.test.renderer.ts
+++ b/electron/src/preload/menu/preload-about.test.renderer.ts
@@ -44,7 +44,7 @@ describe('loadedAboutScreen', () => {
       webappAVSVersion: '9.0.test',
     });
 
-    assert.ok(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []));
+    assert.strictEqual(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []), true);
     done();
   });
 
@@ -80,8 +80,8 @@ describe('loadedAboutScreen', () => {
       assert.fail('Expected webapp AVS version element to exist');
     }
 
-    assert.equal(webappVersionElement.textContent, '2019.04.10.0902');
-    assert.equal(webappAVSVersionElement.textContent, '');
-    assert.equal(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []), true);
+    assert.strictEqual(webappVersionElement.textContent, '2019.04.10.0902');
+    assert.strictEqual(webappAVSVersionElement.textContent, '');
+    assert.strictEqual(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []), true);
   });
 });

--- a/electron/src/preload/menu/preload-about.test.renderer.ts
+++ b/electron/src/preload/menu/preload-about.test.renderer.ts
@@ -18,15 +18,20 @@
  */
 
 import {ipcRenderer} from 'electron';
-import {spy} from 'sinon';
+import {restore, spy} from 'sinon';
 
 import * as assert from 'assert';
 
-import {loadedAboutScreen} from './preload-about';
+import {loadedAboutScreen, updateAboutScreenVersions} from './preload-about';
 
 import {EVENT_TYPE} from '../../lib/eventType';
 
 describe('loadedAboutScreen', () => {
+  afterEach(() => {
+    restore();
+    document.body.innerHTML = '';
+  });
+
   // eslint-disable-next-line jest/no-done-callback
   it('publishes labels', done => {
     const sendSpy = spy(ipcRenderer, 'send');
@@ -41,5 +46,42 @@ describe('loadedAboutScreen', () => {
 
     assert.ok(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []));
     done();
+  });
+
+  it('updates webapp version values without requesting locales again', () => {
+    const sendSpy = spy(ipcRenderer, 'send');
+    document.body.innerHTML = `
+      <span id="webappVersion"></span>
+      <span id="webappAVSVersion">stale-avs-version</span>
+    `;
+
+    loadedAboutScreen(null, {
+      copyright: '&copy; Wire Swiss GmbH',
+      electronVersion: 'Development',
+      productName: 'Wire',
+      webappVersion: '2019.04.10.0901',
+      webappAVSVersion: '9.0.test',
+    });
+    updateAboutScreenVersions(null, {
+      copyright: '&copy; Wire Swiss GmbH',
+      electronVersion: 'Development',
+      productName: 'Wire',
+      webappVersion: '2019.04.10.0902',
+    });
+
+    const webappVersionElement = document.getElementById('webappVersion');
+    const webappAVSVersionElement = document.getElementById('webappAVSVersion');
+
+    if (webappVersionElement === null) {
+      assert.fail('Expected webapp version element to exist');
+    }
+
+    if (webappAVSVersionElement === null) {
+      assert.fail('Expected webapp AVS version element to exist');
+    }
+
+    assert.equal(webappVersionElement.textContent, '2019.04.10.0902');
+    assert.equal(webappAVSVersionElement.textContent, '');
+    assert.equal(sendSpy.calledOnceWith(EVENT_TYPE.ABOUT.LOCALE_VALUES, []), true);
   });
 });

--- a/electron/src/preload/menu/preload-about.ts
+++ b/electron/src/preload/menu/preload-about.ts
@@ -23,14 +23,14 @@ import {EVENT_TYPE} from '../../lib/eventType';
 
 ipcRenderer.once(EVENT_TYPE.ABOUT.LOCALE_RENDER, (_event, labels: Record<string, string>) => {
   for (const [labelName, labelText] of Object.entries(labels)) {
-    if (labelName === 'aboutReleasesUrl' || labelName === 'aboutUpdatesUrl') {
+    if (['aboutReleasesUrl', 'aboutUpdatesUrl'].includes(labelName)) {
       const labelElement = document.querySelector(`[data-href="${labelName}"]`);
-      if (labelElement) {
+      if (labelElement !== null) {
         (labelElement as HTMLAnchorElement).href = labelText;
       }
     } else {
       const labelElement = document.querySelector(`[data-string="${labelName}"]`);
-      if (labelElement) {
+      if (labelElement !== null) {
         (labelElement as HTMLDivElement).textContent = labelText;
       }
     }
@@ -45,36 +45,38 @@ interface Details {
   webappAVSVersion?: string;
 }
 
+function renderWebappVersions(details: Pick<Details, 'webappVersion' | 'webappAVSVersion'>): void {
+  const webappVersionElement = document.getElementById('webappVersion');
+  if (webappVersionElement !== null) {
+    webappVersionElement.textContent = details.webappVersion;
+  }
+
+  const webappAVSVersionElement = document.getElementById('webappAVSVersion');
+  if (webappAVSVersionElement !== null) {
+    webappAVSVersionElement.textContent = details.webappAVSVersion !== undefined ? details.webappAVSVersion : '';
+  }
+}
+
 export function loadedAboutScreen(_event: unknown, details: Details): void {
   const nameElement = document.getElementById('name');
-  if (nameElement) {
+  if (nameElement !== null) {
     nameElement.textContent = details.productName;
   }
 
   const versionElement = document.getElementById('version');
-  if (versionElement) {
+  if (versionElement !== null) {
     versionElement.textContent = details.electronVersion;
   }
 
-  const webappVersionElement = document.getElementById('webappVersion');
-  if (webappVersionElement) {
-    webappVersionElement.textContent = details.webappVersion;
-  }
-
-  if (details.webappAVSVersion) {
-    const webappAVSVersionElement = document.getElementById('webappAVSVersion');
-    if (webappAVSVersionElement) {
-      webappAVSVersionElement.textContent = details.webappAVSVersion;
-    }
-  }
+  renderWebappVersions(details);
 
   const copyrightElement = document.getElementById('copyright');
-  if (copyrightElement) {
+  if (copyrightElement !== null) {
     copyrightElement.textContent = details.copyright;
   }
 
-  const logoElement = document.getElementById('logo') as HTMLImageElement;
-  if (logoElement) {
+  const logoElement = document.getElementById('logo');
+  if (logoElement instanceof HTMLImageElement) {
     logoElement.src = '../img/logo.256.png';
   }
 
@@ -84,7 +86,7 @@ export function loadedAboutScreen(_event: unknown, details: Details): void {
 
   for (const index in dataStrings) {
     const label = dataStrings[index];
-    if (label.dataset) {
+    if (label.dataset !== undefined) {
       labels.push(label.dataset.string);
     }
   }
@@ -92,4 +94,9 @@ export function loadedAboutScreen(_event: unknown, details: Details): void {
   ipcRenderer.send(EVENT_TYPE.ABOUT.LOCALE_VALUES, labels);
 }
 
+export function updateAboutScreenVersions(_event: unknown, details: Details): void {
+  renderWebappVersions(details);
+}
+
 ipcRenderer.once(EVENT_TYPE.ABOUT.LOADED, loadedAboutScreen);
+ipcRenderer.on(EVENT_TYPE.ABOUT.LOADED, updateAboutScreenVersions);

--- a/electron/src/preload/menu/preload-about.ts
+++ b/electron/src/preload/menu/preload-about.ts
@@ -53,7 +53,7 @@ function renderWebappVersions(details: Pick<Details, 'webappVersion' | 'webappAV
 
   const webappAVSVersionElement = document.getElementById('webappAVSVersion');
   if (webappAVSVersionElement !== null) {
-    webappAVSVersionElement.textContent = details.webappAVSVersion !== undefined ? details.webappAVSVersion : '';
+    webappAVSVersionElement.textContent = details.webappAVSVersion ?? '';
   }
 }
 

--- a/electron/src/preload/menu/preload-about.ts
+++ b/electron/src/preload/menu/preload-about.ts
@@ -81,13 +81,13 @@ export function loadedAboutScreen(_event: unknown, details: Details): void {
   }
 
   // Get locales
-  const labels = [];
+  const labels: string[] = [];
   const dataStrings = document.querySelectorAll<HTMLDivElement>('[data-string]');
 
-  for (const index in dataStrings) {
-    const label = dataStrings[index];
-    if (label.dataset !== undefined) {
-      labels.push(label.dataset.string);
+  for (const label of Array.from(dataStrings)) {
+    const localeLabel = label.dataset.string;
+    if (localeLabel !== undefined) {
+      labels.push(localeLabel);
     }
   }
 

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -105,7 +105,7 @@ function requestActiveWebappVersions(): Promise<WebappVersions> {
         return;
       }
 
-      webappVersion = requestedVersion !== undefined ? requestedVersion : webappVersion;
+      webappVersion = requestedVersion ?? webappVersion;
       webappAVSVersion = requestedAVSVersion;
       resolve({webappVersion, webappAVSVersion});
     }

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -72,11 +72,11 @@ function getCachedWebappVersions(): WebappVersions {
   return {webappVersion, webappAVSVersion};
 }
 
-async function requestActiveWebappVersions(): Promise<WebappVersions> {
+function requestActiveWebappVersions(): Promise<WebappVersions> {
   const primaryWindow = WindowManager.getPrimaryWindow();
 
   if (primaryWindow === undefined) {
-    return getCachedWebappVersions();
+    return Promise.resolve(getCachedWebappVersions());
   }
 
   return new Promise(resolve => {
@@ -148,18 +148,21 @@ function renderAboutWindow(activeWebappVersions: WebappVersions): void {
 }
 
 ipcMain.on(EVENT_TYPE.ABOUT.LOCALE_VALUES, (event, labels: locale.i18nLanguageIdentifier[]) => {
-  if (aboutWindow !== undefined) {
-    const isExpected = event.sender.id === aboutWindow.webContents.id;
-    if (isExpected === true) {
-      const localeValues: Record<string, string> = {};
-      labels.forEach(label => {
-        localeValues[label] = locale.getText(label);
-      });
-      localeValues.aboutReleasesUrl = config.aboutReleasesUrl;
-      localeValues.aboutUpdatesUrl = config.aboutUpdatesUrl;
-      event.reply(EVENT_TYPE.ABOUT.LOCALE_RENDER, localeValues);
-    }
+  if (aboutWindow === undefined) {
+    return;
   }
+
+  if (event.sender.id !== aboutWindow.webContents.id) {
+    return;
+  }
+
+  const localeValues: Record<string, string> = {};
+  labels.forEach(label => {
+    localeValues[label] = locale.getText(label);
+  });
+  localeValues.aboutReleasesUrl = config.aboutReleasesUrl;
+  localeValues.aboutUpdatesUrl = config.aboutUpdatesUrl;
+  event.reply(EVENT_TYPE.ABOUT.LOCALE_RENDER, localeValues);
 });
 
 async function showWindow() {

--- a/electron/src/window/AboutWindow.ts
+++ b/electron/src/window/AboutWindow.ts
@@ -31,6 +31,7 @@ import * as WindowUtil from '../window/WindowUtil';
 
 let webappVersion = '';
 let webappAVSVersion: string | undefined;
+let aboutWindow: BrowserWindow | undefined;
 
 const VERSION_REQUEST_TIMEOUT_MS = 1500;
 const AVS_VERSION_GRACE_PERIOD_MS = 50;
@@ -62,61 +63,109 @@ ipcMain.on(EVENT_TYPE.UI.WEBAPP_AVS_VERSION, (_event, version: string) => {
   webappAVSVersion = version;
 });
 
-const requestActiveWebappVersions = async (): Promise<{webappVersion: string; webappAVSVersion?: string}> => {
+interface WebappVersions {
+  webappVersion: string;
+  webappAVSVersion?: string;
+}
+
+function getCachedWebappVersions(): WebappVersions {
+  return {webappVersion, webappAVSVersion};
+}
+
+async function requestActiveWebappVersions(): Promise<WebappVersions> {
   const primaryWindow = WindowManager.getPrimaryWindow();
 
-  if (!primaryWindow) {
-    return {webappVersion, webappAVSVersion};
+  if (primaryWindow === undefined) {
+    return getCachedWebappVersions();
   }
 
   return new Promise(resolve => {
-    let requestedVersion = webappVersion;
-    let requestedAVSVersion = webappAVSVersion;
+    let requestedVersion: string | undefined;
+    let requestedAVSVersion: string | undefined;
     let hasResolved = false;
+    let hasReceivedVersion = false;
     let gracePeriodId: ReturnType<typeof setTimeout> | undefined;
 
-    const resolveWithValues = () => {
-      if (hasResolved) {
+    function resolveWithValues(): void {
+      if (hasResolved === true) {
         return;
       }
       hasResolved = true;
-      if (timeoutId) {
+      if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
       }
-      if (gracePeriodId) {
+      if (gracePeriodId !== undefined) {
         clearTimeout(gracePeriodId);
       }
       ipcMain.removeListener(EVENT_TYPE.UI.WEBAPP_VERSION, onVersion);
       ipcMain.removeListener(EVENT_TYPE.UI.WEBAPP_AVS_VERSION, onAVSVersion);
-      resolve({webappVersion: requestedVersion, webappAVSVersion: requestedAVSVersion});
-    };
 
-    const onVersion = (_event: Electron.IpcMainEvent, version: string) => {
+      if (hasReceivedVersion === false) {
+        resolve(getCachedWebappVersions());
+        return;
+      }
+
+      webappVersion = requestedVersion !== undefined ? requestedVersion : webappVersion;
+      webappAVSVersion = requestedAVSVersion;
+      resolve({webappVersion, webappAVSVersion});
+    }
+
+    function onVersion(_event: Electron.IpcMainEvent, version: string): void {
+      hasReceivedVersion = true;
       requestedVersion = version;
-      if (gracePeriodId) {
+      requestedAVSVersion = undefined;
+      if (gracePeriodId !== undefined) {
         clearTimeout(gracePeriodId);
       }
       // Wait briefly for optional AVS version that can arrive right after main version.
       gracePeriodId = setTimeout(resolveWithValues, AVS_VERSION_GRACE_PERIOD_MS);
-    };
+    }
 
-    const onAVSVersion = (_event: Electron.IpcMainEvent, version: string) => {
+    function onAVSVersion(_event: Electron.IpcMainEvent, version: string): void {
       requestedAVSVersion = version;
       resolveWithValues();
-    };
+    }
 
     ipcMain.on(EVENT_TYPE.UI.WEBAPP_VERSION, onVersion);
     ipcMain.on(EVENT_TYPE.UI.WEBAPP_AVS_VERSION, onAVSVersion);
     const timeoutId = setTimeout(resolveWithValues, VERSION_REQUEST_TIMEOUT_MS);
     primaryWindow.webContents.send(EVENT_TYPE.UI.REQUEST_WEBAPP_VERSION);
   });
-};
+}
 
-const showWindow = async () => {
-  let aboutWindow: BrowserWindow | undefined;
+function renderAboutWindow(activeWebappVersions: WebappVersions): void {
+  if (aboutWindow === undefined) {
+    return;
+  }
+
+  aboutWindow.webContents.send(EVENT_TYPE.ABOUT.LOADED, {
+    copyright: config.copyright,
+    electronVersion: config.version,
+    productName: config.name,
+    webappVersion: activeWebappVersions.webappVersion,
+    webappAVSVersion: activeWebappVersions.webappAVSVersion,
+  });
+}
+
+ipcMain.on(EVENT_TYPE.ABOUT.LOCALE_VALUES, (event, labels: locale.i18nLanguageIdentifier[]) => {
+  if (aboutWindow !== undefined) {
+    const isExpected = event.sender.id === aboutWindow.webContents.id;
+    if (isExpected === true) {
+      const localeValues: Record<string, string> = {};
+      labels.forEach(label => {
+        localeValues[label] = locale.getText(label);
+      });
+      localeValues.aboutReleasesUrl = config.aboutReleasesUrl;
+      localeValues.aboutUpdatesUrl = config.aboutUpdatesUrl;
+      event.reply(EVENT_TYPE.ABOUT.LOCALE_RENDER, localeValues);
+    }
+  }
+});
+
+async function showWindow() {
   const activeWebappVersions = await requestActiveWebappVersions();
 
-  if (!aboutWindow) {
+  if (aboutWindow === undefined) {
     aboutWindow = new BrowserWindow({
       alwaysOnTop: false,
       backgroundColor: '#ececec',
@@ -159,45 +208,30 @@ const showWindow = async () => {
       return {action: 'deny'};
     });
 
-    // Locales
-    ipcMain.on(EVENT_TYPE.ABOUT.LOCALE_VALUES, (event, labels: locale.i18nLanguageIdentifier[]) => {
-      if (aboutWindow) {
-        const isExpected = event.sender.id === aboutWindow.webContents.id;
-        if (isExpected) {
-          const localeValues: Record<string, string> = {};
-          labels.forEach(label => (localeValues[label] = locale.getText(label)));
-          localeValues.aboutReleasesUrl = config.aboutReleasesUrl;
-          localeValues.aboutUpdatesUrl = config.aboutUpdatesUrl;
-          event.reply(EVENT_TYPE.ABOUT.LOCALE_RENDER, localeValues);
-        }
-      }
-    });
-
     // Close window via escape
     aboutWindow.webContents.on('before-input-event', (_event, input) => {
-      if (input.type === 'keyDown' && input.key === 'Escape') {
-        if (aboutWindow) {
-          aboutWindow.close();
-        }
+      if (input.type !== 'keyDown') {
+        return;
+      }
+
+      if (input.key !== 'Escape') {
+        return;
+      }
+
+      if (aboutWindow !== undefined) {
+        aboutWindow.close();
       }
     });
 
-    aboutWindow.on('closed', () => (aboutWindow = undefined));
+    aboutWindow.on('closed', () => {
+      aboutWindow = undefined;
+    });
 
     await aboutWindow.loadURL(ABOUT_HTML);
-
-    if (aboutWindow) {
-      aboutWindow.webContents.send(EVENT_TYPE.ABOUT.LOADED, {
-        copyright: config.copyright,
-        electronVersion: config.version,
-        productName: config.name,
-        webappVersion: activeWebappVersions.webappVersion,
-        webappAVSVersion: activeWebappVersions.webappAVSVersion,
-      });
-    }
   }
 
+  renderAboutWindow(activeWebappVersions);
   aboutWindow.show();
-};
+}
 
 export const AboutWindow = {showWindow};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26554" title="WPB-26554" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26554</a>  [Desktop/QA] Write Notification regression tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

This updates the About dialog so that it requests the currently loaded webapp and AVS versions from the active webview before rendering the dialog.

The previously known values are still kept as a fallback, so the dialog can continue to open even when no webview is available, the webview is not ready, or the version request times out.

## Why

The About dialog could show stale version information after the webapp was updated or reloaded inside the desktop wrapper. The values only became correct after restarting the whole Electron process.

That is confusing for internal builds, because `WireInternal -> About WireInternal` should describe the currently running webapp, not the version that was active when the desktop process started.

## Notes

This only affects the displayed webapp and AVS versions in the About dialog.
It does not change the desktop app version or the update flow itself.