### PR TITLE
Upgrade teams to enterprise via Ibis API [WPB-22420]

### DIFF
--- a/e2e-tests/actions/createTeam.ts
+++ b/e2e-tests/actions/createTeam.ts
@@ -21,6 +21,7 @@ import {createUser, registerUser} from './createUser';
 
 import {BrigApiClient} from '../backend/BrigApiClient';
 import {GalleyApiClient} from '../backend/GalleyApiClient';
+import {IbisApiClient} from '../backend/IbisApiClient';
 import {PublicApiClient, RegisteredUser, TeamOwner} from '../backend/PublicApiClient';
 
 export type TeamRole = 'admin' | 'partner' | 'owner' | 'member';
@@ -33,7 +34,7 @@ export type Team = {
 };
 
 export const createTeam = async (
-  api: {publicApi: PublicApiClient; brigApi: BrigApiClient; galleyApi: GalleyApiClient},
+  api: {publicApi: PublicApiClient; brigApi: BrigApiClient; galleyApi: GalleyApiClient; ibisApi: IbisApiClient},
   teamName: string,
   options?: {
     users?: (RegisteredUser | {user: RegisteredUser; role?: TeamRole})[];
@@ -72,9 +73,7 @@ export const createTeam = async (
   }
 
   if (options?.features && Object.values(options.features).some(Boolean)) {
-    // The team will be reset right after initialization, so we need to wait a short time for it to finish
-    // before changing feature configs since they would otherwise be overwritten (See WPB-23698)
-    await new Promise(resolve => setTimeout(resolve, 5000));
+    await api.ibisApi.upgradeTeam(owner);
 
     if (options.features.conferenceCalling) {
       await api.galleyApi.unlockConferenceCallingFeature(teamId);

--- a/e2e-tests/backend/IbisApiClient.ts
+++ b/e2e-tests/backend/IbisApiClient.ts
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {faker} from '@faker-js/faker';
+import axios, {AxiosInstance} from 'axios';
+
+import {TeamOwner} from './PublicApiClient';
+
+export type IbisApiClientConfig = {
+  baseUrl: string;
+};
+
+// eslint-disable-next-line valid-jsdoc
+/* A manually written api client for the ibis api proxied over nginz, it is used to unlock enterprise features on staging */
+export class IbisApiClient {
+  private readonly axiosInstance: AxiosInstance;
+
+  constructor({baseUrl}: IbisApiClientConfig) {
+    this.axiosInstance = axios.create({
+      baseURL: baseUrl,
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  upgradeTeam = async (teamOwner: TeamOwner) => {
+    const billingInfo = {
+      firstname: teamOwner.firstName,
+      lastname: teamOwner.lastName,
+      company: faker.company.name(),
+      street: '123 Test Street',
+      zip: '12345',
+      city: 'Berlin',
+      country: 'DE',
+    };
+
+    for (let i = 0; i < 5; i++) {
+      const res = await this.axiosInstance.put(`/teams/${teamOwner.teamId}/billing/info`, billingInfo, {
+        headers: {Authorization: `Bearer ${teamOwner.token}`},
+        validateStatus: _status => true, // Since we want the request to be retried we need to prevent axios from throwing automatically
+      });
+      if (res.status !== 412) {
+        break;
+      }
+
+      if (i === 4) {
+        throw new Error(`Failed to set billing information for team with id ${teamOwner.teamId}`);
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `Failed to upgrade team with id ${teamOwner.teamId}, retrying in ${1 * (i + 1)} seconds...`,
+        res.data,
+      );
+      await new Promise(res => setTimeout(res, 1_000 * (i + 1)));
+    }
+
+    await this.axiosInstance.put(
+      `/teams/${teamOwner.teamId}/billing/card`,
+      {
+        // tok_visa is a pre-built test token provided by Stripe for test mode environments.
+        // It represents the card number 4242424242424242 (Visa, always succeeds) without needing to go through the Stripe.js card tokenization flow.
+        stripeToken: 'tok_visa',
+      },
+      {headers: {Authorization: `Bearer ${teamOwner.token}`}},
+    );
+
+    const plansResponse = await this.axiosInstance.get(`teams/${teamOwner.teamId}/billing/plan/list`, {
+      headers: {Authorization: `Bearer ${teamOwner.token}`},
+    });
+    if (!Array.isArray(plansResponse.data) || plansResponse.data.length < 1) {
+      throw new Error('No valid enterprise plans found to upgrade to');
+    }
+
+    const plan = plansResponse.data.find(plan => plan.premium === true);
+
+    await this.axiosInstance.put(
+      `/teams/${teamOwner.teamId}/billing/subscription`,
+      {planId: plan.id},
+      {headers: {Authorization: `Bearer ${teamOwner.token}`}},
+    );
+
+    const {data: upgradedTeam} = await this.axiosInstance.get(`teams/${teamOwner.teamId}/billing/team`, {
+      headers: {Authorization: `Bearer ${teamOwner.token}`},
+    });
+    if (upgradedTeam.status !== 'active') {
+      throw new Error('Failed to upgrade team');
+    }
+  };
+}

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -28,6 +28,7 @@ import {createTeam, Team} from './actions/createTeam';
 import {createUser, registerUser} from './actions/createUser';
 import {BrigApiClient} from './backend/BrigApiClient';
 import {GalleyApiClient} from './backend/GalleyApiClient';
+import {IbisApiClient} from './backend/IbisApiClient';
 import {PublicApiClient, RegisteredUser, TeamOwner} from './backend/PublicApiClient';
 
 export type TestOptions = {
@@ -40,6 +41,7 @@ type Fixtures = {
   publicApi: PublicApiClient;
   brigApi: BrigApiClient;
   galleyApi: GalleyApiClient;
+  ibisApi: IbisApiClient;
 
   createUser: () => Promise<RegisteredUser>;
   createPage: () => Promise<Page>;
@@ -83,6 +85,14 @@ export const test = baseTest.extend<TestOptions & Fixtures>({
     await use(new GalleyApiClient({baseUrl: process.env.BACKEND_URL, basicAuth: process.env.BACKEND_BASIC_AUTH}));
   },
 
+  ibisApi: async ({}, use) => {
+    if (process.env.BACKEND_URL === undefined) {
+      throw new Error('Missing env var BACKEND_URL');
+    }
+
+    await use(new IbisApiClient({baseUrl: process.env.BACKEND_URL}));
+  },
+
   app: async ({appOptions}, use, testInfo) => {
     // Always use a fresh temporary directory for the user data to ensure test isolation
     const tempUserDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wire-desktop-e2e-tests-'));
@@ -120,11 +130,11 @@ export const test = baseTest.extend<TestOptions & Fixtures>({
     await Promise.all(users.map(user => publicApi.deleteUser(user)));
   },
 
-  createTeam: async ({publicApi, brigApi, galleyApi}, use) => {
+  createTeam: async ({publicApi, brigApi, galleyApi, ibisApi}, use) => {
     const teamOwners: TeamOwner[] = [];
 
     await use(async (teamName, options) => {
-      const team = await createTeam({publicApi, brigApi, galleyApi}, teamName, options);
+      const team = await createTeam({publicApi, brigApi, galleyApi, ibisApi}, teamName, options);
       teamOwners.push(team.owner);
       return team;
     });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This is a port from: https://github.com/wireapp/wire-webapp/pull/21867

This PR changes how teams are upgraded to an enterprise plan. So far a workaround was used to unlock the features by calling the backend. The new flow communicates with Ibis directly to set up a payment method first making the flow more realistic and reliable.