### PR TITLE
Allow E2E tests to be triggered for PRs with label "run-e2e" [WPB-22420]

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,9 @@
 name: E2E Tests
 
 on:
+  # This Workflow can be run by labelling a PR with "run-e2e", in this case reporting is skipped.
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
     # Execute workflow every night throughout the week
@@ -10,6 +13,7 @@ jobs:
   run_tests:
     name: Run E2E Tests
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
 
     steps:
       - name: Checkout
@@ -91,6 +95,7 @@ jobs:
           echo "report_message=$MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Upload report to Testiny
+        if: ${{ github.event_name != 'pull_request' }}
         continue-on-error: true
         env:
           TESTINY_API_KEY: ${{ secrets.TESTINY_API_KEY }}
@@ -107,7 +112,7 @@ jobs:
           --reportPath="./playwright-report/report.json"
 
       - name: Notify on Wire about failed tests
-        if: ${{ !cancelled() && steps.generate-description.outputs.failed_tests > 0 }}
+        if: ${{ github.event_name != 'pull_request' && !cancelled() && steps.generate-description.outputs.failed_tests > 0 }}
         uses: 8398a7/action-slack@293f8dc0f9731ac35321056641cdef895f4f65f8
         continue-on-error: true
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,6 +9,10 @@ on:
     # Execute workflow every night throughout the week
     - cron: '37 04 * * 1-5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   run_tests:
     name: Run E2E Tests


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR ports the feature from web to the desktop repo. In some cases it's good to have the added safety gained by running the e2e tests before the PR is merged. As the desktop app is built locally and doesn't need a deployment beforehand only the logic for triggering the workflow and skipping reporting in this case is needed.

