### PR TITLE
Update Beta desktop environment URL [WPB-22420]

### DIFF
--- a/electron/src/runtime/EnvironmentUtil.ts
+++ b/electron/src/runtime/EnvironmentUtil.ts
@@ -44,7 +44,7 @@ let currentEnvironment = settings.restore<ServerType | undefined>(SettingsType.E
 
 const webappEnvironments = {
   [ServerType.PRODUCTION]: {name: 'Production', server: ServerType.PRODUCTION, url: 'https://app.wire.com'},
-  [ServerType.BETA]: {name: 'Beta', server: ServerType.BETA, url: 'https://wire-webapp-staging.wire.com'},
+  [ServerType.BETA]: {name: 'Beta', server: ServerType.BETA, url: 'https://wire-webapp-beta.wire.com'},
   [ServerType.EDGE]: {name: 'Edge', server: ServerType.EDGE, url: 'https://wire-webapp-edge.wire.com'},
 } as const;
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## What changed

The desktop application's **Developer → Environment → Beta** menu entry now opens:

```text
https://wire-webapp-beta.wire.com
```

instead of:

```text
https://wire-webapp-staging.wire.com
```

The existing `ServerType.BETA` identifier and its persisted value remain unchanged.

## Why

Beta now has its own deployment URL (see also https://github.com/zinfra/cailleach/pull/4566) and should no longer point to the staging environment.