### PR TITLE
Reload WebViews without relaunching Wire Desktop [WPB-22420]

### DIFF
--- a/electron/src/lib/forwardWrapperReloadRequest.test.main.ts
+++ b/electron/src/lib/forwardWrapperReloadRequest.test.main.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {EVENT_TYPE} from './eventType';
+import {forwardWrapperReloadRequest} from './forwardWrapperReloadRequest';
+
+describe('forwardWrapperReloadRequest', () => {
+  it('forwards a wrapper reload request', () => {
+    const forwardedEventTypes: string[] = [];
+
+    function send(eventType: string): void {
+      forwardedEventTypes.push(eventType);
+    }
+
+    forwardWrapperReloadRequest({send});
+
+    assert.deepStrictEqual(forwardedEventTypes, [EVENT_TYPE.WRAPPER.RELOAD]);
+  });
+});

--- a/electron/src/lib/forwardWrapperReloadRequest.ts
+++ b/electron/src/lib/forwardWrapperReloadRequest.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {EVENT_TYPE} from './eventType';
+
+type IpcEventSender = {
+  send(eventType: string): void;
+};
+
+export function forwardWrapperReloadRequest(eventSender: IpcEventSender): void {
+  eventSender.send(EVENT_TYPE.WRAPPER.RELOAD);
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -53,6 +53,7 @@ import {
 import {CustomProtocolHandler} from './lib/CoreProtocol';
 import {downloadImage} from './lib/download';
 import {EVENT_TYPE} from './lib/eventType';
+import {forwardWrapperReloadRequest} from './lib/forwardWrapperReloadRequest';
 import {deleteAccount} from './lib/LocalAccountDeletion';
 import {getOpenGraphDataAsync} from './lib/openGraph';
 import {showErrorDialog} from './lib/showDialog';
@@ -196,6 +197,7 @@ const bindIpcEvents = (): void => {
     await deleteAccount(id, accountId, partitionId);
     main.webContents.send(EVENT_TYPE.ACCOUNT.DATA_DELETED);
   });
+  ipcMain.on(EVENT_TYPE.WRAPPER.RELOAD, () => forwardWrapperReloadRequest(main.webContents));
   ipcMain.on(EVENT_TYPE.WRAPPER.RELAUNCH, () => lifecycle.relaunch());
   ipcMain.on(EVENT_TYPE.ABOUT.SHOW, () => AboutWindow.showWindow());
 

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -26,6 +26,7 @@ import type {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
 import {EVENT_TYPE} from '../lib/eventType';
+import {forwardWrapperReloadRequest} from '../lib/forwardWrapperReloadRequest';
 import {getLogger} from '../logging/getLogger';
 import * as EnvironmentUtil from '../runtime/EnvironmentUtil';
 
@@ -73,6 +74,11 @@ webFrame.setZoomFactor(1.0);
 webFrame.setVisualZoomLevelLimits(1, 1);
 
 const subscribeToWebappEvents = (): void => {
+  window.amplify.subscribe(WebAppEvents.LIFECYCLE.REFRESH, () => {
+    logger.info(`Received amplify event "${WebAppEvents.LIFECYCLE.REFRESH}", forwarding event ...`);
+    forwardWrapperReloadRequest(ipcRenderer);
+  });
+
   window.amplify.subscribe(WebAppEvents.LIFECYCLE.RESTART, () => {
     logger.info(`Received amplify event "${WebAppEvents.LIFECYCLE.RESTART}", forwarding event ...`);
     ipcRenderer.send(EVENT_TYPE.WRAPPER.RELAUNCH);


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

## Context

Wire WebApp uses query parameters such as `enabled-features` for startup feature toggles.

When the WebApp requested a refresh, Wire Desktop previously received it as a restart request and relaunched the Electron application. The wrapper then reconstructed the WebApp URL from the configured environment, which removed the current WebView query parameters.

## Changes

This adds support for `WebAppEvents.LIFECYCLE.REFRESH`.

The event is translated into the existing `EVENT_TYPE.WRAPPER.RELOAD` flow:

```text
WebApp refresh request
→ WebView preload
→ Electron main process
→ wrapper renderer
→ reload existing WebViews
```

The existing renderer implementation reloads each WebView in place. This preserves the current WebView URL and its query parameters.

The existing `LIFECYCLE.RESTART` to `WRAPPER.RELAUNCH` flow remains unchanged for operations that require a genuine application restart.

## Result

Clicking "Update now" refreshes the WebApp without relaunching Wire Desktop.

Startup feature toggles and other WebView URL state remain available after the refresh, including when multiple accounts are open.

See also https://github.com/wireapp/wire-webapp/pull/21838