### PR TITLE
test: add localization regression tests [WPB-26736]

### DIFF
--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -75,6 +75,7 @@ export const createApp = async (options: {
      */
     reopen: async () => {
       await app.close();
+      await new Promise(res => setTimeout(res, 3_000)); // Add a small delay so the process can fully close
 
       // During the re-launch the old instance of the app is closed. However the fixture is still pointing to it, so we set its close function to now close the relaunched instance.
       // This way it's ensured that even after relaunch(es) the app will always be cleaned up.

--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -74,8 +74,9 @@ export const createApp = async (options: {
      * @returns {App} app
      */
     reopen: async () => {
+      const closePromise = app.waitForEvent('close');
       await app.close();
-      await new Promise(res => setTimeout(res, 3_000)); // Add a small delay so the process can fully close
+      await closePromise; // Wait until the app is fully closed before continuing
 
       // During the re-launch the old instance of the app is closed. However the fixture is still pointing to it, so we set its close function to now close the relaunched instance.
       // This way it's ensured that even after relaunch(es) the app will always be cleaned up.

--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -48,7 +48,10 @@ export const createApp = async (options: {
 
   // Forward all logs from the electron apps main thread to the terminal
   app.on('console', async msg => {
-    const args = await Promise.all(msg.args().map(arg => arg.jsonValue()));
+    const args = (await Promise.allSettled(msg.args().map(arg => arg.jsonValue())))
+      .filter(result => result.status === 'fulfilled')
+      .map(arg => arg.value);
+
     // eslint-disable-next-line no-console
     console.log(...args);
   });

--- a/e2e-tests/actions/createApp.ts
+++ b/e2e-tests/actions/createApp.ts
@@ -17,21 +17,16 @@
  *
  */
 
-import {_electron as electron, ElectronApplication, Page} from '@playwright/test';
+import {_electron as electron} from '@playwright/test';
 
-export type App = ElectronApplication & {
-  /* The playwright page for the main electron window wrapping the webapp */
-  wrapper: Page;
-  /* The playwright page for the currently shown webapp */
-  page: Page;
-};
+export type App = Awaited<ReturnType<typeof createApp>>;
 
 export const createApp = async (options: {
   env?: string;
   lang?: string;
   dataDir: string;
   bypassPermissions?: boolean;
-}): Promise<App> => {
+}) => {
   if (!options.env) {
     throw new Error(`Can't create app without environment, make sure the env var "WEBAPP_URL" is set`);
   }
@@ -65,5 +60,25 @@ export const createApp = async (options: {
   const wrapper = await app.waitForEvent('window');
   const page = await app.waitForEvent('window');
 
-  return Object.assign(app, {wrapper, page});
+  return Object.assign(app, {
+    /* The playwright page for the main electron window wrapping the webapp */
+    wrapper,
+    /* The playwright page for the currently shown webapp */
+    page,
+    /**
+     * Utility function to re-open the application re-using the existing storage state
+     * **Important:** the existing app won't be updated by this, instead the variable needs to be re-assigned
+     * @returns {App} app
+     */
+    reopen: async () => {
+      await app.close();
+
+      // During the re-launch the old instance of the app is closed. However the fixture is still pointing to it, so we set its close function to now close the relaunched instance.
+      // This way it's ensured that even after relaunch(es) the app will always be cleaned up.
+      const relaunchedApp = await createApp(options);
+      app.close = relaunchedApp.close;
+
+      return relaunchedApp;
+    },
+  });
 };

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -101,7 +101,7 @@ export const test = baseTest.extend<TestOptions & Fixtures>({
     }
 
     await app.close();
-    await fs.rm(tempUserDataDir, {recursive: true, maxRetries: 3, retryDelay: 1_000});
+    await fs.rm(tempUserDataDir, {recursive: true, force: true, maxRetries: 3, retryDelay: 1_000});
   },
 
   createUser: async ({publicApi, brigApi}, use) => {

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -101,7 +101,7 @@ export const test = baseTest.extend<TestOptions & Fixtures>({
     }
 
     await app.close();
-    await fs.rm(tempUserDataDir, {recursive: true});
+    await fs.rm(tempUserDataDir, {recursive: true, maxRetries: 3, retryDelay: 1_000});
   },
 
   createUser: async ({publicApi, brigApi}, use) => {

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -100,8 +100,11 @@ export const test = baseTest.extend<TestOptions & Fixtures>({
       await testInfo.attach('app-trace.zip', {path: tracePath});
     }
 
-    await app.close();
-    await fs.rm(tempUserDataDir, {recursive: true, force: true, maxRetries: 3, retryDelay: 1_000});
+    // This block is to clean up the data stored in the temp dir, it's optional and e.g. windows file locking should not cause the test to fail
+    try {
+      await app.close();
+      await fs.rm(tempUserDataDir, {recursive: true, force: true, maxRetries: 3, retryDelay: 1_000});
+    } catch {}
   },
 
   createUser: async ({publicApi, brigApi}, use) => {

--- a/e2e-tests/poms/app/menuBar.page.ts
+++ b/e2e-tests/poms/app/menuBar.page.ts
@@ -25,15 +25,14 @@ export const menuBar = (app: App) => {
   // eslint-disable-next-line valid-jsdoc
   /**
    * Triggers an Electron application menu item by matching its label.
-   * Supports cross-platform variants by accepting either a single string or an array of strings.
-   * @param {string[]} labels - The menu label(s) to match against (e.g., 'Settings' or ['Preferences', 'Settings'])
+   * @param {string} label - The menu label to match against (e.g., 'Settings')
    * @returns A Promise resolving to the serialized accelerator string of the clicked MenuItem
    */
-  const triggerApplicationMenu = async (labels: string[]): Promise<Pick<MenuItem, 'accelerator'>> => {
-    return await app.evaluate(async ({Menu, BrowserWindow}, targets) => {
+  const triggerApplicationMenu = async (label: string): Promise<Pick<MenuItem, 'accelerator'>> => {
+    return await app.evaluate(async ({Menu, BrowserWindow}, label) => {
       const menu = Menu.getApplicationMenu();
 
-      const target = menu?.items.flatMap(item => item.submenu?.items ?? []).find(item => targets.includes(item.label));
+      const target = menu?.items.flatMap(item => item.submenu?.items ?? []).find(item => label === item.label);
 
       if (!target) {
         throw new Error('Menu item not found');
@@ -49,7 +48,7 @@ export const menuBar = (app: App) => {
       return {
         accelerator: target.accelerator,
       };
-    }, labels);
+    }, label);
   };
 
   return {triggerApplicationMenu};

--- a/e2e-tests/poms/app/menuBar.page.ts
+++ b/e2e-tests/poms/app/menuBar.page.ts
@@ -22,6 +22,43 @@ import type {MenuItem} from 'electron';
 import type {App} from '../../actions/createApp';
 
 export const menuBar = (app: App) => {
+  /* Get the current lange set in the apps menu bar */
+  const getCurrentLanguage = async () => {
+    return await app.evaluate(async ({Menu}) => {
+      const menu = Menu.getApplicationMenu();
+      const languageItem = menu?.items
+        .flatMap(item => item.submenu?.items ?? [])
+        .find(item => ['Language', 'Sprache'].includes(item.label));
+
+      if (!languageItem) {
+        throw new Error('Language menu item not found');
+      }
+
+      return languageItem.submenu?.items.find(item => item.checked === true)?.label;
+    });
+  };
+
+  /* Change the language of the app by selecting it from the menu bar */
+  const switchLanguage = async (language: string) => {
+    await app.evaluate(async ({Menu}, language) => {
+      const menu = Menu.getApplicationMenu();
+      const languageItem = menu?.items
+        .flatMap(item => item.submenu?.items ?? [])
+        .find(item => ['Language', 'Sprache'].includes(item.label));
+
+      if (!languageItem) {
+        throw new Error('Language menu item not found');
+      }
+
+      const targetItem = languageItem.submenu?.items.find(item => item.label === language);
+      if (!targetItem) {
+        throw new Error(`Language "${language}" not found in the menu`);
+      }
+
+      targetItem.click();
+    }, language);
+  };
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * Triggers an Electron application menu item by matching its label.
@@ -45,11 +82,9 @@ export const menuBar = (app: App) => {
 
       // Programmatically trigger the menu item's click action
       target.click(target, targetWindow);
-      return {
-        accelerator: target.accelerator,
-      };
+      return target;
     }, label);
   };
 
-  return {triggerApplicationMenu};
+  return {getCurrentLanguage, switchLanguage, triggerApplicationMenu};
 };

--- a/e2e-tests/poms/app/menuBar.page.ts
+++ b/e2e-tests/poms/app/menuBar.page.ts
@@ -65,7 +65,7 @@ export const menuBar = (app: App) => {
    * @param {string} label - The menu label to match against (e.g., 'Settings')
    * @returns A Promise resolving to the serialized accelerator string of the clicked MenuItem
    */
-  const triggerApplicationMenu = async (label: string): Promise<Pick<MenuItem, 'accelerator'>> => {
+  const clickItem = async (label: string): Promise<Pick<MenuItem, 'accelerator'>> => {
     return await app.evaluate(async ({Menu, BrowserWindow}, label) => {
       const menu = Menu.getApplicationMenu();
 
@@ -86,5 +86,5 @@ export const menuBar = (app: App) => {
     }, label);
   };
 
-  return {getCurrentLanguage, switchLanguage, triggerApplicationMenu};
+  return {getCurrentLanguage, switchLanguage, clickItem};
 };

--- a/e2e-tests/poms/app/menuBar.page.ts
+++ b/e2e-tests/poms/app/menuBar.page.ts
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {MenuItem} from 'electron';
+
+import type {App} from '../../actions/createApp';
+
+export const menuBar = (app: App) => {
+  // eslint-disable-next-line valid-jsdoc
+  /**
+   * Triggers an Electron application menu item by matching its label.
+   * Supports cross-platform variants by accepting either a single string or an array of strings.
+   * @param {string[]} labels - The menu label(s) to match against (e.g., 'Settings' or ['Preferences', 'Settings'])
+   * @returns A Promise resolving to the serialized accelerator string of the clicked MenuItem
+   */
+  const triggerApplicationMenu = async (labels: string[]): Promise<Pick<MenuItem, 'accelerator'>> => {
+    return await app.evaluate(async ({Menu, BrowserWindow}, targets) => {
+      const menu = Menu.getApplicationMenu();
+
+      const target = menu?.items.flatMap(item => item.submenu?.items ?? []).find(item => targets.includes(item.label));
+
+      if (!target) {
+        throw new Error('Menu item not found');
+      }
+
+      const targetWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+      if (!targetWindow) {
+        throw new Error('No Electron window found to send the menu event to');
+      }
+
+      // Programmatically trigger the menu item's click action
+      target.click(target, targetWindow);
+      return {
+        accelerator: target.accelerator,
+      };
+    }, labels);
+  };
+
+  return {triggerApplicationMenu};
+};

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -66,7 +66,7 @@ test.describe('Localization', () => {
           const stubMeta = {calls: [] as unknown[]};
           const stubFunction: typeof dialog.showMessageBox = async (...args: unknown[]) => {
             stubMeta.calls.push(args);
-            return {response: 0, checkboxChecked: false}; // Response 0 means button at index one which ignores the reboot as we have to do it manually
+            return {response: 1, checkboxChecked: false}; // Response 0 means button at index one which ignores the reboot as we have to do it manually
           };
 
           // We overload the stub function to add the __mock property to it. This way we can check the arguments it was called with in the next test step

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {MenuItem} from 'electron';
+
+import {type App} from '../../actions/createApp';
+import {loginUser} from '../../actions/loginUser';
+import {expect, test} from '../../fixtures';
+import {ssoPage} from '../../poms/webapp/sso.page';
+
+type MenuItemSnapshot = {
+  label: string;
+  checked?: boolean;
+  enabled?: boolean;
+  type?: string;
+  submenu?: MenuItemSnapshot[];
+};
+
+const normalizeMenuLabel = (label?: string) => (label ?? '').replace(/&/g, '');
+
+const getApplicationMenu = async (app: App): Promise<MenuItemSnapshot[]> =>
+  app.evaluate(({Menu}) => {
+    const serialize = (item: MenuItem): MenuItemSnapshot => ({
+      label: item.label,
+      checked: item.checked,
+      enabled: item.enabled,
+      type: item.type,
+      submenu: item.submenu?.items.map(serialize),
+    });
+
+    return Menu.getApplicationMenu()?.items.map(serialize) ?? [];
+  });
+
+const findMenuItem = (
+  items: MenuItemSnapshot[],
+  predicate: (item: MenuItemSnapshot) => boolean,
+): MenuItemSnapshot | undefined => {
+  for (const item of items) {
+    if (predicate(item)) {
+      return item;
+    }
+
+    if (item.submenu) {
+      const nestedItem = findMenuItem(item.submenu, predicate);
+      if (nestedItem) {
+        return nestedItem;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const expectSelectedMenuLanguage = async (app: App, expectedLanguageLabel: 'English' | 'Deutsch') => {
+  const menu = await getApplicationMenu(app);
+
+  const languageItem = findMenuItem(menu, item => normalizeMenuLabel(item.label) === expectedLanguageLabel);
+
+  expect(languageItem, `Expected language "${expectedLanguageLabel}" to exist in the menu`).toBeTruthy();
+  expect(languageItem?.checked, `Expected language "${expectedLanguageLabel}" to be selected`).toBe(true);
+};
+
+test.describe('Localization', () => {
+  test('I want to verify initial language is EN', {tag: ['@TC-11283', '@regression']}, async ({app, createUser}) => {
+    const user = await createUser();
+
+    await test.step('Go to login screen and verify welcome screen', async () => {
+      await expect(ssoPage(app.page).codeEmailInput).toBeVisible();
+    });
+
+    await test.step('User logs in', async () => {
+      await loginUser(app.page, user);
+    });
+
+    await test.step('Verify English is selected in the menu bar', async () => {
+      await expectSelectedMenuLanguage(app, 'English');
+    });
+
+    await test.step('Verify English "All conversations"', async () => {
+      await expect(app.page.getByText('All conversations')).toBeVisible();
+    });
+  });
+});

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -17,9 +17,13 @@
  *
  */
 
-import {MenuItem} from 'electron';
+import type {MenuItem} from 'electron';
 
-import {type App} from '../../actions/createApp';
+import fs from 'node:fs/promises';
+import nodeOs from 'node:os';
+import path from 'node:path';
+
+import {createApp, type App} from '../../actions/createApp';
 import {loginUser} from '../../actions/loginUser';
 import {expect, test} from '../../fixtures';
 import {ssoPage} from '../../poms/webapp/sso.page';
@@ -32,7 +36,19 @@ type MenuItemSnapshot = {
   submenu?: MenuItemSnapshot[];
 };
 
-const normalizeMenuLabel = (label?: string) => (label ?? '').replace(/&/g, '');
+type RestartDialogSnapshot = {
+  buttons: string[];
+  message: string;
+  title?: string;
+  type?: string;
+};
+
+type ElectronPlatform = 'darwin' | 'win32';
+
+const normalizeMenuLabel = (label?: string): string => (label ?? '').replace(/&/g, '');
+
+const getElectronPlatform = async (app: App): Promise<ElectronPlatform> =>
+  app.evaluate(() => process.platform as ElectronPlatform);
 
 const getApplicationMenu = async (app: App): Promise<MenuItemSnapshot[]> =>
   app.evaluate(({Menu}) => {
@@ -58,6 +74,7 @@ const findMenuItem = (
 
     if (item.submenu) {
       const nestedItem = findMenuItem(item.submenu, predicate);
+
       if (nestedItem) {
         return nestedItem;
       }
@@ -69,11 +86,222 @@ const findMenuItem = (
 
 const expectSelectedMenuLanguage = async (app: App, expectedLanguageLabel: 'English' | 'Deutsch') => {
   const menu = await getApplicationMenu(app);
-
   const languageItem = findMenuItem(menu, item => normalizeMenuLabel(item.label) === expectedLanguageLabel);
 
   expect(languageItem, `Expected language "${expectedLanguageLabel}" to exist in the menu`).toBeTruthy();
   expect(languageItem?.checked, `Expected language "${expectedLanguageLabel}" to be selected`).toBe(true);
+};
+
+/*
+ * Selects a language from Electron's native application menu.
+ */
+const triggerLanguageMenuItem = async (app: App, expectedLanguageLabel: 'English' | 'Deutsch'): Promise<void> => {
+  await app.evaluate(({BrowserWindow, Menu}, languageLabel) => {
+    const normalizeLabel = (label?: string): string => (label ?? '').replace(/&/g, '');
+
+    const isLanguageSubmenu = (items: MenuItem[]): boolean => {
+      const radioLabels = new Set(items.filter(item => item.type === 'radio').map(item => normalizeLabel(item.label)));
+
+      return radioLabels.has('English') && radioLabels.has('Deutsch');
+    };
+
+    const findLanguageItem = (items: MenuItem[]): MenuItem | undefined => {
+      for (const item of items) {
+        const submenuItems = item.submenu?.items ?? [];
+
+        if (isLanguageSubmenu(submenuItems)) {
+          return submenuItems.find(
+            submenuItem => submenuItem.type === 'radio' && normalizeLabel(submenuItem.label) === languageLabel,
+          );
+        }
+
+        const nestedItem = findLanguageItem(submenuItems);
+
+        if (nestedItem) {
+          return nestedItem;
+        }
+      }
+
+      return undefined;
+    };
+
+    const formatMenu = (items: MenuItem[], depth = 0): string[] =>
+      items.flatMap(item => {
+        const prefix = `${'  '.repeat(depth)}- ${normalizeLabel(item.label) || `[${item.type}]`}`;
+        return [prefix, ...formatMenu(item.submenu?.items ?? [], depth + 1)];
+      });
+
+    const applicationMenu = Menu.getApplicationMenu();
+    const menuItems = applicationMenu?.items ?? [];
+    const target = findLanguageItem(menuItems);
+
+    if (!target) {
+      throw new Error(
+        `Language menu item was not found: ${languageLabel}\n` +
+          `Actual application menu:\n${formatMenu(menuItems).join('\n')}`,
+      );
+    }
+
+    if (!target.enabled) {
+      throw new Error(`Language menu item is disabled: ${languageLabel}`);
+    }
+
+    const targetWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+
+    if (!targetWindow) {
+      throw new Error('No Electron window found for the menu event');
+    }
+
+    target.click(target, targetWindow);
+  }, expectedLanguageLabel);
+};
+
+/*
+ * Replaces Electron's native message box with a controllable promise.
+ */
+const installRestartDialogProbe = async (app: App): Promise<void> => {
+  await app.evaluate(({app: electronApp, dialog}) => {
+    type DialogResult = {
+      checkboxChecked: boolean;
+      response: number;
+    };
+
+    type DialogOptions = {
+      buttons?: string[];
+      message: string;
+      title?: string;
+      type?: string;
+    };
+
+    type Probe = {
+      options: {
+        buttons: string[];
+        message: string;
+        title?: string;
+        type?: string;
+      };
+      resolve: (result: DialogResult) => void;
+    };
+
+    const globals = globalThis as typeof globalThis & {
+      __wireRestartDialogProbe?: Probe;
+    };
+
+    if (process.platform === 'win32') {
+      const mutableElectronApp = electronApp as unknown as {
+        relaunch: () => void;
+      };
+
+      mutableElectronApp.relaunch = () => {};
+    }
+
+    const mutableDialog = dialog as unknown as {
+      showMessageBox: (...args: unknown[]) => Promise<DialogResult>;
+    };
+
+    mutableDialog.showMessageBox = (...args: unknown[]) => {
+      const options = (args.length === 1 ? args[0] : args[1]) as DialogOptions;
+
+      return new Promise<DialogResult>(resolve => {
+        globals.__wireRestartDialogProbe = {
+          options: {
+            buttons: [...(options.buttons ?? [])],
+            message: options.message,
+            title: options.title,
+            type: options.type,
+          },
+          resolve,
+        };
+      });
+    };
+  });
+};
+
+const getRestartDialog = async (app: App): Promise<RestartDialogSnapshot> => {
+  await expect
+    .poll(() =>
+      app.evaluate(() => {
+        type Probe = {
+          options: RestartDialogSnapshot;
+        };
+
+        const globals = globalThis as typeof globalThis & {
+          __wireRestartDialogProbe?: Probe;
+        };
+
+        return globals.__wireRestartDialogProbe?.options ?? null;
+      }),
+    )
+    .not.toBeNull();
+
+  return app.evaluate(() => {
+    type Probe = {
+      options: RestartDialogSnapshot;
+    };
+
+    const globals = globalThis as typeof globalThis & {
+      __wireRestartDialogProbe?: Probe;
+    };
+
+    const probe = globals.__wireRestartDialogProbe;
+
+    if (!probe) {
+      throw new Error('The restart dialog was not opened');
+    }
+
+    return probe.options;
+  });
+};
+
+/*
+ * Resolves the native dialog with response 1, corresponding to:
+ *
+ * macOS: 'Beenden'
+ * Windows: 'Jetzt Neu Starten'
+ */
+const confirmRestartDialog = async (app: App): Promise<void> => {
+  const closePromise = app.waitForEvent('close');
+
+  const resolvePromise = app.evaluate(() => {
+    type DialogResult = {
+      checkboxChecked: boolean;
+      response: number;
+    };
+
+    type Probe = {
+      resolve: (result: DialogResult) => void;
+    };
+
+    const globals = globalThis as typeof globalThis & {
+      __wireRestartDialogProbe?: Probe;
+    };
+
+    const probe = globals.__wireRestartDialogProbe;
+
+    if (!probe) {
+      throw new Error('The restart dialog was not opened');
+    }
+
+    probe.resolve({
+      response: 1,
+      checkboxChecked: false,
+    });
+  });
+
+  await closePromise;
+  await resolvePromise.catch(() => undefined);
+};
+
+const isAppRunning = (app: App): boolean => {
+  const process = app.process();
+
+  return process.exitCode === null && process.signalCode === null;
+};
+
+const closeAppIfRunning = async (app?: App): Promise<void> => {
+  if (app && isAppRunning(app)) {
+    await app.close();
+  }
 };
 
 test.describe('Localization', () => {
@@ -95,5 +323,87 @@ test.describe('Localization', () => {
     await test.step('Verify English "All conversations"', async () => {
       await expect(app.page.getByText('All conversations')).toBeVisible();
     });
+  });
+
+  test('I want to switch language to DE', {tag: ['@TC-11284', '@regression']}, async ({appOptions, createUser}) => {
+    const dataDir = await fs.mkdtemp(path.join(nodeOs.tmpdir(), 'wire-localization-de-'));
+    const user = await createUser();
+    let currentApp: App | undefined;
+
+    try {
+      const initialApp = await createApp({
+        ...appOptions,
+        dataDir,
+      });
+      currentApp = initialApp;
+      const electronPlatform = await getElectronPlatform(initialApp);
+
+      await test.step('Go to login screen and verify welcome screen', async () => {
+        await expect(ssoPage(initialApp.page).codeEmailInput).toBeVisible();
+      });
+
+      await test.step('User logs in', async () => {
+        await loginUser(initialApp.page, user);
+        await expectSelectedMenuLanguage(initialApp, 'English');
+        await expect(initialApp.page.getByText('All conversations')).toBeVisible();
+      });
+
+      await test.step('Switch language to German via menu bar', async () => {
+        await installRestartDialogProbe(initialApp);
+        await triggerLanguageMenuItem(initialApp, 'Deutsch');
+      });
+
+      await test.step('Verify restart popup is shown', async () => {
+        const restartDialog = await getRestartDialog(initialApp);
+
+        expect(restartDialog).toMatchObject({
+          type: 'info',
+          title: 'Neustart erforderlich',
+          message: 'Bitte starten Sie Wire erneut, damit diese Einstellung wirksam wird.',
+        });
+
+        expect(restartDialog.buttons).toHaveLength(2);
+        expect(restartDialog.buttons[0]).toBe('Später');
+
+        if (electronPlatform === 'darwin') {
+          expect(restartDialog.buttons[1]).toMatch(/beenden$/);
+        } else if (electronPlatform === 'win32') {
+          expect(restartDialog.buttons[1]).toBe('Jetzt Neu Starten');
+        } else {
+          throw new Error(`TC-11284 is not supported on Electron platform: ${electronPlatform}`);
+        }
+      });
+
+      await test.step('User restarts app via popup', async () => {
+        await confirmRestartDialog(initialApp);
+        currentApp = undefined;
+      });
+
+      const restartedApp = await createApp({
+        ...appOptions,
+        dataDir,
+      });
+      currentApp = restartedApp;
+
+      await test.step('Verify German is selected in the menu bar', async () => {
+        await expectSelectedMenuLanguage(restartedApp, 'Deutsch');
+      });
+
+      await test.step('Verify German "Alle Unterhaltungen"', async () => {
+        await expect(
+          restartedApp.page.getByText('Alle Unterhaltungen', {
+            exact: true,
+          }),
+        ).toBeVisible();
+      });
+    } finally {
+      await closeAppIfRunning(currentApp).catch(() => undefined);
+      await fs.rm(dataDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      });
+    }
   });
 });

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -20,6 +20,7 @@
 import {loginUser} from '../../actions/loginUser';
 import {expect, test} from '../../fixtures';
 import {menuBar} from '../../poms/app/menuBar.page';
+import {LOGIN_TIMEOUT} from '../../poms/webapp/login.page';
 import {ssoPage} from '../../poms/webapp/sso.page';
 
 test.describe('Localization', () => {
@@ -106,7 +107,7 @@ test.describe('Localization', () => {
       });
 
       await test.step('Verify German "Alle Unterhaltungen"', async () => {
-        await expect(app.page.getByText('Alle Unterhaltungen', {exact: true})).toBeVisible();
+        await expect(app.page.getByText('Alle Unterhaltungen', {exact: true})).toBeVisible({timeout: LOGIN_TIMEOUT});
       });
     },
   );

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -17,292 +17,10 @@
  *
  */
 
-import type {MenuItem} from 'electron';
-
-import fs from 'node:fs/promises';
-import nodeOs from 'node:os';
-import path from 'node:path';
-
-import {createApp, type App} from '../../actions/createApp';
 import {loginUser} from '../../actions/loginUser';
 import {expect, test} from '../../fixtures';
+import {menuBar} from '../../poms/app/menuBar.page';
 import {ssoPage} from '../../poms/webapp/sso.page';
-
-type MenuItemSnapshot = {
-  label: string;
-  checked?: boolean;
-  enabled?: boolean;
-  type?: string;
-  submenu?: MenuItemSnapshot[];
-};
-
-type RestartDialogSnapshot = {
-  buttons: string[];
-  message: string;
-  title?: string;
-  type?: string;
-};
-
-type ElectronPlatform = 'darwin' | 'win32';
-
-const normalizeMenuLabel = (label?: string): string => (label ?? '').replace(/&/g, '');
-
-const getElectronPlatform = async (app: App): Promise<ElectronPlatform> =>
-  app.evaluate(() => process.platform as ElectronPlatform);
-
-const getApplicationMenu = async (app: App): Promise<MenuItemSnapshot[]> =>
-  app.evaluate(({Menu}) => {
-    const serialize = (item: MenuItem): MenuItemSnapshot => ({
-      label: item.label,
-      checked: item.checked,
-      enabled: item.enabled,
-      type: item.type,
-      submenu: item.submenu?.items.map(serialize),
-    });
-
-    return Menu.getApplicationMenu()?.items.map(serialize) ?? [];
-  });
-
-const findMenuItem = (
-  items: MenuItemSnapshot[],
-  predicate: (item: MenuItemSnapshot) => boolean,
-): MenuItemSnapshot | undefined => {
-  for (const item of items) {
-    if (predicate(item)) {
-      return item;
-    }
-
-    if (item.submenu) {
-      const nestedItem = findMenuItem(item.submenu, predicate);
-
-      if (nestedItem) {
-        return nestedItem;
-      }
-    }
-  }
-
-  return undefined;
-};
-
-const expectSelectedMenuLanguage = async (app: App, expectedLanguageLabel: 'English' | 'Deutsch') => {
-  const menu = await getApplicationMenu(app);
-  const languageItem = findMenuItem(menu, item => normalizeMenuLabel(item.label) === expectedLanguageLabel);
-
-  expect(languageItem, `Expected language "${expectedLanguageLabel}" to exist in the menu`).toBeTruthy();
-  expect(languageItem?.checked, `Expected language "${expectedLanguageLabel}" to be selected`).toBe(true);
-};
-
-/*
- * Selects a language from Electron's native application menu.
- */
-const triggerLanguageMenuItem = async (app: App, expectedLanguageLabel: 'English' | 'Deutsch'): Promise<void> => {
-  await app.evaluate(({BrowserWindow, Menu}, languageLabel) => {
-    const normalizeLabel = (label?: string): string => (label ?? '').replace(/&/g, '');
-
-    const isLanguageSubmenu = (items: MenuItem[]): boolean => {
-      const radioLabels = new Set(items.filter(item => item.type === 'radio').map(item => normalizeLabel(item.label)));
-
-      return radioLabels.has('English') && radioLabels.has('Deutsch');
-    };
-
-    const findLanguageItem = (items: MenuItem[]): MenuItem | undefined => {
-      for (const item of items) {
-        const submenuItems = item.submenu?.items ?? [];
-
-        if (isLanguageSubmenu(submenuItems)) {
-          return submenuItems.find(
-            submenuItem => submenuItem.type === 'radio' && normalizeLabel(submenuItem.label) === languageLabel,
-          );
-        }
-
-        const nestedItem = findLanguageItem(submenuItems);
-
-        if (nestedItem) {
-          return nestedItem;
-        }
-      }
-
-      return undefined;
-    };
-
-    const formatMenu = (items: MenuItem[], depth = 0): string[] =>
-      items.flatMap(item => {
-        const prefix = `${'  '.repeat(depth)}- ${normalizeLabel(item.label) || `[${item.type}]`}`;
-        return [prefix, ...formatMenu(item.submenu?.items ?? [], depth + 1)];
-      });
-
-    const applicationMenu = Menu.getApplicationMenu();
-    const menuItems = applicationMenu?.items ?? [];
-    const target = findLanguageItem(menuItems);
-
-    if (!target) {
-      throw new Error(
-        `Language menu item was not found: ${languageLabel}\n` +
-          `Actual application menu:\n${formatMenu(menuItems).join('\n')}`,
-      );
-    }
-
-    if (!target.enabled) {
-      throw new Error(`Language menu item is disabled: ${languageLabel}`);
-    }
-
-    const targetWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
-
-    if (!targetWindow) {
-      throw new Error('No Electron window found for the menu event');
-    }
-
-    target.click(target, targetWindow);
-  }, expectedLanguageLabel);
-};
-
-/*
- * Replaces Electron's native message box with a controllable promise.
- */
-const installRestartDialogProbe = async (app: App): Promise<void> => {
-  await app.evaluate(({app: electronApp, dialog}) => {
-    type DialogResult = {
-      checkboxChecked: boolean;
-      response: number;
-    };
-
-    type DialogOptions = {
-      buttons?: string[];
-      message: string;
-      title?: string;
-      type?: string;
-    };
-
-    type Probe = {
-      options: {
-        buttons: string[];
-        message: string;
-        title?: string;
-        type?: string;
-      };
-      resolve: (result: DialogResult) => void;
-    };
-
-    const globals = globalThis as typeof globalThis & {
-      __wireRestartDialogProbe?: Probe;
-    };
-
-    if (process.platform === 'win32') {
-      const mutableElectronApp = electronApp as unknown as {
-        relaunch: () => void;
-      };
-
-      mutableElectronApp.relaunch = () => {};
-    }
-
-    const mutableDialog = dialog as unknown as {
-      showMessageBox: (...args: unknown[]) => Promise<DialogResult>;
-    };
-
-    mutableDialog.showMessageBox = (...args: unknown[]) => {
-      const options = (args.length === 1 ? args[0] : args[1]) as DialogOptions;
-
-      return new Promise<DialogResult>(resolve => {
-        globals.__wireRestartDialogProbe = {
-          options: {
-            buttons: [...(options.buttons ?? [])],
-            message: options.message,
-            title: options.title,
-            type: options.type,
-          },
-          resolve,
-        };
-      });
-    };
-  });
-};
-
-const getRestartDialog = async (app: App): Promise<RestartDialogSnapshot> => {
-  await expect
-    .poll(() =>
-      app.evaluate(() => {
-        type Probe = {
-          options: RestartDialogSnapshot;
-        };
-
-        const globals = globalThis as typeof globalThis & {
-          __wireRestartDialogProbe?: Probe;
-        };
-
-        return globals.__wireRestartDialogProbe?.options ?? null;
-      }),
-    )
-    .not.toBeNull();
-
-  return app.evaluate(() => {
-    type Probe = {
-      options: RestartDialogSnapshot;
-    };
-
-    const globals = globalThis as typeof globalThis & {
-      __wireRestartDialogProbe?: Probe;
-    };
-
-    const probe = globals.__wireRestartDialogProbe;
-
-    if (!probe) {
-      throw new Error('The restart dialog was not opened');
-    }
-
-    return probe.options;
-  });
-};
-
-/*
- * Resolves the native dialog with response 1, corresponding to:
- *
- * macOS: 'Beenden'
- * Windows: 'Jetzt Neu Starten'
- */
-const confirmRestartDialog = async (app: App): Promise<void> => {
-  const closePromise = app.waitForEvent('close');
-
-  const resolvePromise = app.evaluate(() => {
-    type DialogResult = {
-      checkboxChecked: boolean;
-      response: number;
-    };
-
-    type Probe = {
-      resolve: (result: DialogResult) => void;
-    };
-
-    const globals = globalThis as typeof globalThis & {
-      __wireRestartDialogProbe?: Probe;
-    };
-
-    const probe = globals.__wireRestartDialogProbe;
-
-    if (!probe) {
-      throw new Error('The restart dialog was not opened');
-    }
-
-    probe.resolve({
-      response: 1,
-      checkboxChecked: false,
-    });
-  });
-
-  await closePromise;
-  await resolvePromise.catch(() => undefined);
-};
-
-const isAppRunning = (app: App): boolean => {
-  const process = app.process();
-
-  return process.exitCode === null && process.signalCode === null;
-};
-
-const closeAppIfRunning = async (app?: App): Promise<void> => {
-  if (app && isAppRunning(app)) {
-    await app.close();
-  }
-};
 
 test.describe('Localization', () => {
   test('I want to verify initial language is EN', {tag: ['@TC-11283', '@regression']}, async ({app, createUser}) => {
@@ -317,7 +35,8 @@ test.describe('Localization', () => {
     });
 
     await test.step('Verify English is selected in the menu bar', async () => {
-      await expectSelectedMenuLanguage(app, 'English');
+      const selectedLanguage = await menuBar(app).getCurrentLanguage();
+      expect(selectedLanguage).toBe('English');
     });
 
     await test.step('Verify English "All conversations"', async () => {
@@ -325,85 +44,69 @@ test.describe('Localization', () => {
     });
   });
 
-  test('I want to switch language to DE', {tag: ['@TC-11284', '@regression']}, async ({appOptions, createUser}) => {
-    const dataDir = await fs.mkdtemp(path.join(nodeOs.tmpdir(), 'wire-localization-de-'));
-    const user = await createUser();
-    let currentApp: App | undefined;
-
-    try {
-      const initialApp = await createApp({
-        ...appOptions,
-        dataDir,
-      });
-      currentApp = initialApp;
-      const electronPlatform = await getElectronPlatform(initialApp);
+  test(
+    'I want to switch language to DE',
+    {tag: ['@TC-11284', '@regression']},
+    async ({os, app: initialApp, createUser}) => {
+      let app = initialApp; // The app needs to be re-assigned after reopening it
+      const user = await createUser();
 
       await test.step('Go to login screen and verify welcome screen', async () => {
-        await expect(ssoPage(initialApp.page).codeEmailInput).toBeVisible();
+        await expect(ssoPage(app.page).codeEmailInput).toBeVisible();
       });
 
       await test.step('User logs in', async () => {
-        await loginUser(initialApp.page, user);
-        await expectSelectedMenuLanguage(initialApp, 'English');
-        await expect(initialApp.page.getByText('All conversations')).toBeVisible();
+        await loginUser(app.page, user);
+        await expect(app.page.getByText('All conversations')).toBeVisible();
       });
 
       await test.step('Switch language to German via menu bar', async () => {
-        await installRestartDialogProbe(initialApp);
-        await triggerLanguageMenuItem(initialApp, 'Deutsch');
+        // Stub showMessageBox function of electron
+        await app.evaluate(({dialog}) => {
+          const stubMeta = {calls: [] as unknown[]};
+          const stubFunction: typeof dialog.showMessageBox = async (...args: unknown[]) => {
+            stubMeta.calls.push(args);
+            return {response: 0, checkboxChecked: false}; // Response 0 means button at index one which ignores the reboot as we have to do it manually
+          };
+
+          // We overload the stub function to add the __mock property to it. This way we can check the arguments it was called with in the next test step
+          dialog.showMessageBox = Object.assign(stubFunction, {__mock: stubMeta});
+        });
+
+        await menuBar(app).switchLanguage('Deutsch');
       });
 
       await test.step('Verify restart popup is shown', async () => {
-        const restartDialog = await getRestartDialog(initialApp);
+        // Get metadata from stub
+        const showMessageBox = await app.evaluate(
+          ({dialog}) => (dialog.showMessageBox as unknown as {__mock: {calls: unknown[]}}).__mock,
+        );
 
-        expect(restartDialog).toMatchObject({
-          type: 'info',
-          title: 'Neustart erforderlich',
-          message: 'Bitte starten Sie Wire erneut, damit diese Einstellung wirksam wird.',
-        });
-
-        expect(restartDialog.buttons).toHaveLength(2);
-        expect(restartDialog.buttons[0]).toBe('Später');
-
-        if (electronPlatform === 'darwin') {
-          expect(restartDialog.buttons[1]).toMatch(/beenden$/);
-        } else if (electronPlatform === 'win32') {
-          expect(restartDialog.buttons[1]).toBe('Jetzt Neu Starten');
-        } else {
-          throw new Error(`TC-11284 is not supported on Electron platform: ${electronPlatform}`);
-        }
+        expect(showMessageBox.calls).toMatchObject([
+          [
+            {
+              type: 'info',
+              title: 'Neustart erforderlich',
+              message: 'Bitte starten Sie Wire erneut, damit diese Einstellung wirksam wird.',
+              buttons: ['Später', expect.stringContaining(os === 'macOS' ? 'beenden' : 'Neu Starten')],
+            },
+          ],
+        ]);
       });
 
-      await test.step('User restarts app via popup', async () => {
-        await confirmRestartDialog(initialApp);
-        currentApp = undefined;
+      // We need to manually relaunch the app because by executing the restart from the app itself playwright would loose the reference to it
+      app = await test.step('User restarts app', async () => {
+        return await app.reopen();
       });
-
-      const restartedApp = await createApp({
-        ...appOptions,
-        dataDir,
-      });
-      currentApp = restartedApp;
 
       await test.step('Verify German is selected in the menu bar', async () => {
-        await expectSelectedMenuLanguage(restartedApp, 'Deutsch');
+        const selectedLanguage = await menuBar(app).getCurrentLanguage();
+        expect(selectedLanguage).toBe('Deutsch');
       });
 
       await test.step('Verify German "Alle Unterhaltungen"', async () => {
-        await expect(
-          restartedApp.page.getByText('Alle Unterhaltungen', {
-            exact: true,
-          }),
-        ).toBeVisible();
+        await expect(app.page.getByText('Alle Unterhaltungen', {exact: true})).toBeVisible();
       });
-    } finally {
-      await closeAppIfRunning(currentApp).catch(() => undefined);
-      await fs.rm(dataDir, {
-        recursive: true,
-        force: true,
-        maxRetries: 3,
-        retryDelay: 100,
-      });
-    }
-  });
+    },
+  );
 });

--- a/e2e-tests/specs/regression/localization.spec.ts
+++ b/e2e-tests/specs/regression/localization.spec.ts
@@ -66,7 +66,7 @@ test.describe('Localization', () => {
           const stubMeta = {calls: [] as unknown[]};
           const stubFunction: typeof dialog.showMessageBox = async (...args: unknown[]) => {
             stubMeta.calls.push(args);
-            return {response: 1, checkboxChecked: false}; // Response 0 means button at index one which ignores the reboot as we have to do it manually
+            return {response: 0, checkboxChecked: false}; // Response 0 means button at index one which ignores the reboot as we have to do it manually
           };
 
           // We overload the stub function to add the __mock property to it. This way we can check the arguments it was called with in the next test step
@@ -96,6 +96,7 @@ test.describe('Localization', () => {
 
       // We need to manually relaunch the app because by executing the restart from the app itself playwright would loose the reference to it
       app = await test.step('User restarts app', async () => {
+        await menuBar(app).clickItem('Quit WireInternal'); // Close the app via the menu bar. This is necessary because otherwise the config change won't be persisted
         return await app.reopen();
       });
 

--- a/e2e-tests/specs/regression/menuBar.spec.ts
+++ b/e2e-tests/specs/regression/menuBar.spec.ts
@@ -17,63 +17,34 @@
  *
  */
 
-import {MenuItem} from 'electron';
-
 import {conversationsList} from './../../poms/webapp/conversationList.page';
 
 import {connectWithUser} from '../../actions/connectWithUser';
-import {type App} from '../../actions/createApp';
 import {createGroup} from '../../actions/createGroup';
 import {loginUser} from '../../actions/loginUser';
 import {test, expect, Page} from '../../fixtures';
+import {menuBar} from '../../poms/app/menuBar.page';
 import {callCell} from '../../poms/webapp/callCell.page';
 import {conversation} from '../../poms/webapp/conversation.page';
 import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page';
 import {loginPage} from '../../poms/webapp/login.page';
 import {settingsPage} from '../../poms/webapp/settings.page';
 
-/**
- * Triggers an Electron application menu item by matching its label.
- * Supports cross-platform variants by accepting either a single string or an array of strings.
- * * @param {object} app - The Playwright Electron application instance
- * @param {string[]} labels - The menu label(s) to match against (e.g., 'Settings' or ['Preferences', 'Settings'])
- * @returns A Promise resolving to the serialized accelerator string of the clicked MenuItem
- */
-
-const triggerApplicationMenu = async (app: App, labels: string[]): Promise<Pick<MenuItem, 'accelerator'>> => {
-  return await app.evaluate(async ({Menu, BrowserWindow}, targets) => {
-    const menu = Menu.getApplicationMenu();
-
-    const target = menu?.items.flatMap(item => item.submenu?.items ?? []).find(item => targets.includes(item.label));
-
-    if (!target) {
-      throw new Error('Menu item not found');
-    }
-
-    const targetWindow = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
-    if (!targetWindow) {
-      throw new Error('No Electron window found to send the menu event to');
-    }
-
-    // Programmatically trigger the menu item's click action
-    target.click(target, targetWindow);
-    return {
-      accelerator: target.accelerator,
-    };
-  }, labels);
-};
-
 test.describe('Menu Bar', () => {
-  test('Open preferences/settings with menu bar', {tag: ['@TC-11010', '@regression']}, async ({app, createUser}) => {
-    const user = await createUser();
-    await loginUser(app.page, user);
+  test(
+    'Open preferences/settings with menu bar',
+    {tag: ['@TC-11010', '@regression']},
+    async ({os, app, createUser}) => {
+      const user = await createUser();
+      await loginUser(app.page, user);
 
-    // Access the native Electron application menu and click the appropriate item
-    const menuItem = await triggerApplicationMenu(app, ['Preferences', 'Settings']);
+      // Access the native Electron application menu and click the appropriate item
+      const menuItem = await menuBar(app).triggerApplicationMenu(['Preferences', 'Settings']);
 
-    expect(menuItem.accelerator).toMatch(/^(Command\+,|Ctrl\+,)$/);
-    await expect(settingsPage(app.page).accountButton).toBeVisible();
-  });
+      expect(menuItem.accelerator).toMatch(/^(Command\+,|Ctrl\+,)$/);
+      await expect(settingsPage(app.page).accountButton).toBeVisible();
+    },
+  );
 
   test(
     'Verify switching to next and previous conversation using menu bar',
@@ -90,14 +61,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('Verify navigation to the next conversation and validate its keyboard shortcut', async () => {
         await conversationsList(app.page).getConversation('Group 1').open();
-        const menuItem = await triggerApplicationMenu(app, ['Next Conversation']);
+        const menuItem = await menuBar(app).triggerApplicationMenu(['Next Conversation']);
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Up)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 2');
       });
 
       await test.step('Navigate to the previous conversation via the application menu', async () => {
-        const menuItem = await triggerApplicationMenu(app, ['Previous Conversation']);
+        const menuItem = await menuBar(app).triggerApplicationMenu(['Previous Conversation']);
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Down)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 1');
@@ -112,7 +83,7 @@ test.describe('Menu Bar', () => {
       const user = await createUser();
       await loginUser(app.page, user);
 
-      const menuItem = await triggerApplicationMenu(app, ['Create Group']);
+      const menuItem = await menuBar(app).triggerApplicationMenu(['Create Group']);
 
       expect(menuItem.accelerator).toBe('CmdOrCtrl+N');
       await expect(app.page.getByRole('dialog').getByText('Create group')).toBeVisible();
@@ -123,7 +94,7 @@ test.describe('Menu Bar', () => {
     const user = await createUser();
     await loginUser(app.page, user);
 
-    await triggerApplicationMenu(app, ['Log Out']);
+    await menuBar(app).triggerApplicationMenu(['Log Out']);
     await app.page.getByRole('dialog').getByRole('button', {name: 'Log out'}).click();
     await expect(loginPage(app.page).loginButton).toBeVisible();
   });
@@ -138,7 +109,7 @@ test.describe('Menu Bar', () => {
       await createGroup(app.page, 'Test group', []);
       await conversationsList(app.page).getConversation('Test group').open();
 
-      const menuItem = await triggerApplicationMenu(app, ['Add People...']);
+      const menuItem = await menuBar(app).triggerApplicationMenu(['Add People...']);
 
       expect(menuItem.accelerator).toBe('Shift+CmdOrCtrl+K');
       await expect(app.page.getByRole('complementary').filter({hasText: 'Add participants'})).toBeVisible();
@@ -162,7 +133,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive in 1:1 conversation', async () => {
         await conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuItem = await triggerApplicationMenu(app, ['Archive']);
+        const menuItem = await menuBar(app).triggerApplicationMenu(['Archive']);
 
         expect(menuItem.accelerator).toBe('CmdOrCtrl+D');
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
@@ -171,7 +142,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive group conversation', async () => {
         await conversationsList(userAPage).getConversation('Test group').open();
-        await triggerApplicationMenu(app, ['Archive']);
+        await menuBar(app).triggerApplicationMenu(['Archive']);
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
         await expect(conversationsList(app.page).items).toHaveCount(0);
       });
@@ -233,14 +204,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A actions in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        await triggerApplicationMenu(app, [menuItem]);
+        await menuBar(app).triggerApplicationMenu([menuItem]);
         await verifyDirect(app.page);
       });
 
       await test.step('User A actions in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await triggerApplicationMenu(app, [menuItem]);
+        await menuBar(app).triggerApplicationMenu([menuItem]);
         await verifyGroup(app.page);
       });
     });
@@ -260,7 +231,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A can open people popover in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuResult = await triggerApplicationMenu(app, ['People']);
+        const menuResult = await menuBar(app).triggerApplicationMenu(['People']);
         expect(menuResult?.accelerator).toBe('CmdOrCtrl+I');
         await expect(app.page.getByTestId('status-profile-picture')).toBeVisible();
       });
@@ -268,7 +239,7 @@ test.describe('Menu Bar', () => {
       await test.step('User A can open conversation details in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await triggerApplicationMenu(app, ['People']);
+        await menuBar(app).triggerApplicationMenu(['People']);
         await expect(app.page.getByTestId('list-users')).toBeVisible();
       });
     },

--- a/e2e-tests/specs/regression/menuBar.spec.ts
+++ b/e2e-tests/specs/regression/menuBar.spec.ts
@@ -39,7 +39,7 @@ test.describe('Menu Bar', () => {
       await loginUser(app.page, user);
 
       // Access the native Electron application menu and click the appropriate item
-      const menuItem = await menuBar(app).triggerApplicationMenu(os === 'macOS' ? 'Preferences' : 'Settings');
+      const menuItem = await menuBar(app).clickItem(os === 'macOS' ? 'Preferences' : 'Settings');
 
       expect(menuItem.accelerator).toMatch(/^(Command\+,|Ctrl\+,)$/);
       await expect(settingsPage(app.page).accountButton).toBeVisible();
@@ -61,14 +61,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('Verify navigation to the next conversation and validate its keyboard shortcut', async () => {
         await conversationsList(app.page).getConversation('Group 1').open();
-        const menuItem = await menuBar(app).triggerApplicationMenu('Next Conversation');
+        const menuItem = await menuBar(app).clickItem('Next Conversation');
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Up)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 2');
       });
 
       await test.step('Navigate to the previous conversation via the application menu', async () => {
-        const menuItem = await menuBar(app).triggerApplicationMenu('Previous Conversation');
+        const menuItem = await menuBar(app).clickItem('Previous Conversation');
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Down)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 1');
@@ -83,7 +83,7 @@ test.describe('Menu Bar', () => {
       const user = await createUser();
       await loginUser(app.page, user);
 
-      const menuItem = await menuBar(app).triggerApplicationMenu('Create Group');
+      const menuItem = await menuBar(app).clickItem('Create Group');
 
       expect(menuItem.accelerator).toBe('CmdOrCtrl+N');
       await expect(app.page.getByRole('dialog').getByText('Create group')).toBeVisible();
@@ -94,7 +94,7 @@ test.describe('Menu Bar', () => {
     const user = await createUser();
     await loginUser(app.page, user);
 
-    await menuBar(app).triggerApplicationMenu('Log Out');
+    await menuBar(app).clickItem('Log Out');
     await app.page.getByRole('dialog').getByRole('button', {name: 'Log out'}).click();
     await expect(loginPage(app.page).loginButton).toBeVisible();
   });
@@ -109,7 +109,7 @@ test.describe('Menu Bar', () => {
       await createGroup(app.page, 'Test group', []);
       await conversationsList(app.page).getConversation('Test group').open();
 
-      const menuItem = await menuBar(app).triggerApplicationMenu('Add People...');
+      const menuItem = await menuBar(app).clickItem('Add People...');
 
       expect(menuItem.accelerator).toBe('Shift+CmdOrCtrl+K');
       await expect(app.page.getByRole('complementary').filter({hasText: 'Add participants'})).toBeVisible();
@@ -133,7 +133,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive in 1:1 conversation', async () => {
         await conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuItem = await menuBar(app).triggerApplicationMenu('Archive');
+        const menuItem = await menuBar(app).clickItem('Archive');
 
         expect(menuItem.accelerator).toBe('CmdOrCtrl+D');
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
@@ -142,7 +142,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive group conversation', async () => {
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu('Archive');
+        await menuBar(app).clickItem('Archive');
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
         await expect(conversationsList(app.page).items).toHaveCount(0);
       });
@@ -204,14 +204,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A actions in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        await menuBar(app).triggerApplicationMenu(menuItem);
+        await menuBar(app).clickItem(menuItem);
         await verifyDirect(app.page);
       });
 
       await test.step('User A actions in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu(menuItem);
+        await menuBar(app).clickItem(menuItem);
         await verifyGroup(app.page);
       });
     });
@@ -231,7 +231,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A can open people popover in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuResult = await menuBar(app).triggerApplicationMenu('People');
+        const menuResult = await menuBar(app).clickItem('People');
         expect(menuResult?.accelerator).toBe('CmdOrCtrl+I');
         await expect(app.page.getByTestId('status-profile-picture')).toBeVisible();
       });
@@ -239,7 +239,7 @@ test.describe('Menu Bar', () => {
       await test.step('User A can open conversation details in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu('People');
+        await menuBar(app).clickItem('People');
         await expect(app.page.getByTestId('list-users')).toBeVisible();
       });
     },

--- a/e2e-tests/specs/regression/menuBar.spec.ts
+++ b/e2e-tests/specs/regression/menuBar.spec.ts
@@ -39,7 +39,7 @@ test.describe('Menu Bar', () => {
       await loginUser(app.page, user);
 
       // Access the native Electron application menu and click the appropriate item
-      const menuItem = await menuBar(app).triggerApplicationMenu(['Preferences', 'Settings']);
+      const menuItem = await menuBar(app).triggerApplicationMenu(os === 'macOS' ? 'Preferences' : 'Settings');
 
       expect(menuItem.accelerator).toMatch(/^(Command\+,|Ctrl\+,)$/);
       await expect(settingsPage(app.page).accountButton).toBeVisible();
@@ -61,14 +61,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('Verify navigation to the next conversation and validate its keyboard shortcut', async () => {
         await conversationsList(app.page).getConversation('Group 1').open();
-        const menuItem = await menuBar(app).triggerApplicationMenu(['Next Conversation']);
+        const menuItem = await menuBar(app).triggerApplicationMenu('Next Conversation');
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Up)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 2');
       });
 
       await test.step('Navigate to the previous conversation via the application menu', async () => {
-        const menuItem = await menuBar(app).triggerApplicationMenu(['Previous Conversation']);
+        const menuItem = await menuBar(app).triggerApplicationMenu('Previous Conversation');
 
         expect(menuItem.accelerator).toMatch(/^(Alt\+(Cmd|Shift)\+Down)$/);
         await expect(conversation(app.page).conversationTitle).toContainText('Group 1');
@@ -83,7 +83,7 @@ test.describe('Menu Bar', () => {
       const user = await createUser();
       await loginUser(app.page, user);
 
-      const menuItem = await menuBar(app).triggerApplicationMenu(['Create Group']);
+      const menuItem = await menuBar(app).triggerApplicationMenu('Create Group');
 
       expect(menuItem.accelerator).toBe('CmdOrCtrl+N');
       await expect(app.page.getByRole('dialog').getByText('Create group')).toBeVisible();
@@ -94,7 +94,7 @@ test.describe('Menu Bar', () => {
     const user = await createUser();
     await loginUser(app.page, user);
 
-    await menuBar(app).triggerApplicationMenu(['Log Out']);
+    await menuBar(app).triggerApplicationMenu('Log Out');
     await app.page.getByRole('dialog').getByRole('button', {name: 'Log out'}).click();
     await expect(loginPage(app.page).loginButton).toBeVisible();
   });
@@ -109,7 +109,7 @@ test.describe('Menu Bar', () => {
       await createGroup(app.page, 'Test group', []);
       await conversationsList(app.page).getConversation('Test group').open();
 
-      const menuItem = await menuBar(app).triggerApplicationMenu(['Add People...']);
+      const menuItem = await menuBar(app).triggerApplicationMenu('Add People...');
 
       expect(menuItem.accelerator).toBe('Shift+CmdOrCtrl+K');
       await expect(app.page.getByRole('complementary').filter({hasText: 'Add participants'})).toBeVisible();
@@ -133,7 +133,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive in 1:1 conversation', async () => {
         await conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuItem = await menuBar(app).triggerApplicationMenu(['Archive']);
+        const menuItem = await menuBar(app).triggerApplicationMenu('Archive');
 
         expect(menuItem.accelerator).toBe('CmdOrCtrl+D');
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
@@ -142,7 +142,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('Archive group conversation', async () => {
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu(['Archive']);
+        await menuBar(app).triggerApplicationMenu('Archive');
         await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
         await expect(conversationsList(app.page).items).toHaveCount(0);
       });
@@ -204,14 +204,14 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A actions in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        await menuBar(app).triggerApplicationMenu([menuItem]);
+        await menuBar(app).triggerApplicationMenu(menuItem);
         await verifyDirect(app.page);
       });
 
       await test.step('User A actions in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu([menuItem]);
+        await menuBar(app).triggerApplicationMenu(menuItem);
         await verifyGroup(app.page);
       });
     });
@@ -231,7 +231,7 @@ test.describe('Menu Bar', () => {
 
       await test.step('User A can open people popover in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
-        const menuResult = await menuBar(app).triggerApplicationMenu(['People']);
+        const menuResult = await menuBar(app).triggerApplicationMenu('People');
         expect(menuResult?.accelerator).toBe('CmdOrCtrl+I');
         await expect(app.page.getByTestId('status-profile-picture')).toBeVisible();
       });
@@ -239,7 +239,7 @@ test.describe('Menu Bar', () => {
       await test.step('User A can open conversation details in group conversation', async () => {
         await createGroup(app.page, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
-        await menuBar(app).triggerApplicationMenu(['People']);
+        await menuBar(app).triggerApplicationMenu('People');
         await expect(app.page.getByTestId('list-users')).toBeVisible();
       });
     },


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26736" title="WPB-26736" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26736</a>  [Desktop/QA] Write Localization regression tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


This PR adds two e2e regression tests for **localization**.
- **TC-11283** verifies that a fresh profile starts in English.
- **TC-11284** verifies switching the language to German. 

**Implementation notes:**
For TC-11284, both application instances use the same temporary user-data directory so the selected locale is restored after restart. The test manages its own Electron instances and removes the temporary profile in a finally block because the shared app fixture supports only a single application instance.