### PR TITLE
test: deny media permissions programmatically in calling test [WPB-22420]

### DIFF
--- a/e2e-tests/specs/regression/calling.spec.ts
+++ b/e2e-tests/specs/regression/calling.spec.ts
@@ -64,6 +64,9 @@ test.describe('Calling - Feature Functionality', () => {
 
           await expect(fullscreenWindow.getByRole('switch', {name: 'Camera'})).toBeVisible();
           await fullscreenWindow.getByRole('button', {name: 'Hang up'}).click();
+          if (callType === '1:1') {
+            await expect(callCell(userBPage)).not.toBeVisible();
+          }
         });
       }
     },
@@ -84,6 +87,14 @@ test.describe('Calling - Negative Scenarios / Permissions', () => {
     'Verify call establishment fails without required permissions',
     {tag: ['@TC-11297', '@regression']},
     async ({app, createUser, createTeam, createPage}) => {
+      await app.evaluate(({session}) => {
+        session.defaultSession.setPermissionRequestHandler((_, permission, callback) => {
+          if (permission === 'media') {
+            return callback(false);
+          }
+          callback(true);
+        });
+      });
       const userB = await createUser();
       const {owner: userA} = await createTeam('Test Team', {
         users: [userB],

--- a/e2e-tests/specs/regression/menuBar.spec.ts
+++ b/e2e-tests/specs/regression/menuBar.spec.ts
@@ -128,28 +128,28 @@ test.describe('Menu Bar', () => {
       await Promise.all([loginUser(userAPage, userA), loginUser(userBPage, userB)]);
       await connectWithUser(userAPage, userB);
 
-      await createGroup(app.page, 'Test group', []);
-      await expect(conversationsList(app.page).items).toHaveCount(2);
+      await createGroup(userAPage, 'Test group', []);
+      await expect(conversationsList(userAPage).items).toHaveCount(2);
 
       await test.step('Archive in 1:1 conversation', async () => {
-        await conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'}).open();
+        await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
         const menuItem = await menuBar(app).clickItem('Archive');
 
         expect(menuItem.accelerator).toBe('CmdOrCtrl+D');
-        await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
-        await expect(conversationsList(app.page).items).toHaveCount(1);
+        await expect(conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
+        await expect(conversationsList(userAPage).items).toHaveCount(1);
       });
 
       await test.step('Archive group conversation', async () => {
         await conversationsList(userAPage).getConversation('Test group').open();
         await menuBar(app).clickItem('Archive');
-        await expect(conversationsList(app.page).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
-        await expect(conversationsList(app.page).items).toHaveCount(0);
+        await expect(conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'})).not.toBeVisible();
+        await expect(conversationsList(userAPage).items).toHaveCount(0);
       });
 
       await test.step('Confirm that conversations were moved to archive folder', async () => {
         await conversationsSidebar(userAPage).archiveButton.click();
-        await expect(conversationsList(app.page).items).toHaveCount(2);
+        await expect(conversationsList(userAPage).items).toHaveCount(2);
       });
     },
   );
@@ -205,14 +205,14 @@ test.describe('Menu Bar', () => {
       await test.step('User A actions in 1:1 conversation', async () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
         await menuBar(app).clickItem(menuItem);
-        await verifyDirect(app.page);
+        await verifyDirect(userAPage);
       });
 
       await test.step('User A actions in group conversation', async () => {
-        await createGroup(app.page, 'Test group', [userB]);
+        await createGroup(userAPage, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
         await menuBar(app).clickItem(menuItem);
-        await verifyGroup(app.page);
+        await verifyGroup(userAPage);
       });
     });
   });
@@ -233,14 +233,14 @@ test.describe('Menu Bar', () => {
         await conversationsList(userAPage).getConversation(userB.fullName, {protocol: 'mls'}).open();
         const menuResult = await menuBar(app).clickItem('People');
         expect(menuResult?.accelerator).toBe('CmdOrCtrl+I');
-        await expect(app.page.getByTestId('status-profile-picture')).toBeVisible();
+        await expect(userAPage.getByTestId('status-profile-picture')).toBeVisible();
       });
 
       await test.step('User A can open conversation details in group conversation', async () => {
-        await createGroup(app.page, 'Test group', [userB]);
+        await createGroup(userAPage, 'Test group', [userB]);
         await conversationsList(userAPage).getConversation('Test group').open();
         await menuBar(app).clickItem('People');
-        await expect(app.page.getByTestId('list-users')).toBeVisible();
+        await expect(userAPage.getByTestId('list-users')).toBeVisible();
       });
     },
   );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This PR fixes a flaky negative test (TC-11297) that was passing on Windows CI runners but failing on macOS runners.