### PR TITLE
chore(e2e): Small fix for Logout test and Readme update [WPB-27123]

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -6,6 +6,13 @@ This readme serves as documentation for the E2E tests which are part of this rep
 
 Make sure you already followed the instructions of the [README.md](../README.md) in the root of this repository e.g. for installing dependencies.
 
+### Installing dependencies
+
+1. Install JS dependencies: `yarn --immutable`
+2. Install Playwright browsers (needed for some tests): `yarn playwright install --only-shell --with-deps chromium`
+
+_Note: If in doubt, refer to test jobs in [git actions workflows folder](/.github/workflows)._
+
 ### Setting up environment variables
 
 The E2E tests depend on configs / secrets which need to be provided as environment variables in order to run them. These secrets are stored within 1Password. To create a `.env` file containing the actual values follow these steps:

--- a/e2e-tests/specs/criticalFlow/logout.spec.ts
+++ b/e2e-tests/specs/criticalFlow/logout.spec.ts
@@ -31,6 +31,7 @@ import {conversationsSidebar} from '../../poms/webapp/conversationsSidebar.page'
 import {logoutModal} from '../../poms/webapp/logoutModal.page';
 
 test('Logout flow', {tag: ['@TC-11286', '@crit-flow-desktop']}, async ({app, createUser, createTeam, createPage}) => {
+  test.setTimeout(120_000);
   const userB = await createUser();
   const {owner: userA} = await createTeam('Test Team', {users: [userB]});
   const userBPage = await createPage();


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27123" title="WPB-27123" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27123</a>  [Desktop][QA] Small fixes for Logout test and adding missing steps in Readme
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27123

Small fixes for Logout test (bumped timeout) and adding missing set up steps in Readme for e2e tests.