### PR TITLE
Prevent Desktop from persisting static asset URLs as WebApp targets [WPB-26939]

### DIFF
--- a/electron/renderer/src/components/WebView/Webview.tsx
+++ b/electron/renderer/src/components/WebView/Webview.tsx
@@ -187,10 +187,14 @@ const Webview = ({
           const [customUrl] = args;
 
           if (isString(customUrl)) {
-            const updatedWebapp = WindowUrl.createWebAppUrl(window.location.toString(), customUrl);
-            updateAccountData(accountId, {
-              webappUrl: updatedWebapp,
-            });
+            try {
+              const updatedWebapp = WindowUrl.createWebAppUrl(window.location.toString(), customUrl);
+              updateAccountData(accountId, {
+                webappUrl: updatedWebapp,
+              });
+            } catch (error) {
+              console.warn(`Ignoring invalid WebApp navigation URL "${customUrl}"`, error);
+            }
           }
           break;
         }

--- a/electron/renderer/src/lib/WindowUrl.ts
+++ b/electron/renderer/src/lib/WindowUrl.ts
@@ -19,10 +19,72 @@
 
 import {wrapperLocale} from './locale';
 
+const staticResourcePathPrefixes = [
+  '/min',
+  '/assets',
+  '/audio',
+  '/ext',
+  '/font',
+  '/image',
+  '/proto',
+  '/style',
+  '/worker',
+];
+
+const staticResourcePathExtensions = [
+  '.js',
+  '.css',
+  '.map',
+  '.wasm',
+  '.mjs',
+  '.json',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.mp3',
+  '.ogg',
+];
+
+export function isAllowedWebAppNavigationUrl(url: URL): boolean {
+  const pathname = url.pathname.toLowerCase();
+  const hasStaticResourcePrefix = staticResourcePathPrefixes.some(
+    pathPrefix => pathname === pathPrefix || pathname.startsWith(`${pathPrefix}/`),
+  );
+
+  if (hasStaticResourcePrefix) {
+    return false;
+  }
+
+  if (pathname === '/sw.js') {
+    return false;
+  }
+
+  const hasStaticResourceExtension = staticResourcePathExtensions.some(extension => pathname.endsWith(extension));
+
+  if (hasStaticResourceExtension) {
+    return false;
+  }
+
+  return true;
+}
+
 export class WindowUrl {
-  static createWebAppUrl(localRendererUrl: URL | string, customBackendUrl: string) {
+  static createWebAppUrl(localRendererUrl: URL | string, customBackendUrl: string): string {
     const localFileParams = new URL(localRendererUrl).searchParams;
     const customBackendUrlParsed = new URL(customBackendUrl);
+
+    if (!isAllowedWebAppNavigationUrl(customBackendUrlParsed)) {
+      throw new Error(
+        `Invalid WebApp URL: static resource URLs cannot be used as WebApp navigation URLs (${customBackendUrlParsed.href})`,
+      );
+    }
+
     const envUrl = decodeURIComponent(localFileParams.get('env')!);
     const envUrlParams = new URL(envUrl).searchParams;
 

--- a/electron/renderer/src/lib/__tests__/WindowUrl.spec.ts
+++ b/electron/renderer/src/lib/__tests__/WindowUrl.spec.ts
@@ -20,7 +20,7 @@
 import {WindowUrl} from '../WindowUrl';
 
 describe('WindowUrl', () => {
-  describe('createWebappUrl', () => {
+  describe('createWebAppUrl', () => {
     it('creates a custom environment WebApp URL based on parameters from an existing renderer page', () => {
       const rendererPage =
         'file:///D:/dev/projects/wireapp/wire-desktop/electron/renderer/index.html?env=https%3A%2F%2Fwire-webapp-dev.zinfra.io%3Fhl%3Den%26enableLogging%3D%40wireapp%2F*';
@@ -34,10 +34,23 @@ describe('WindowUrl', () => {
       const rendererPage = 'file:///D:/dev/projects/wireapp/wire-desktop/electron/renderer/index.html?env=undefined';
       const customWebApp = 'https://webapp.qa-demo.wire.link?clienttype=permanent';
 
-      try {
-        const url = WindowUrl.createWebAppUrl(rendererPage, customWebApp);
-        expect(url).toBe('Invalid URL: undefined');
-      } catch (error) {}
+      expect(() => WindowUrl.createWebAppUrl(rendererPage, customWebApp)).toThrow();
+    });
+
+    it.each([
+      'https://example.com/min/app.js',
+      'https://example.com/min/vendor.js',
+      'https://example.com/assets/foo.png',
+      'https://example.com/style/app.css',
+      'https://example.com/sw.js',
+      'https://example.com/downloads/app.js',
+    ])('rejects static resource WebApp URLs: %s', customWebApp => {
+      const rendererPage =
+        'file:///D:/dev/projects/wireapp/wire-desktop/electron/renderer/index.html?env=https%3A%2F%2Fwire-webapp-dev.zinfra.io%3Fhl%3Den%26enableLogging%3D%40wireapp%2F*';
+
+      expect(() => WindowUrl.createWebAppUrl(rendererPage, customWebApp)).toThrow(
+        'Invalid WebApp URL: static resource URLs cannot be used as WebApp navigation URLs',
+      );
     });
   });
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26939" title="WPB-26939" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26939</a>  [Web] Prevent Desktop from persisting invalid WebApp asset URLs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

This makes the Desktop wrapper more defensive when the WebApp asks it to navigate to another WebApp URL.

`WindowUrl.createWebAppUrl()` now rejects URLs that clearly point to static assets, for example `/min/*`, `/assets/*`, `/style/*`, `/sw.js`, or files ending in `.js`, `.css`, `.map`, `.wasm`, images, fonts, and similar asset extensions.

The `NAVIGATE_WEBVIEW` handler now catches invalid navigation URLs, logs a warning, and does not persist them as `account.webappUrl`.

## Why

We saw cases where the Desktop wrapper could end up rendering raw minified JavaScript in the main window after an update/restart:

<img width="1292" height="142" alt="Screenshot 2026-07-04 at 11 24 25" src="https://github.com/user-attachments/assets/205df4ba-212f-496e-8419-9e72f30d7a2b" />

The likely cause is that an invalid static asset URL was persisted as the account WebApp URL. Once stored, the wrapper reused that URL on the next startup and loaded the asset directly in the webview.

This pull request prevents new invalid WebApp URLs from being persisted.

## Not included

This does not clean up already persisted bad `webappUrl` values. It only prevents writing new invalid state.

A follow-up can add a small startup cleanup or migration if we confirm that users already have broken persisted state.