### PR TITLE
chore(e2e): Increase timeout for multiple accounts e2e test [WPB-28071]

### DIFF
--- a/e2e-tests/specs/criticalFlow/multipleAccounts.spec.ts
+++ b/e2e-tests/specs/criticalFlow/multipleAccounts.spec.ts
@@ -27,6 +27,7 @@ test(
   'I want to add multiple accounts to the app and switch between them',
   {tag: ['@TC-10925', '@crit-flow-desktop']},
   async ({app, createUser}) => {
+    test.setTimeout(120_000);
     const userA = await createUser();
     const userA2 = await createUser();
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28071" title="WPB-28071" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28071</a>  [Desktop] General maintenance ticket for PR merges related to e2e test flakiness
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Since login alone can take up to 40 on staging environment (depending on it's load and state), two users can take somewhat close to 90sec default timeout. I'm bumping the timeout for this test to 120sec to avoid flakiness. 