### PR TITLE
Expose WebView refresh capability to embedded WebApp [WPB-22420]

### DIFF
--- a/electron/src/lib/desktopAppConfig.test.main.ts
+++ b/electron/src/lib/desktopAppConfig.test.main.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import assert from 'node:assert';
+
+import {createDesktopAppConfig} from './desktopAppConfig';
+
+describe('createDesktopAppConfig', () => {
+  it('exposes support for refreshing existing webviews', () => {
+    const desktopAppConfig = createDesktopAppConfig('3.42.0', {applockOverride: false});
+
+    assert.strictEqual(desktopAppConfig.supportsWebViewRefresh, true);
+  });
+});

--- a/electron/src/lib/desktopAppConfig.ts
+++ b/electron/src/lib/desktopAppConfig.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import type {ManagedConfig} from '../managed/ManagedConfig';
+
+export type DesktopAppConfig = {
+  readonly version: string;
+  readonly supportsCallingPopoutWindow?: boolean;
+  readonly supportsWebViewRefresh?: boolean;
+  readonly managedConfig?: ManagedConfig;
+};
+
+export function createDesktopAppConfig(version: string, managedConfig: ManagedConfig): DesktopAppConfig {
+  return {
+    version,
+    supportsCallingPopoutWindow: true,
+    supportsWebViewRefresh: true,
+    managedConfig,
+  };
+}

--- a/electron/src/preload/preload-webview.ts
+++ b/electron/src/preload/preload-webview.ts
@@ -25,6 +25,7 @@ import * as path from 'path';
 import type {Availability} from '@wireapp/protocol-messaging';
 import {WebAppEvents} from '@wireapp/webapp-events';
 
+import {createDesktopAppConfig} from '../lib/desktopAppConfig';
 import {EVENT_TYPE} from '../lib/eventType';
 import {forwardWrapperReloadRequest} from '../lib/forwardWrapperReloadRequest';
 import {getLogger} from '../logging/getLogger';
@@ -295,11 +296,7 @@ process.once('loaded', () => {
   } catch (error) {
     logger.warn('Failed to read managed config from the main process, treating the device as unmanaged:', error);
   }
-  global.desktopAppConfig = {
-    version: EnvironmentUtil.app.DESKTOP_VERSION,
-    supportsCallingPopoutWindow: true,
-    managedConfig,
-  };
+  global.desktopAppConfig = createDesktopAppConfig(EnvironmentUtil.app.DESKTOP_VERSION, managedConfig);
   global.openGraphAsync = getOpenGraphDataViaChannel;
   global.setImmediate = _setImmediate;
 });

--- a/electron/src/types/globals.d.ts
+++ b/electron/src/types/globals.d.ts
@@ -22,8 +22,8 @@ import type {Data as OpenGraphResult} from 'open-graph';
 
 import type {WebAppEvents} from '@wireapp/webapp-events';
 
+import type {DesktopAppConfig} from '../lib/desktopAppConfig';
 import type {i18nStrings, SupportedI18nLanguage} from '../locale';
-import type {ManagedConfig} from '../managed/ManagedConfig';
 import type * as EnvironmentUtil from '../runtime/EnvironmentUtil';
 
 export declare global {
@@ -44,11 +44,7 @@ export declare global {
   };
   var environment: typeof EnvironmentUtil;
   var openGraphAsync: (url: string) => Promise<OpenGraphResult>;
-  var desktopAppConfig: {
-    version: string;
-    supportsCallingPopoutWindow?: boolean;
-    managedConfig?: ManagedConfig;
-  };
+  var desktopAppConfig: DesktopAppConfig;
   /* eslint-enable no-var */
 
   interface Window {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22420" title="WPB-22420" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22420</a>  [Web] General maintenance ticket for PR merges
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Expose supportsWebViewRefresh through desktopAppConfig and retain the existing REFRESH to WRAPPER.RELOAD flow for reloading WebViews in place. Older wrappers omit the capability and continue using RESTART.

See also https://github.com/wireapp/wire-webapp/pull/21989