### PR TITLE
test: write calling regression tests [WPB-26928]

### DIFF
--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -26,7 +26,12 @@ export type App = ElectronApplication & {
   page: Page;
 };
 
-export const createApp = async (options: {env?: string; lang?: string; dataDir: string}): Promise<App> => {
+export const createApp = async (options: {
+  env?: string;
+  lang?: string;
+  dataDir: string;
+  bypassPermissions?: boolean;
+}): Promise<App> => {
   if (!options.env) {
     throw new Error(`Can't create app without environment, make sure the env var "WEBAPP_URL" is set`);
   }
@@ -35,9 +40,10 @@ export const createApp = async (options: {env?: string; lang?: string; dataDir: 
     args: [
       // Chromium launch args
       `--user-data-dir=${options.dataDir}`,
-      '--use-fake-device-for-media-stream', // Provide fake devices for audio & video device input
-      '--use-fake-ui-for-media-stream', // Bypasses the popup to grant permission and select video / audio input device by automatically selecting the default one
       '--mute-audio', // Mute all audio output from the test browser because e.g. the ringtone of a call can be annoying during testing
+      ...(options.bypassPermissions ?? true
+        ? ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream']
+        : []), // Provide fake devices for audio & video device input and bypasses the popup to grant permission and select video / audio input device by automatically selecting the default one
       '.',
       // Wire specific cli flags to set during launch
       `--env=${options.env}`,

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -32,7 +32,7 @@ import {PublicApiClient, RegisteredUser, TeamOwner} from './backend/PublicApiCli
 
 export type TestOptions = {
   os: 'windows' | 'macOS';
-  appOptions: {env?: string; lang?: string};
+  appOptions: {env?: string; lang?: string; bypassPermissions?: boolean};
 };
 
 type Fixtures = {

--- a/e2e-tests/poms/webapp/callCell.page.ts
+++ b/e2e-tests/poms/webapp/callCell.page.ts
@@ -26,5 +26,6 @@ export const callCell = (page: Page) => {
     acceptCallButton: callCell.getByRole('button', {name: 'Accept'}),
     declineButton: callCell.getByRole('button', {name: 'Hang up'}),
     goFullScreen: page.locator('[data-uie-name="do-maximize-call"]'),
+    openInNewWindow: page.getByRole('button', {name: 'Open in a new window'}),
   });
 };

--- a/e2e-tests/specs/regression/calling.spec.ts
+++ b/e2e-tests/specs/regression/calling.spec.ts
@@ -25,7 +25,7 @@ import {callCell} from '../../poms/webapp/callCell.page';
 import {conversation} from '../../poms/webapp/conversation.page';
 import {conversationsList} from '../../poms/webapp/conversationList.page';
 
-test.describe('Calling', () => {
+test.describe('Calling - Feature Functionality', () => {
   test(
     'Verify call window maximization in 1:1 and the group call',
     {tag: ['@TC-11291', '@regression']},
@@ -66,6 +66,39 @@ test.describe('Calling', () => {
           await fullscreenWindow.getByRole('button', {name: 'Hang up'}).click();
         });
       }
+    },
+  );
+});
+
+test.describe('Calling - Negative Scenarios / Permissions', () => {
+  test.use({
+    appOptions: async ({appOptions}, use) => {
+      await use({
+        ...appOptions,
+        bypassPermissions: false,
+      });
+    },
+  });
+
+  test(
+    'Verify call establishment fails without required permissions',
+    {tag: ['@TC-11297', '@regression']},
+    async ({app, createUser, createTeam, createPage}) => {
+      const userB = await createUser();
+      const {owner: userA} = await createTeam('Test Team', {
+        users: [userB],
+      });
+      const userAPage = app.page;
+      const userBPage = await createPage();
+
+      await Promise.all([loginUser(userAPage, userA), loginUser(userBPage, userB)]);
+      await connectWithUser(userAPage, userB);
+
+      await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
+      await conversation(userAPage).startCallButton.click();
+
+      await expect(app.page.getByText('No camera access')).toBeVisible();
+      await expect(conversation(userAPage).systemMessages.filter({hasText: 'You called'})).toBeVisible();
     },
   );
 });

--- a/e2e-tests/specs/regression/calling.spec.ts
+++ b/e2e-tests/specs/regression/calling.spec.ts
@@ -98,7 +98,6 @@ test.describe('Calling - Negative Scenarios / Permissions', () => {
       await conversation(userAPage).startCallButton.click();
 
       await expect(app.page.getByText('No camera access')).toBeVisible();
-      await expect(conversation(userAPage).systemMessages.filter({hasText: 'You called'})).toBeVisible();
     },
   );
 });

--- a/e2e-tests/specs/regression/calling.spec.ts
+++ b/e2e-tests/specs/regression/calling.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {connectWithUser} from '../../actions/connectWithUser';
+import {createGroup} from '../../actions/createGroup';
+import {loginUser} from '../../actions/loginUser';
+import {test, expect} from '../../fixtures';
+import {callCell} from '../../poms/webapp/callCell.page';
+import {conversation} from '../../poms/webapp/conversation.page';
+import {conversationsList} from '../../poms/webapp/conversationList.page';
+
+test.describe('Calling', () => {
+  test(
+    'Verify call window maximization in 1:1 and the group call',
+    {tag: ['@TC-11291', '@regression']},
+    async ({app, createUser, createTeam, createPage}) => {
+      const userB = await createUser();
+      const {owner: userA} = await createTeam('Test Team', {
+        users: [userB],
+        features: {conferenceCalling: true},
+      });
+      const userAPage = app.page;
+      const userBPage = await createPage();
+
+      await Promise.all([loginUser(userAPage, userA), loginUser(userBPage, userB)]);
+      await connectWithUser(userAPage, userB);
+
+      for (const callType of ['1:1', 'Group']) {
+        if (callType === 'Group') {
+          await createGroup(userAPage, 'Calling Group', [userB]);
+          await conversationsList(userAPage).getConversation('Calling Group').open();
+        } else {
+          await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
+        }
+
+        await test.step(`User A initiates a ${callType} call with user B`, async () => {
+          await conversation(userAPage).startCallButton.click();
+          await expect(callCell(userAPage)).toBeVisible();
+
+          await expect(callCell(userBPage)).toBeVisible();
+          await callCell(userBPage).acceptCallButton.click();
+        });
+
+        await test.step('User A can maximized the call with user B', async () => {
+          const newWindowPromise = app.waitForEvent('window');
+          await callCell(userAPage).openInNewWindow.click();
+          const fullscreenWindow = await newWindowPromise;
+
+          await expect(fullscreenWindow.getByRole('switch', {name: 'Camera'})).toBeVisible();
+          await fullscreenWindow.getByRole('button', {name: 'Hang up'}).click();
+        });
+      }
+    },
+  );
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26928" title="WPB-26928" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26928</a>  [Desktop/QA] Write calling regression tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR introduces two new test cases to verify core functionality and error handling for the calling feature.

TC-11291: Verify call window maximization in 1:1 and group calls
Ensures that the call window correctly expands to full screen/maximized state during both one-on-one and group calling scenarios.

TC-11297: Verify call establishment fails without required permissions
Validates the application's error handling and permission guardrails, ensuring a call cannot be initiated if camera/microphone permissions are denied.