### PR TITLE
Increase timeout for logout test [WPB-26754]

### DIFF
--- a/e2e-tests/specs/criticalFlow/logout.spec.ts
+++ b/e2e-tests/specs/criticalFlow/logout.spec.ts
@@ -31,6 +31,8 @@ import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page'
 import {logoutModal} from '../../poms/webapp/logoutModal.page';
 
 test('Logout flow', {tag: ['@TC-11286', '@crit-flow-desktop']}, async ({app, createUser, createTeam, createPage}) => {
+  test.setTimeout(150_000); // This test has to complete 3 logins which may take more than the default timeout of 90s
+
   const userB = await createUser();
   const {owner: userA} = await createTeam('Test Team', {users: [userB]});
   const userBPage = await createPage();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26754" title="WPB-26754" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-26754</a>  [Desktop/QA] Write Logout tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
TC-11286 needs to log in the user 3 times, which depending on the current load can take more than the default timeout of 90s.

