### PR TITLE
Harden desktop log lifecycle [WPB-27016]

### DIFF
--- a/electron/src/lib/LocalAccountDeletion.ts
+++ b/electron/src/lib/LocalAccountDeletion.ts
@@ -28,6 +28,11 @@ import {ValidationUtil} from '@wireapp/commons';
 import {deleteAccountLogDirectories} from './accountLogDeletion';
 
 import {getLogger} from '../logging/getLogger';
+import {
+  LogDirectoryCleanupDependencies,
+  LogDirectoryCleanupResult,
+  removeEmptyLogDirectoryAncestors,
+} from '../logging/logDirectoryCleanup';
 import {getLogFilenames} from '../logging/logFiles';
 import {getLogDirectory} from '../logging/logPaths';
 
@@ -94,14 +99,28 @@ export async function deleteAccount(id: number, accountId: string, partitionId?:
     }
     const logDirectory = getLogDirectory();
     const logFilePaths = getLogFilenames({absolute: true, baseDirectory: logDirectory});
+    const directoryCleanupDependencies: LogDirectoryCleanupDependencies = {
+      async getDirectoryMetadata(directoryPath: string) {
+        const directoryStatistics = await fs.lstat(directoryPath);
+
+        return {
+          isDirectory: directoryStatistics.isDirectory(),
+          isSymbolicLink: directoryStatistics.isSymbolicLink(),
+        };
+      },
+      async removeDirectory(directoryPath: string): Promise<void> {
+        await fs.rmdir(directoryPath);
+      },
+    };
+
     await deleteAccountLogDirectories({
       accountId,
       dependencies: {
         async isSafeDirectory(directoryPath: string): Promise<boolean> {
           try {
-            const directoryStatistics = await fs.lstat(directoryPath);
+            const directoryMetadata = await directoryCleanupDependencies.getDirectoryMetadata(directoryPath);
 
-            return directoryStatistics.isDirectory() && directoryStatistics.isSymbolicLink() === false;
+            return directoryMetadata.isDirectory && directoryMetadata.isSymbolicLink === false;
           } catch (error) {
             if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
               return false;
@@ -109,6 +128,14 @@ export async function deleteAccount(id: number, accountId: string, partitionId?:
 
             throw error;
           }
+        },
+        async removeEmptyDirectoryAncestors(directoryPath: string): Promise<LogDirectoryCleanupResult> {
+          return removeEmptyLogDirectoryAncestors({
+            dependencies: directoryCleanupDependencies,
+            logDirectory,
+            pathToRemove: directoryPath,
+            pathType: 'directory',
+          });
         },
         async removeDirectory(directoryPath: string): Promise<void> {
           await fs.remove(directoryPath);

--- a/electron/src/lib/accountLogDeletion.test.main.ts
+++ b/electron/src/lib/accountLogDeletion.test.main.ts
@@ -17,10 +17,18 @@
  *
  */
 
+import {Result} from 'true-myth';
+
 import * as assert from 'assert';
 import * as path from 'path';
 
-import {deleteAccountLogDirectories, getAccountLogDirectories} from './accountLogDeletion';
+import {
+  deleteAccountLogDirectories,
+  getAccountLogDirectories,
+  parseLegacyAccountLogDirectory,
+} from './accountLogDeletion';
+
+import {LogDirectoryCleanupResult} from '../logging/logDirectoryCleanup';
 
 const logDirectory = path.join('user-data', 'logs');
 const accountId = '11111111-1111-4111-8111-111111111111';
@@ -34,6 +42,9 @@ describe('account log deletion', () => {
       path.join(logDirectory, `2_2026_07_10_12_34_56_${accountId}`, 'console.log'),
       path.join(logDirectory, `2_2026_07_10_12_34_56_${otherAccountId}`, 'console.log'),
       path.join(logDirectory, '2026-07-10', 'accounts', `${accountId}-suffix`, 'console.log'),
+      path.join(logDirectory, `foo_${accountId}`, 'console.log'),
+      path.join(logDirectory, `backup_2_2026_07_10_12_34_56_${accountId}`, 'console.log'),
+      path.join(logDirectory, `2_invalid_${accountId}`, 'console.log'),
     ];
 
     const actualDirectories = getAccountLogDirectories({accountId, filePaths, logDirectory});
@@ -44,6 +55,27 @@ describe('account log deletion', () => {
     ].toSorted();
 
     assert.deepStrictEqual(actualDirectories, expectedDirectories);
+  });
+
+  it('parses only the historic timestamped account directory format', () => {
+    const parsedDirectory = parseLegacyAccountLogDirectory(`2_2026_07_10_12_34_56_${accountId}`);
+    const rejectedDirectoryNames = [
+      `foo_${accountId}`,
+      `backup_2_2026_07_10_12_34_56_${accountId}`,
+      `2_invalid_${accountId}`,
+      `-1_2026_07_10_12_34_56_${accountId}`,
+    ];
+
+    assert.strictEqual(parsedDirectory.isJust, true);
+
+    if (parsedDirectory.isJust) {
+      assert.strictEqual(parsedDirectory.value.accountId, accountId);
+      assert.strictEqual(parsedDirectory.value.accountIndex, 2);
+    }
+
+    for (const directoryName of rejectedDirectoryNames) {
+      assert.strictEqual(parseLegacyAccountLogDirectory(directoryName).isNothing, true);
+    }
   });
 
   it('skips unsafe directories and continues after deletion failures', async () => {
@@ -59,6 +91,11 @@ describe('account log deletion', () => {
       dependencies: {
         async isSafeDirectory(directoryPath: string): Promise<boolean> {
           return directoryPath === path.join(logDirectory, accountId);
+        },
+        async removeEmptyDirectoryAncestors(): Promise<LogDirectoryCleanupResult> {
+          // Account directory pruning is covered by the filesystem boundary tests.
+
+          return Result.ok();
         },
         async removeDirectory(directoryPath: string): Promise<void> {
           if (directoryPath === path.join(logDirectory, accountId)) {
@@ -77,5 +114,46 @@ describe('account log deletion', () => {
 
     assert.deepStrictEqual(removedDirectories, []);
     assert.strictEqual(failures.length, 1);
+  });
+
+  it('deletes new and valid legacy account directories and prunes their ancestors', async () => {
+    const removedDirectories: string[] = [];
+    const prunedDirectories: string[] = [];
+    const filePaths = [
+      path.join(logDirectory, '2026-07-10', 'accounts', accountId, 'console.log'),
+      path.join(logDirectory, `2_2026_07_10_12_34_56_${accountId}`, 'console.log'),
+    ];
+
+    await deleteAccountLogDirectories({
+      accountId,
+      dependencies: {
+        async isSafeDirectory(): Promise<boolean> {
+          return true;
+        },
+        async removeEmptyDirectoryAncestors(directoryPath: string): Promise<LogDirectoryCleanupResult> {
+          prunedDirectories.push(directoryPath);
+
+          return Result.ok();
+        },
+        async removeDirectory(directoryPath: string): Promise<void> {
+          removedDirectories.push(directoryPath);
+        },
+        reportFailure: (): void => {
+          // The valid account layouts should not report failures.
+        },
+      },
+      filePaths,
+      logDirectory,
+    });
+
+    assert.deepStrictEqual(
+      removedDirectories,
+      [
+        path.join(logDirectory, accountId),
+        path.join(logDirectory, '2026-07-10', 'accounts', accountId),
+        path.join(logDirectory, `2_2026_07_10_12_34_56_${accountId}`),
+      ].toSorted(),
+    );
+    assert.deepStrictEqual(prunedDirectories, removedDirectories);
   });
 });

--- a/electron/src/lib/accountLogDeletion.ts
+++ b/electron/src/lib/accountLogDeletion.ts
@@ -17,7 +17,13 @@
  *
  */
 
+import {Maybe} from 'true-myth';
+
 import * as path from 'path';
+
+import {ValidationUtil} from '@wireapp/commons';
+
+import {LogDirectoryCleanupResult} from '../logging/logDirectoryCleanup';
 
 export type AccountLogDirectoryParameters = {
   accountId: string;
@@ -27,6 +33,7 @@ export type AccountLogDirectoryParameters = {
 
 export type AccountLogDeletionDependencies = {
   isSafeDirectory: (directoryPath: string) => Promise<boolean>;
+  removeEmptyDirectoryAncestors: (directoryPath: string) => Promise<LogDirectoryCleanupResult>;
   removeDirectory: (directoryPath: string) => Promise<void>;
   reportFailure: (message: string, error: unknown) => void;
 };
@@ -34,6 +41,14 @@ export type AccountLogDeletionDependencies = {
 export type DeleteAccountLogDirectoriesParameters = AccountLogDirectoryParameters & {
   dependencies: AccountLogDeletionDependencies;
 };
+
+export type LegacyAccountLogDirectory = {
+  accountId: string;
+  accountIndex: number;
+};
+
+const LEGACY_ACCOUNT_LOG_DIRECTORY_PATTERN =
+  /^(\d+)_(\d{4})_(\d{2})_(\d{2})_(\d{2})_(\d{2})_(\d{2})_([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
 
 function getRelativePathSegments(logDirectory: string, filePath: string): string[] {
   return path.relative(logDirectory, filePath).split(path.sep);
@@ -43,14 +58,32 @@ function isNewAccountLogPath(pathSegments: readonly string[], accountId: string)
   return pathSegments.length >= 4 && pathSegments[1] === 'accounts' && pathSegments[2] === accountId;
 }
 
+export function parseLegacyAccountLogDirectory(directoryName: string): Maybe<LegacyAccountLogDirectory> {
+  const patternMatch = Maybe.of(LEGACY_ACCOUNT_LOG_DIRECTORY_PATTERN.exec(directoryName));
+
+  if (patternMatch.isNothing) {
+    return Maybe.nothing<LegacyAccountLogDirectory>();
+  }
+
+  const accountIndex = Number(patternMatch.value[1]);
+  const accountId = patternMatch.value[8];
+
+  if (Number.isSafeInteger(accountIndex) === false || ValidationUtil.isUUIDv4(accountId) === false) {
+    return Maybe.nothing<LegacyAccountLogDirectory>();
+  }
+
+  return Maybe.just({accountId, accountIndex});
+}
+
 function isLegacyTimestampedAccountLogPath(pathSegments: readonly string[], accountId: string): boolean {
   if (pathSegments.length < 2) {
     return false;
   }
 
   const directoryName = pathSegments[pathSegments.length - 2];
+  const parsedDirectory = parseLegacyAccountLogDirectory(directoryName);
 
-  return directoryName.endsWith(`_${accountId}`);
+  return parsedDirectory.isJust && parsedDirectory.value.accountId === accountId;
 }
 
 export function getAccountLogDirectories(parameters: AccountLogDirectoryParameters): readonly string[] {
@@ -80,6 +113,14 @@ export async function deleteAccountLogDirectories(parameters: DeleteAccountLogDi
 
       if (isSafeDirectory) {
         await parameters.dependencies.removeDirectory(directoryPath);
+        const cleanupResult = await parameters.dependencies.removeEmptyDirectoryAncestors(directoryPath);
+
+        if (cleanupResult.isErr) {
+          parameters.dependencies.reportFailure(
+            `Failed to delete account log directory "${directoryPath}"`,
+            cleanupResult.error,
+          );
+        }
       }
     } catch (error) {
       parameters.dependencies.reportFailure(`Failed to delete account log directory "${directoryPath}"`, error);

--- a/electron/src/lib/fireAndForgetInvoker.test.main.ts
+++ b/electron/src/lib/fireAndForgetInvoker.test.main.ts
@@ -1,0 +1,122 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {createFireAndForgetInvoker} from './fireAndForgetInvoker';
+
+describe('fire-and-forget invoker', () => {
+  it('invokes an asynchronous action without waiting for it', () => {
+    let actionInvocationCount = 0;
+    const invoker = createFireAndForgetInvoker({
+      reportFailure(): void {
+        // The action is expected to resolve.
+      },
+    });
+
+    invoker.fireAndForget(async (): Promise<void> => {
+      actionInvocationCount += 1;
+    });
+
+    assert.strictEqual(actionInvocationCount, 1);
+  });
+
+  it('reports synchronous action failures', async () => {
+    const failures: unknown[] = [];
+    const expectedFailure = new Error('synchronous failure');
+    const invoker = createFireAndForgetInvoker({
+      reportFailure(error: unknown): void {
+        failures.push(error);
+      },
+    });
+
+    invoker.fireAndForget(() => {
+      throw expectedFailure;
+    });
+    await invoker.waitUntilAllSettled();
+
+    assert.deepStrictEqual(failures, [expectedFailure]);
+  });
+
+  it('reports rejected asynchronous actions', async () => {
+    const failures: unknown[] = [];
+    const expectedFailure = new Error('asynchronous failure');
+    const invoker = createFireAndForgetInvoker({
+      reportFailure(error: unknown): void {
+        failures.push(error);
+      },
+    });
+
+    invoker.fireAndForget(async (): Promise<void> => {
+      throw expectedFailure;
+    });
+    await invoker.waitUntilAllSettled();
+
+    assert.deepStrictEqual(failures, [expectedFailure]);
+  });
+
+  it('waits for active actions to settle', async () => {
+    let resolveFirstAction: () => void = () => {
+      // The resolver is replaced by the Promise constructor.
+    };
+    let resolveSecondAction: () => void = () => {
+      // The resolver is replaced by the Promise constructor.
+    };
+    const invoker = createFireAndForgetInvoker({
+      reportFailure(): void {
+        // The actions are expected to resolve.
+      },
+    });
+    const firstAction = new Promise<void>(resolve => {
+      resolveFirstAction = resolve;
+    });
+    const secondAction = new Promise<void>(resolve => {
+      resolveSecondAction = resolve;
+    });
+    let hasWaitFinished = false;
+
+    invoker.fireAndForget(async (): Promise<void> => {
+      await firstAction;
+    });
+    invoker.fireAndForget(async (): Promise<void> => {
+      await secondAction;
+    });
+
+    async function waitForActionsToSettle(): Promise<void> {
+      await invoker.waitUntilAllSettled();
+
+      hasWaitFinished = true;
+    }
+
+    const waitPromise = waitForActionsToSettle();
+    await Promise.resolve();
+
+    assert.strictEqual(hasWaitFinished, false);
+
+    resolveFirstAction();
+    await Promise.resolve();
+
+    assert.strictEqual(hasWaitFinished, false);
+
+    resolveSecondAction();
+    await waitPromise;
+
+    assert.strictEqual(hasWaitFinished, true);
+  });
+});

--- a/electron/src/lib/fireAndForgetInvoker.ts
+++ b/electron/src/lib/fireAndForgetInvoker.ts
@@ -1,0 +1,69 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export type FireAndForgetInvokerDependencies = {
+  reportFailure: (error: unknown) => void;
+};
+
+export type FireAndForgetInvoker = {
+  fireAndForget: (asyncAction: () => Promise<unknown>) => void;
+  waitUntilAllSettled: () => Promise<void>;
+};
+
+export function createFireAndForgetInvoker(dependencies: FireAndForgetInvokerDependencies): FireAndForgetInvoker {
+  const activePromises = new Set<Promise<unknown>>();
+
+  async function observePromise(trackedPromise: Promise<unknown>): Promise<void> {
+    try {
+      await trackedPromise;
+    } catch (error) {
+      dependencies.reportFailure(error);
+    } finally {
+      activePromises.delete(trackedPromise);
+    }
+  }
+
+  function reportUnexpectedObservationFailure(error: unknown): void {
+    dependencies.reportFailure(error);
+  }
+
+  function trackPromise(trackedPromise: Promise<unknown>): void {
+    activePromises.add(trackedPromise);
+    observePromise(trackedPromise).catch(reportUnexpectedObservationFailure);
+  }
+
+  function fireAndForget(asyncAction: () => Promise<unknown>): void {
+    try {
+      const trackedPromise = asyncAction();
+
+      trackPromise(trackedPromise);
+    } catch (error) {
+      dependencies.reportFailure(error);
+    }
+  }
+
+  async function waitUntilAllSettled(): Promise<void> {
+    await Promise.allSettled(Array.from(activePromises));
+  }
+
+  return {
+    fireAndForget,
+    waitUntilAllSettled,
+  };
+}

--- a/electron/src/logging/boundedLogWriter.test.main.ts
+++ b/electron/src/logging/boundedLogWriter.test.main.ts
@@ -23,8 +23,10 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 import {BoundedLogWriter, BoundedLogWriterDependencies, createBoundedLogWriter} from './boundedLogWriter';
+import {createLogMaintenanceCoordinator} from './logMaintenance';
 
 import {withTemporaryDirectory} from '../../test/withTemporaryDirectory';
+import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
 
 function createTestFileSystemDependencies(currentTimeMilliseconds: number): BoundedLogWriterDependencies {
   return {
@@ -73,8 +75,18 @@ function waitMilliseconds(milliseconds: number): Promise<void> {
   });
 }
 
-function ignoreLogRotation(): Promise<void> {
+function ignorePostWriteCleanup(): Promise<void> {
   return Promise.resolve();
+}
+
+function createTestMaintenanceCoordinator() {
+  const invoker = createFireAndForgetInvoker({
+    reportFailure(): void {
+      // The coordinator's public promises report expected operation failures.
+    },
+  });
+
+  return createLogMaintenanceCoordinator({fireAndForget: invoker.fireAndForget});
 }
 
 describe('bounded desktop log writer', () => {
@@ -83,8 +95,9 @@ describe('bounded desktop log writer', () => {
     withTemporaryDirectory('wire-bounded-log-writer-', async (temporaryLogDirectory: string) => {
       const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
       const boundedLogWriter = createBoundedLogWriter({
-        afterRotation: ignoreLogRotation,
+        afterWrite: ignorePostWriteCleanup,
         dependencies: createTestFileSystemDependencies(1),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
         maximumFileSizeBytes: 1024,
       });
 
@@ -116,8 +129,9 @@ describe('bounded desktop log writer', () => {
         },
       };
       const boundedLogWriter = createBoundedLogWriter({
-        afterRotation: ignoreLogRotation,
+        afterWrite: ignorePostWriteCleanup,
         dependencies,
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
         maximumFileSizeBytes: 1024,
       });
 
@@ -131,15 +145,42 @@ describe('bounded desktop log writer', () => {
   );
 
   it(
+    'appends to a pre-existing current file with a fresh writer instance',
+    withTemporaryDirectory('wire-bounded-log-restart-', async (temporaryLogDirectory: string) => {
+      const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
+      const firstWriter = createBoundedLogWriter({
+        afterWrite: ignorePostWriteCleanup,
+        dependencies: createTestFileSystemDependencies(7),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
+        maximumFileSizeBytes: 1024,
+      });
+      const secondWriter = createBoundedLogWriter({
+        afterWrite: ignorePostWriteCleanup,
+        dependencies: createTestFileSystemDependencies(7),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
+        maximumFileSizeBytes: 1024,
+      });
+
+      await firstWriter.write({logFilePath, message: 'before restart'});
+      await secondWriter.write({logFilePath, message: 'after restart'});
+
+      const actualLogContent = await fs.readFile(logFilePath, 'utf8');
+
+      assert.strictEqual(actualLogContent, 'before restart\nafter restart\n');
+    }),
+  );
+
+  it(
     'rotates before an entry exceeds the configured file size',
     withTemporaryDirectory('wire-bounded-log-rotation-', async (temporaryLogDirectory: string) => {
       const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
       let rotationCount = 0;
       const boundedLogWriter = createBoundedLogWriter({
-        async afterRotation(): Promise<void> {
+        async afterWrite(): Promise<void> {
           rotationCount += 1;
         },
         dependencies: createTestFileSystemDependencies(2),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
         maximumFileSizeBytes: 10,
       });
 
@@ -161,8 +202,9 @@ describe('bounded desktop log writer', () => {
       const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
       const existingRotatedLogPath = `${logFilePath}.3-0.old`;
       const boundedLogWriter = createBoundedLogWriter({
-        afterRotation: ignoreLogRotation,
+        afterWrite: ignorePostWriteCleanup,
         dependencies: createTestFileSystemDependencies(3),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
         maximumFileSizeBytes: 10,
       });
 
@@ -182,8 +224,9 @@ describe('bounded desktop log writer', () => {
     withTemporaryDirectory('wire-bounded-log-large-entry-', async (temporaryLogDirectory: string) => {
       const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
       const boundedLogWriter = createBoundedLogWriter({
-        afterRotation: ignoreLogRotation,
+        afterWrite: ignorePostWriteCleanup,
         dependencies: createTestFileSystemDependencies(4),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
         maximumFileSizeBytes: 5,
       });
 
@@ -195,6 +238,51 @@ describe('bounded desktop log writer', () => {
 
       assert.strictEqual(actualCurrentLogContent, 'x\n');
       assert.strictEqual(actualRotatedLogContent, '123456\n');
+    }),
+  );
+
+  it(
+    'runs post-write cleanup after an oversized entry',
+    withTemporaryDirectory('wire-bounded-log-large-entry-cleanup-', async (temporaryLogDirectory: string) => {
+      const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
+      let cleanupCount = 0;
+      const boundedLogWriter = createBoundedLogWriter({
+        async afterWrite(): Promise<void> {
+          cleanupCount += 1;
+        },
+        dependencies: createTestFileSystemDependencies(5),
+        maintenanceCoordinator: createTestMaintenanceCoordinator(),
+        maximumFileSizeBytes: 5,
+      });
+
+      await boundedLogWriter.write({logFilePath, message: '123456'});
+
+      assert.strictEqual(cleanupCount, 1);
+    }),
+  );
+
+  it(
+    'does not deadlock when rotation cleanup requests maintenance',
+    withTemporaryDirectory('wire-bounded-log-rotation-cleanup-', async (temporaryLogDirectory: string) => {
+      const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
+      const maintenanceCoordinator = createTestMaintenanceCoordinator();
+      let cleanupCount = 0;
+      const boundedLogWriter = createBoundedLogWriter({
+        async afterWrite(): Promise<void> {
+          cleanupCount += 1;
+          await maintenanceCoordinator.runMaintenance(async (): Promise<void> => {
+            // The test only verifies that the maintenance request completes.
+          });
+        },
+        dependencies: createTestFileSystemDependencies(6),
+        maintenanceCoordinator,
+        maximumFileSizeBytes: 10,
+      });
+
+      await boundedLogWriter.write({logFilePath, message: '12345'});
+      await boundedLogWriter.write({logFilePath, message: '6789'});
+
+      assert.strictEqual(cleanupCount, 1);
     }),
   );
 });

--- a/electron/src/logging/boundedLogWriter.test.main.ts
+++ b/electron/src/logging/boundedLogWriter.test.main.ts
@@ -23,7 +23,9 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 import {BoundedLogWriter, BoundedLogWriterDependencies, createBoundedLogWriter} from './boundedLogWriter';
+import {createLogCleanup, createLogCleanupFileSystemDependencies} from './logCleanup';
 import {createLogMaintenanceCoordinator} from './logMaintenance';
+import {LogRetentionPolicy} from './logRetention';
 
 import {withTemporaryDirectory} from '../../test/withTemporaryDirectory';
 import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
@@ -258,6 +260,66 @@ describe('bounded desktop log writer', () => {
       await boundedLogWriter.write({logFilePath, message: '123456'});
 
       assert.strictEqual(cleanupCount, 1);
+    }),
+  );
+
+  it(
+    'removes an oversized entry during post-write cleanup',
+    withTemporaryDirectory('wire-bounded-log-large-entry-retention-', async (temporaryLogDirectory: string) => {
+      const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
+      const maintenanceCoordinator = createTestMaintenanceCoordinator();
+      const retentionPolicy: LogRetentionPolicy = {
+        maximumAgeMilliseconds: 7 * 24 * 60 * 60 * 1_000,
+        maximumTotalSizeBytes: 10,
+      };
+      const cleanupFailureMessages: string[] = [];
+      const cleanup = createLogCleanup(
+        createLogCleanupFileSystemDependencies((message: string): void => {
+          cleanupFailureMessages.push(message);
+        }),
+      );
+      let isWriteCriticalSectionActive = false;
+      let writtenLogSizeBytes = 0;
+      let cleanupCount = 0;
+      let cleanupStartedAfterWriteCriticalSection = false;
+      const baseDependencies = createTestFileSystemDependencies(9);
+      const dependencies: BoundedLogWriterDependencies = {
+        ...baseDependencies,
+        async appendFile(filePath: string, content: string): Promise<void> {
+          isWriteCriticalSectionActive = true;
+
+          try {
+            await fs.appendFile(filePath, content);
+            writtenLogSizeBytes = Buffer.byteLength(content);
+          } finally {
+            isWriteCriticalSectionActive = false;
+          }
+        },
+      };
+      const boundedLogWriter = createBoundedLogWriter({
+        async afterWrite(): Promise<void> {
+          cleanupCount += 1;
+          await maintenanceCoordinator.runMaintenance(async (): Promise<void> => {
+            cleanupStartedAfterWriteCriticalSection = isWriteCriticalSectionActive === false;
+            await cleanup.run({
+              activeFilePaths: new Set<string>(),
+              logDirectory: temporaryLogDirectory,
+              policy: retentionPolicy,
+            });
+          });
+        },
+        dependencies,
+        maintenanceCoordinator,
+        maximumFileSizeBytes: 5,
+      });
+
+      await boundedLogWriter.write({logFilePath, message: '1234567890'});
+
+      assert.strictEqual(writtenLogSizeBytes, 11);
+      assert.strictEqual(cleanupCount, 1);
+      assert.strictEqual(cleanupStartedAfterWriteCriticalSection, true);
+      assert.strictEqual(cleanupFailureMessages.length, 0);
+      assert.strictEqual(await fs.pathExists(logFilePath), false);
     }),
   );
 

--- a/electron/src/logging/boundedLogWriter.ts
+++ b/electron/src/logging/boundedLogWriter.ts
@@ -22,6 +22,8 @@ import {Maybe} from 'true-myth';
 import * as os from 'os';
 import * as path from 'path';
 
+import {LogMaintenanceCoordinator} from './logMaintenance';
+
 export type BoundedLogWriterDependencies = {
   appendFile: (filePath: string, content: string) => Promise<void>;
   ensureDirectory: (directoryPath: string) => Promise<void>;
@@ -32,8 +34,9 @@ export type BoundedLogWriterDependencies = {
 };
 
 export type CreateBoundedLogWriterParameters = {
-  afterRotation: (parameters: LogRotationNotificationParameters) => Promise<void>;
+  afterWrite: () => Promise<void>;
   dependencies: BoundedLogWriterDependencies;
+  maintenanceCoordinator: LogMaintenanceCoordinator;
   maximumFileSizeBytes: number;
 };
 
@@ -42,13 +45,9 @@ export type WriteLogMessageParameters = {
   message: string;
 };
 
-export type LogRotationNotificationParameters = {
-  activeFilePaths: ReadonlySet<string>;
-  logFilePath: string;
-};
-
 export type BoundedLogWriter = {
   getActiveFilePaths: () => ReadonlySet<string>;
+  runMaintenance<Result>(operation: () => Promise<Result>): Promise<Result>;
   write: (parameters: WriteLogMessageParameters) => Promise<void>;
 };
 
@@ -69,11 +68,13 @@ type RotateLogFileParameters = {
 };
 
 type WriteLogEntryParameters = {
-  afterRotation: (parameters: LogRotationNotificationParameters) => Promise<void>;
   dependencies: BoundedLogWriterDependencies;
-  getActiveFilePaths: () => ReadonlySet<string>;
   maximumFileSizeBytes: number;
   writeParameters: WriteLogMessageParameters;
+};
+
+type WriteLogEntryResult = {
+  requiresPostWriteCleanup: boolean;
 };
 
 function isExistingFileError(error: unknown): boolean {
@@ -115,7 +116,7 @@ async function rotateLogFile(parameters: RotateLogFileParameters): Promise<void>
   }
 }
 
-async function writeLogEntry(parameters: WriteLogEntryParameters): Promise<void> {
+async function writeLogEntry(parameters: WriteLogEntryParameters): Promise<WriteLogEntryResult> {
   const logEntry = `${parameters.writeParameters.message}${os.EOL}`;
   const logEntrySizeBytes = Buffer.byteLength(logEntry);
 
@@ -124,6 +125,7 @@ async function writeLogEntry(parameters: WriteLogEntryParameters): Promise<void>
   const currentFileSizeBytes = await parameters.dependencies.getFileSize(parameters.writeParameters.logFilePath);
   const wouldExceedMaximumFileSize =
     currentFileSizeBytes > 0 && currentFileSizeBytes + logEntrySizeBytes > parameters.maximumFileSizeBytes;
+  let didRotate = false;
 
   if (wouldExceedMaximumFileSize) {
     await rotateLogFile({
@@ -132,13 +134,12 @@ async function writeLogEntry(parameters: WriteLogEntryParameters): Promise<void>
       dependencies: parameters.dependencies,
       logFilePath: parameters.writeParameters.logFilePath,
     });
-    await parameters.afterRotation({
-      activeFilePaths: parameters.getActiveFilePaths(),
-      logFilePath: parameters.writeParameters.logFilePath,
-    });
+    didRotate = true;
   }
 
   await parameters.dependencies.appendFile(parameters.writeParameters.logFilePath, logEntry);
+
+  return {requiresPostWriteCleanup: didRotate || logEntrySizeBytes > parameters.maximumFileSizeBytes};
 }
 
 function removePendingWrite(pendingWrites: PendingWrites, logFilePath: string, pendingWrite: Promise<void>): void {
@@ -147,34 +148,60 @@ function removePendingWrite(pendingWrites: PendingWrites, logFilePath: string, p
   }
 }
 
-function ignorePreviousWriteFailure(): void {}
+type RunQueuedWriteParameters = {
+  afterWrite: () => Promise<void>;
+  maintenanceCoordinator: LogMaintenanceCoordinator;
+  maximumFileSizeBytes: number;
+  previousWrite: Promise<void>;
+  writeParameters: WriteLogMessageParameters;
+  dependencies: BoundedLogWriterDependencies;
+};
+
+async function runQueuedWrite(parameters: RunQueuedWriteParameters): Promise<void> {
+  try {
+    await parameters.previousWrite;
+  } catch {
+    // A failed previous write must not prevent the next queued write.
+  }
+
+  const writeResult = await parameters.maintenanceCoordinator.runWrite(() => {
+    return writeLogEntry({
+      dependencies: parameters.dependencies,
+      maximumFileSizeBytes: parameters.maximumFileSizeBytes,
+      writeParameters: parameters.writeParameters,
+    });
+  });
+
+  if (writeResult.requiresPostWriteCleanup) {
+    await parameters.afterWrite();
+  }
+}
 
 export function createBoundedLogWriter(parameters: CreateBoundedLogWriterParameters): BoundedLogWriter {
   const pendingWrites: PendingWrites = new Map();
 
   function writeLogMessage(writeParameters: WriteLogMessageParameters): Promise<void> {
     const previousWrite = Maybe.of(pendingWrites.get(writeParameters.logFilePath)).unwrapOr(Promise.resolve());
-    const writeOperation = previousWrite.catch(ignorePreviousWriteFailure).then(() => {
-      return writeLogEntry({
-        afterRotation: parameters.afterRotation,
-        dependencies: parameters.dependencies,
-        getActiveFilePaths,
-        maximumFileSizeBytes: parameters.maximumFileSizeBytes,
-        writeParameters,
-      });
+    const writeOperation = runQueuedWrite({
+      afterWrite: parameters.afterWrite,
+      dependencies: parameters.dependencies,
+      maintenanceCoordinator: parameters.maintenanceCoordinator,
+      maximumFileSizeBytes: parameters.maximumFileSizeBytes,
+      previousWrite,
+      writeParameters,
     });
 
-    let pendingWrite = Promise.resolve();
-    pendingWrite = writeOperation.then(
-      () => {
-        return removePendingWrite(pendingWrites, writeParameters.logFilePath, pendingWrite);
-      },
-      error => {
-        removePendingWrite(pendingWrites, writeParameters.logFilePath, pendingWrite);
+    let pendingWrite: Promise<void> = Promise.resolve();
 
-        throw error;
-      },
-    );
+    async function removePendingWriteAfterCompletion(): Promise<void> {
+      try {
+        await writeOperation;
+      } finally {
+        removePendingWrite(pendingWrites, writeParameters.logFilePath, pendingWrite);
+      }
+    }
+
+    pendingWrite = removePendingWriteAfterCompletion();
     pendingWrites.set(writeParameters.logFilePath, pendingWrite);
 
     return pendingWrite;
@@ -184,5 +211,9 @@ export function createBoundedLogWriter(parameters: CreateBoundedLogWriterParamet
     return new Set(pendingWrites.keys());
   }
 
-  return {getActiveFilePaths, write: writeLogMessage};
+  return {
+    getActiveFilePaths,
+    runMaintenance: parameters.maintenanceCoordinator.runMaintenance,
+    write: writeLogMessage,
+  };
 }

--- a/electron/src/logging/boundedLogWriter.ts
+++ b/electron/src/logging/boundedLogWriter.ts
@@ -46,7 +46,6 @@ export type WriteLogMessageParameters = {
 };
 
 export type BoundedLogWriter = {
-  getActiveFilePaths: () => ReadonlySet<string>;
   runMaintenance<Result>(operation: () => Promise<Result>): Promise<Result>;
   write: (parameters: WriteLogMessageParameters) => Promise<void>;
 };
@@ -207,12 +206,7 @@ export function createBoundedLogWriter(parameters: CreateBoundedLogWriterParamet
     return pendingWrite;
   }
 
-  function getActiveFilePaths(): ReadonlySet<string> {
-    return new Set(pendingWrites.keys());
-  }
-
   return {
-    getActiveFilePaths,
     runMaintenance: parameters.maintenanceCoordinator.runMaintenance,
     write: writeLogMessage,
   };

--- a/electron/src/logging/desktopLogWriter.ts
+++ b/electron/src/logging/desktopLogWriter.ts
@@ -92,7 +92,7 @@ let currentDesktopLogCleanup: Maybe<Promise<void>> = Maybe.nothing<Promise<void>
 
 export function runDesktopLogCleanupWithinMaintenance(): Promise<void> {
   return cleanupDesktopLogs({
-    activeFilePaths: desktopBoundedLogWriter.getActiveFilePaths(),
+    activeFilePaths: new Set<string>(),
     logDirectory: getLogDirectory(),
     policy: DESKTOP_LOG_RETENTION_POLICY,
   });

--- a/electron/src/logging/desktopLogWriter.ts
+++ b/electron/src/logging/desktopLogWriter.ts
@@ -18,16 +18,19 @@
  */
 
 import * as fs from 'fs-extra';
+import {Maybe} from 'true-myth';
 
 import {
   BoundedLogWriter,
   BoundedLogWriterDependencies,
   createBoundedLogWriter,
-  LogRotationNotificationParameters,
   WriteLogMessageParameters,
 } from './boundedLogWriter';
 import {cleanupDesktopLogs, DESKTOP_LOG_RETENTION_POLICY} from './logCleanup';
+import {createLogMaintenanceCoordinator, LogMaintenanceCoordinator} from './logMaintenance';
 import {getLogDirectory} from './logPaths';
+
+import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
 
 function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
@@ -66,22 +69,65 @@ function createFileSystemDependencies(): BoundedLogWriterDependencies {
   };
 }
 
+const desktopLogFireAndForgetInvoker = createFireAndForgetInvoker({
+  reportFailure(error: unknown): void {
+    console.error('Failed to execute a desktop log background operation.', error);
+  },
+});
+
+const desktopLogMaintenanceCoordinator: LogMaintenanceCoordinator = createLogMaintenanceCoordinator({
+  fireAndForget: desktopLogFireAndForgetInvoker.fireAndForget,
+});
+
 const desktopBoundedLogWriter: BoundedLogWriter = createBoundedLogWriter({
-  async afterRotation(rotationParameters: LogRotationNotificationParameters): Promise<void> {
-    await cleanupDesktopLogs({
-      activeFilePaths: rotationParameters.activeFilePaths,
-      logDirectory: getLogDirectory(),
-      policy: DESKTOP_LOG_RETENTION_POLICY,
-    });
+  async afterWrite(): Promise<void> {
+    await runDesktopLogCleanup();
   },
   dependencies: createFileSystemDependencies(),
+  maintenanceCoordinator: desktopLogMaintenanceCoordinator,
   maximumFileSizeBytes: 10 * 1024 * 1024,
 });
+
+let currentDesktopLogCleanup: Maybe<Promise<void>> = Maybe.nothing<Promise<void>>();
+
+export function runDesktopLogCleanupWithinMaintenance(): Promise<void> {
+  return cleanupDesktopLogs({
+    activeFilePaths: desktopBoundedLogWriter.getActiveFilePaths(),
+    logDirectory: getLogDirectory(),
+    policy: DESKTOP_LOG_RETENTION_POLICY,
+  });
+}
+
+async function resetCleanupAfterCompletion(cleanupPromise: Promise<void>): Promise<void> {
+  try {
+    await cleanupPromise;
+  } finally {
+    currentDesktopLogCleanup = Maybe.nothing<Promise<void>>();
+  }
+}
+
+export async function runDesktopLogCleanup(): Promise<void> {
+  if (currentDesktopLogCleanup.isJust) {
+    await currentDesktopLogCleanup.value;
+
+    return;
+  }
+
+  const cleanupPromise = desktopLogMaintenanceCoordinator.runMaintenance(runDesktopLogCleanupWithinMaintenance);
+  const cleanupPromiseWithReset = resetCleanupAfterCompletion(cleanupPromise);
+  currentDesktopLogCleanup = Maybe.just(cleanupPromiseWithReset);
+
+  await cleanupPromiseWithReset;
+}
+
+export function runDesktopLogMaintenance<Result>(operation: () => Promise<Result>): Promise<Result> {
+  return desktopLogMaintenanceCoordinator.runMaintenance(operation);
+}
 
 export function writeBoundedLogMessage(parameters: WriteLogMessageParameters): Promise<void> {
   return desktopBoundedLogWriter.write(parameters);
 }
 
-export function getActiveLogFilePaths(): ReadonlySet<string> {
-  return desktopBoundedLogWriter.getActiveFilePaths();
+export function fireAndForgetDesktopLogOperation(asyncAction: () => Promise<unknown>): void {
+  desktopLogFireAndForgetInvoker.fireAndForget(asyncAction);
 }

--- a/electron/src/logging/getLogger.ts
+++ b/electron/src/logging/getLogger.ts
@@ -21,7 +21,7 @@ import * as logdown from 'logdown';
 
 import {LogFactory, LoggerOptions} from '@wireapp/commons';
 
-import {writeBoundedLogMessage} from './desktopLogWriter';
+import {fireAndForgetDesktopLogOperation, writeBoundedLogMessage} from './desktopLogWriter';
 import {getLogDirectory, getMainProcessLogPath} from './logPaths';
 
 import {config} from '../settings/config';
@@ -37,7 +37,9 @@ function writeMainProcessLog(transportOptions: logdown.TransportOptions): void {
   const logFilePath = getMainProcessLogPath({date: new Date(), logDirectory: getLogDirectory()});
   const logMessage = `${transportOptions.args[0]} ${transportOptions.msg}`;
 
-  void writeBoundedLogMessage({logFilePath, message: logMessage});
+  fireAndForgetDesktopLogOperation(async (): Promise<void> => {
+    await writeBoundedLogMessage({logFilePath, message: logMessage});
+  });
 }
 
 function configureLogTransports(): void {

--- a/electron/src/logging/logCleanup.test.main.ts
+++ b/electron/src/logging/logCleanup.test.main.ts
@@ -17,10 +17,22 @@
  *
  */
 
-import * as assert from 'assert';
+import * as fs from 'fs-extra';
+import {Result} from 'true-myth';
 
-import {createLogCleanup, LogCleanupDependencies, RunLogCleanupParameters} from './logCleanup';
+import * as assert from 'assert';
+import * as path from 'path';
+
+import {
+  createLogCleanup,
+  createLogCleanupFileSystemDependencies,
+  LogCleanupDependencies,
+  RunLogCleanupParameters,
+} from './logCleanup';
+import {LogDirectoryCleanupResult} from './logDirectoryCleanup';
 import {LogFileMetadata} from './logRetention';
+
+import {withTemporaryDirectory} from '../../test/withTemporaryDirectory';
 
 type CleanupTestState = {
   failures: string[];
@@ -52,8 +64,10 @@ function createCleanupTestDependencies(
 
       throw new Error(`Missing test metadata for ${filePath}`);
     },
-    async removeEmptyDirectory(directoryPath: string): Promise<void> {
+    async removeEmptyDirectory(directoryPath: string): Promise<LogDirectoryCleanupResult> {
       state.removedDirectories.push(directoryPath);
+
+      return Result.ok();
     },
     async removeFile(filePath: string): Promise<void> {
       state.removedFiles.push(filePath);
@@ -76,7 +90,12 @@ describe('desktop log cleanup', () => {
   it('removes planned files and their empty parent directories', async () => {
     const state: CleanupTestState = {failures: [], removedDirectories: [], removedFiles: []};
     const fileMetadata: LogFileMetadata[] = [
-      {filePath: 'logs/old/console.log', fileSizeBytes: 10, isSymbolicLink: false, modifiedTimeMilliseconds: 1},
+      {
+        filePath: 'logs/2026-08-20/accounts/account/console.log',
+        fileSizeBytes: 10,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 1,
+      },
       {
         filePath: 'logs/recent/console.log',
         fileSizeBytes: 10,
@@ -88,8 +107,12 @@ describe('desktop log cleanup', () => {
 
     await cleanup.run(createCleanupParameters(new Set()));
 
-    assert.deepStrictEqual(state.removedFiles, ['logs/old/console.log']);
-    assert.deepStrictEqual(state.removedDirectories, ['logs/recent', 'logs/old']);
+    assert.deepStrictEqual(state.removedFiles, ['logs/2026-08-20/accounts/account/console.log']);
+    assert.deepStrictEqual(state.removedDirectories, [
+      'logs/2026-08-20/accounts/account',
+      'logs/2026-08-20/accounts',
+      'logs/2026-08-20',
+    ]);
     assert.deepStrictEqual(state.failures, []);
   });
 
@@ -152,4 +175,34 @@ describe('desktop log cleanup', () => {
 
     assert.strictEqual(discoveryCount, 1);
   });
+
+  it(
+    'removes empty ancestors without removing the log root or following symbolic links',
+    withTemporaryDirectory('wire-log-cleanup-directories-', async (temporaryLogDirectory: string) => {
+      const reportFailure = (): void => {
+        // The test expects no filesystem failures.
+      };
+      const dependencies = createLogCleanupFileSystemDependencies(reportFailure);
+      const dateDirectory = path.join(temporaryLogDirectory, '2026-08-20');
+      const accountsDirectory = path.join(dateDirectory, 'accounts');
+      const accountDirectory = path.join(accountsDirectory, 'account');
+      const symbolicLinkTarget = path.join(temporaryLogDirectory, 'symbolic-link-target');
+      const symbolicLinkPath = path.join(accountsDirectory, 'symbolic-link');
+
+      await fs.ensureDir(accountDirectory);
+      await fs.ensureDir(symbolicLinkTarget);
+      await fs.symlink(symbolicLinkTarget, symbolicLinkPath, 'dir');
+
+      await dependencies.removeEmptyDirectory(accountDirectory);
+      await dependencies.removeEmptyDirectory(accountsDirectory);
+      await dependencies.removeEmptyDirectory(dateDirectory);
+      await dependencies.removeEmptyDirectory(symbolicLinkPath);
+
+      assert.strictEqual(await fs.pathExists(accountDirectory), false);
+      assert.strictEqual(await fs.pathExists(accountsDirectory), true);
+      assert.strictEqual(await fs.pathExists(dateDirectory), true);
+      assert.strictEqual(await fs.pathExists(temporaryLogDirectory), true);
+      assert.strictEqual((await fs.lstat(symbolicLinkPath)).isSymbolicLink(), true);
+    }),
+  );
 });

--- a/electron/src/logging/logCleanup.ts
+++ b/electron/src/logging/logCleanup.ts
@@ -20,8 +20,12 @@
 import * as fs from 'fs-extra';
 import {Maybe} from 'true-myth';
 
-import * as path from 'path';
-
+import {getLogDirectoryAncestors} from './logDirectoryAncestors';
+import {
+  LogDirectoryCleanupDependencies,
+  LogDirectoryCleanupResult,
+  removeEmptyLogDirectory,
+} from './logDirectoryCleanup';
 import {getLogFilenames} from './logFiles';
 import {LogFileMetadata, LogRetentionPlanParameters, LogRetentionPolicy, planLogCleanup} from './logRetention';
 
@@ -36,7 +40,7 @@ export type LogCleanupDependencies = {
   discoverLogFilePaths: (logDirectory: string) => Promise<readonly string[]>;
   getCurrentTimeMilliseconds: () => number;
   getFileMetadata: (filePath: string) => Promise<LogFileMetadata>;
-  removeEmptyDirectory: (directoryPath: string) => Promise<void>;
+  removeEmptyDirectory: (directoryPath: string) => Promise<LogDirectoryCleanupResult>;
   removeFile: (filePath: string) => Promise<void>;
   reportFailure: (message: string, error: unknown) => void;
 };
@@ -56,30 +60,32 @@ type CleanupFileMetadataParameters = {
   dependencies: LogCleanupDependencies;
 };
 
-function getParentDirectories(filePaths: readonly string[]): string[] {
+function compareDirectoryDepth(firstPath: string, secondPath: string): number {
+  const pathLengthDifference = secondPath.length - firstPath.length;
+
+  if (pathLengthDifference !== 0) {
+    return pathLengthDifference;
+  }
+
+  if (firstPath < secondPath) {
+    return -1;
+  }
+
+  if (firstPath > secondPath) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function getParentDirectories(filePaths: readonly string[], logDirectory: string): string[] {
   const parentDirectories = new Set(
-    filePaths.map(filePath => {
-      return path.dirname(filePath);
+    filePaths.flatMap(filePath => {
+      return getLogDirectoryAncestors({logDirectory, pathToRemove: filePath, pathType: 'file'});
     }),
   );
 
-  return [...parentDirectories].toSorted((firstPath, secondPath) => {
-    const pathLengthDifference = secondPath.length - firstPath.length;
-
-    if (pathLengthDifference !== 0) {
-      return pathLengthDifference;
-    }
-
-    if (firstPath < secondPath) {
-      return -1;
-    }
-
-    if (firstPath > secondPath) {
-      return 1;
-    }
-
-    return 0;
-  });
+  return [...parentDirectories].toSorted(compareDirectoryDepth);
 }
 
 async function getCleanupFileMetadata(parameters: CleanupFileMetadataParameters): Promise<LogFileMetadata[]> {
@@ -108,11 +114,16 @@ async function removePlannedFiles(filePaths: readonly string[], dependencies: Lo
 
 async function removeParentDirectories(
   filePaths: readonly string[],
+  logDirectory: string,
   dependencies: LogCleanupDependencies,
 ): Promise<void> {
-  for (const directoryPath of getParentDirectories(filePaths)) {
+  for (const directoryPath of getParentDirectories(filePaths, logDirectory)) {
     try {
-      await dependencies.removeEmptyDirectory(directoryPath);
+      const cleanupResult = await dependencies.removeEmptyDirectory(directoryPath);
+
+      if (cleanupResult.isErr) {
+        dependencies.reportFailure(`Failed to remove empty log directory "${directoryPath}"`, cleanupResult.error);
+      }
     } catch (error) {
       dependencies.reportFailure(`Failed to remove empty log directory "${directoryPath}"`, error);
     }
@@ -140,20 +151,30 @@ async function runCleanup(parameters: RunLogCleanupParameters, dependencies: Log
   const retentionPlan = planLogCleanup(retentionPlanParameters);
 
   await removePlannedFiles(retentionPlan.filesToDelete, dependencies);
-  await removeParentDirectories(logFilePaths, dependencies);
+  await removeParentDirectories(retentionPlan.filesToDelete, parameters.logDirectory, dependencies);
 }
 
-function isMissingPathError(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+function createLogDirectoryCleanupDependencies(): LogDirectoryCleanupDependencies {
+  return {
+    async getDirectoryMetadata(directoryPath: string) {
+      const directoryStatistics = await fs.lstat(directoryPath);
+
+      return {
+        isDirectory: directoryStatistics.isDirectory(),
+        isSymbolicLink: directoryStatistics.isSymbolicLink(),
+      };
+    },
+    async removeDirectory(directoryPath: string): Promise<void> {
+      await fs.rmdir(directoryPath);
+    },
+  };
 }
 
-function isNonEmptyDirectoryError(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && (error.code === 'ENOTEMPTY' || error.code === 'EEXIST');
-}
-
-function createFileSystemDependencies(
+export function createLogCleanupFileSystemDependencies(
   reportFailure: (message: string, error: unknown) => void,
 ): LogCleanupDependencies {
+  const directoryCleanupDependencies = createLogDirectoryCleanupDependencies();
+
   return {
     async discoverLogFilePaths(logDirectory: string): Promise<readonly string[]> {
       return getLogFilenames({absolute: true, baseDirectory: logDirectory});
@@ -171,22 +192,8 @@ function createFileSystemDependencies(
         modifiedTimeMilliseconds: fileStatistics.mtimeMs,
       };
     },
-    async removeEmptyDirectory(directoryPath: string): Promise<void> {
-      try {
-        const directoryStatistics = await fs.lstat(directoryPath);
-
-        if (directoryStatistics.isSymbolicLink() || directoryStatistics.isDirectory() === false) {
-          return;
-        }
-
-        await fs.rmdir(directoryPath);
-      } catch (error) {
-        if (isMissingPathError(error) || isNonEmptyDirectoryError(error)) {
-          return;
-        }
-
-        throw error;
-      }
+    async removeEmptyDirectory(directoryPath: string): Promise<LogDirectoryCleanupResult> {
+      return removeEmptyLogDirectory({directoryPath, dependencies: directoryCleanupDependencies});
     },
     async removeFile(filePath: string): Promise<void> {
       await fs.unlink(filePath);
@@ -219,7 +226,7 @@ export function createLogCleanup(dependencies: LogCleanupDependencies): LogClean
 }
 
 const desktopLogCleanup = createLogCleanup(
-  createFileSystemDependencies((message: string, error: unknown): void => {
+  createLogCleanupFileSystemDependencies((message: string, error: unknown): void => {
     console.error(message, error);
   }),
 );

--- a/electron/src/logging/logCleanupScheduler.test.main.ts
+++ b/electron/src/logging/logCleanupScheduler.test.main.ts
@@ -21,6 +21,8 @@ import * as assert from 'assert';
 
 import {scheduleLogCleanup, UnrefableInterval} from './logCleanupScheduler';
 
+import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
+
 describe('desktop log cleanup scheduler', () => {
   it('schedules an unrefed hourly cleanup interval', async () => {
     let scheduledCallback: () => void = () => {};
@@ -32,8 +34,14 @@ describe('desktop log cleanup scheduler', () => {
         wasUnrefed = true;
       },
     };
+    const invoker = createFireAndForgetInvoker({
+      reportFailure(error: unknown): void {
+        throw error;
+      },
+    });
 
     scheduleLogCleanup({
+      fireAndForget: invoker.fireAndForget,
       intervalMilliseconds: 60_000,
       async runCleanup(): Promise<void> {
         cleanupRunCount += 1;

--- a/electron/src/logging/logDirectoryAncestors.test.main.ts
+++ b/electron/src/logging/logDirectoryAncestors.test.main.ts
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+
+import {getLogDirectoryAncestors} from './logDirectoryAncestors';
+
+describe('desktop log directory ancestors', () => {
+  it('returns nested ancestors deepest-first without the log root', () => {
+    const actualAncestors = getLogDirectoryAncestors({
+      logDirectory: path.join('logs'),
+      pathToRemove: path.join('logs', '2026-08-20', 'accounts', 'account', 'console.log'),
+      pathType: 'file',
+    });
+    const expectedAncestors = [
+      path.join('logs', '2026-08-20', 'accounts', 'account'),
+      path.join('logs', '2026-08-20', 'accounts'),
+      path.join('logs', '2026-08-20'),
+    ];
+
+    assert.deepStrictEqual(actualAncestors, expectedAncestors);
+  });
+
+  it('returns no ancestors for the root or a path outside the root', () => {
+    const actualRootAncestors = getLogDirectoryAncestors({
+      logDirectory: path.join('logs'),
+      pathToRemove: path.join('logs'),
+      pathType: 'directory',
+    });
+    const actualOutsideAncestors = getLogDirectoryAncestors({
+      logDirectory: path.join('logs'),
+      pathToRemove: path.join('other', 'account', 'console.log'),
+      pathType: 'file',
+    });
+
+    assert.deepStrictEqual(actualRootAncestors, []);
+    assert.deepStrictEqual(actualOutsideAncestors, []);
+  });
+});

--- a/electron/src/logging/logDirectoryAncestors.ts
+++ b/electron/src/logging/logDirectoryAncestors.ts
@@ -1,0 +1,66 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as path from 'path';
+
+export type LogDirectoryPathType = 'directory' | 'file';
+
+export type GetLogDirectoryAncestorsParameters = {
+  logDirectory: string;
+  pathToRemove: string;
+  pathType: LogDirectoryPathType;
+};
+
+function isPathInsideLogDirectory(logDirectory: string, candidatePath: string): boolean {
+  const relativePath = path.relative(logDirectory, candidatePath);
+
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    relativePath.startsWith(`..${path.sep}`) === false &&
+    path.isAbsolute(relativePath) === false
+  );
+}
+
+function getStartingDirectory(parameters: GetLogDirectoryAncestorsParameters): string {
+  const resolvedPath = path.resolve(parameters.pathToRemove);
+
+  if (parameters.pathType === 'file') {
+    return path.dirname(resolvedPath);
+  }
+
+  return resolvedPath;
+}
+
+export function getLogDirectoryAncestors(parameters: GetLogDirectoryAncestorsParameters): readonly string[] {
+  const resolvedLogDirectory = path.resolve(parameters.logDirectory);
+  let currentDirectory = getStartingDirectory(parameters);
+  const ancestorDirectories: string[] = [];
+
+  while (
+    currentDirectory !== resolvedLogDirectory &&
+    isPathInsideLogDirectory(resolvedLogDirectory, currentDirectory)
+  ) {
+    const relativeAncestorPath = path.relative(resolvedLogDirectory, currentDirectory);
+    ancestorDirectories.push(path.join(parameters.logDirectory, relativeAncestorPath));
+    currentDirectory = path.dirname(currentDirectory);
+  }
+
+  return ancestorDirectories;
+}

--- a/electron/src/logging/logDirectoryCleanup.test.main.ts
+++ b/electron/src/logging/logDirectoryCleanup.test.main.ts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {LogDirectoryCleanupDependencies, LogDirectoryMetadata, removeEmptyLogDirectory} from './logDirectoryCleanup';
+
+describe('log directory cleanup', () => {
+  it('returns unexpected filesystem failures as an Err result', async () => {
+    const expectedFailure = new Error('directory removal failed');
+    const dependencies: LogDirectoryCleanupDependencies = {
+      async getDirectoryMetadata(): Promise<LogDirectoryMetadata> {
+        return {isDirectory: true, isSymbolicLink: false};
+      },
+      async removeDirectory(): Promise<void> {
+        return Promise.reject(expectedFailure);
+      },
+    };
+
+    const cleanupResult = await removeEmptyLogDirectory({dependencies, directoryPath: 'logs/2026-08-20'});
+
+    assert.strictEqual(cleanupResult.isErr, true);
+
+    if (cleanupResult.isErr) {
+      assert.strictEqual(cleanupResult.error, expectedFailure);
+    }
+  });
+});

--- a/electron/src/logging/logDirectoryCleanup.ts
+++ b/electron/src/logging/logDirectoryCleanup.ts
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Result, Unit} from 'true-myth';
+
+import {getLogDirectoryAncestors, GetLogDirectoryAncestorsParameters} from './logDirectoryAncestors';
+
+export type LogDirectoryMetadata = {
+  isDirectory: boolean;
+  isSymbolicLink: boolean;
+};
+
+export type LogDirectoryCleanupResult = Result<Unit, unknown>;
+
+export type LogDirectoryCleanupDependencies = {
+  getDirectoryMetadata: (directoryPath: string) => Promise<LogDirectoryMetadata>;
+  removeDirectory: (directoryPath: string) => Promise<void>;
+};
+
+export type RemoveEmptyLogDirectoryParameters = {
+  dependencies: LogDirectoryCleanupDependencies;
+  directoryPath: string;
+};
+
+export type RemoveEmptyLogDirectoryAncestorsParameters = GetLogDirectoryAncestorsParameters & {
+  dependencies: LogDirectoryCleanupDependencies;
+};
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function isNonEmptyDirectoryError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error.code === 'ENOTEMPTY' || error.code === 'EEXIST');
+}
+
+export async function removeEmptyLogDirectory(
+  parameters: RemoveEmptyLogDirectoryParameters,
+): Promise<LogDirectoryCleanupResult> {
+  try {
+    const directoryMetadata = await parameters.dependencies.getDirectoryMetadata(parameters.directoryPath);
+
+    if (directoryMetadata.isSymbolicLink || directoryMetadata.isDirectory === false) {
+      return Result.ok<Unit, unknown>();
+    }
+
+    await parameters.dependencies.removeDirectory(parameters.directoryPath);
+
+    return Result.ok<Unit, unknown>();
+  } catch (error) {
+    if (isMissingPathError(error) || isNonEmptyDirectoryError(error)) {
+      return Result.ok<Unit, unknown>();
+    }
+
+    return Result.err<Unit, unknown>(error);
+  }
+}
+
+export async function removeEmptyLogDirectoryAncestors(
+  parameters: RemoveEmptyLogDirectoryAncestorsParameters,
+): Promise<LogDirectoryCleanupResult> {
+  const ancestorDirectories = getLogDirectoryAncestors(parameters);
+
+  for (const directoryPath of ancestorDirectories) {
+    const cleanupResult = await removeEmptyLogDirectory({dependencies: parameters.dependencies, directoryPath});
+
+    if (cleanupResult.isErr) {
+      return cleanupResult;
+    }
+  }
+
+  return Result.ok<Unit, unknown>();
+}

--- a/electron/src/logging/logExport.test.main.ts
+++ b/electron/src/logging/logExport.test.main.ts
@@ -1,0 +1,96 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as fs from 'fs-extra';
+
+import * as assert from 'assert';
+import * as path from 'path';
+
+import {gatherLogFiles} from './logExport';
+import {createLogMaintenanceCoordinator} from './logMaintenance';
+
+import {withTemporaryDirectory} from '../../test/withTemporaryDirectory';
+import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
+
+function createDeferredCompletion(): {promise: Promise<void>; resolve: () => void} {
+  let resolvePromise: () => void = () => {
+    // The resolver is replaced by the Promise constructor.
+  };
+  const promise = new Promise<void>(resolve => {
+    resolvePromise = resolve;
+  });
+
+  return {promise, resolve: resolvePromise};
+}
+
+function createTestMaintenanceCoordinator() {
+  const invoker = createFireAndForgetInvoker({
+    reportFailure(): void {
+      // The coordinator's public promises report expected operation failures.
+    },
+  });
+
+  return createLogMaintenanceCoordinator({fireAndForget: invoker.fireAndForget});
+}
+
+describe('desktop log export', () => {
+  it(
+    'waits for pending writes before cleanup and gathering files',
+    withTemporaryDirectory('wire-log-export-', async (temporaryLogDirectory: string) => {
+      const logFilePath = path.join(temporaryLogDirectory, 'electron.log');
+      const writeCompletion = createDeferredCompletion();
+      const maintenanceCoordinator = createTestMaintenanceCoordinator();
+      const writePromise = maintenanceCoordinator.runWrite(async (): Promise<void> => {
+        await writeCompletion.promise;
+        await fs.outputFile(logFilePath, 'complete entry\n');
+      });
+      const events: string[] = [];
+      const exportPromise = gatherLogFiles({
+        async cleanup(): Promise<void> {
+          events.push('cleanup');
+        },
+        discoverLogFilePaths(): readonly string[] {
+          events.push('discover');
+
+          return ['electron.log'];
+        },
+        logDirectory: temporaryLogDirectory,
+        async readFile(filePath: string): Promise<Uint8Array> {
+          events.push('read');
+
+          return fs.readFile(filePath);
+        },
+        reportReadFailure(): void {
+          events.push('read-failed');
+        },
+        runMaintenance: maintenanceCoordinator.runMaintenance,
+      });
+
+      await Promise.resolve();
+      assert.deepStrictEqual(events, []);
+
+      writeCompletion.resolve();
+      await writePromise;
+      const actualLogFiles = await exportPromise;
+
+      assert.deepStrictEqual(events, ['cleanup', 'discover', 'read']);
+      assert.strictEqual(Buffer.from(actualLogFiles['electron.log']).toString(), 'complete entry\n');
+    }),
+  );
+});

--- a/electron/src/logging/logExport.ts
+++ b/electron/src/logging/logExport.ts
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as path from 'path';
+
+export type GatherLogFilesParameters = {
+  cleanup: () => Promise<void>;
+  discoverLogFilePaths: () => readonly string[];
+  logDirectory: string;
+  readFile: (filePath: string) => Promise<Uint8Array>;
+  reportReadFailure: (filePath: string, error: unknown) => void;
+  runMaintenance<Result>(operation: () => Promise<Result>): Promise<Result>;
+};
+
+export async function gatherLogFiles(parameters: GatherLogFilesParameters): Promise<Record<string, Uint8Array>> {
+  return parameters.runMaintenance(async () => {
+    await parameters.cleanup();
+
+    const logFiles: Record<string, Uint8Array> = {};
+    const relativeFilePaths = parameters.discoverLogFilePaths();
+
+    for (const relativeFilePath of relativeFilePaths) {
+      const resolvedPath = path.join(parameters.logDirectory, relativeFilePath);
+
+      try {
+        logFiles[relativeFilePath] = await parameters.readFile(resolvedPath);
+      } catch (error) {
+        parameters.reportReadFailure(relativeFilePath, error);
+      }
+    }
+
+    return logFiles;
+  });
+}

--- a/electron/src/logging/logMaintenance.test.main.ts
+++ b/electron/src/logging/logMaintenance.test.main.ts
@@ -1,0 +1,156 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {createLogMaintenanceCoordinator} from './logMaintenance';
+
+import {createFireAndForgetInvoker} from '../lib/fireAndForgetInvoker';
+
+function createDeferredCompletion(): {promise: Promise<void>; resolve: () => void} {
+  let resolvePromise: () => void = () => {
+    // The resolver is replaced by the Promise constructor.
+  };
+  const promise = new Promise<void>(resolve => {
+    resolvePromise = resolve;
+  });
+
+  return {promise, resolve: resolvePromise};
+}
+
+function createTestMaintenanceCoordinator() {
+  const invoker = createFireAndForgetInvoker({
+    reportFailure(): void {
+      // The coordinator's public promises report expected operation failures.
+    },
+  });
+
+  return createLogMaintenanceCoordinator({fireAndForget: invoker.fireAndForget});
+}
+
+describe('desktop log maintenance coordination', () => {
+  it('waits for active writes and blocks writes requested after maintenance', async () => {
+    const coordinator = createTestMaintenanceCoordinator();
+    const firstWriteCompletion = createDeferredCompletion();
+    let writeCount = 0;
+    let maintenanceCount = 0;
+
+    const firstWrite = coordinator.runWrite(async (): Promise<void> => {
+      writeCount += 1;
+      await firstWriteCompletion.promise;
+    });
+    const maintenance = coordinator.runMaintenance(async (): Promise<void> => {
+      maintenanceCount += 1;
+    });
+    const queuedWrite = coordinator.runWrite(async (): Promise<void> => {
+      writeCount += 1;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.strictEqual(writeCount, 1);
+    assert.strictEqual(maintenanceCount, 0);
+
+    firstWriteCompletion.resolve();
+    await firstWrite;
+    await maintenance;
+    await queuedWrite;
+
+    assert.strictEqual(writeCount, 2);
+    assert.strictEqual(maintenanceCount, 1);
+  });
+
+  it('keeps normal writes to different files concurrent', async () => {
+    const coordinator = createTestMaintenanceCoordinator();
+    const firstWriteCompletion = createDeferredCompletion();
+    const secondWriteCompletion = createDeferredCompletion();
+    let activeWriteCount = 0;
+    let maximumActiveWriteCount = 0;
+
+    const writeFirstFile = coordinator.runWrite(async (): Promise<void> => {
+      activeWriteCount += 1;
+      maximumActiveWriteCount = Math.max(maximumActiveWriteCount, activeWriteCount);
+      await firstWriteCompletion.promise;
+      activeWriteCount -= 1;
+    });
+    const writeSecondFile = coordinator.runWrite(async (): Promise<void> => {
+      activeWriteCount += 1;
+      maximumActiveWriteCount = Math.max(maximumActiveWriteCount, activeWriteCount);
+      await secondWriteCompletion.promise;
+      activeWriteCount -= 1;
+    });
+
+    await Promise.resolve();
+
+    assert.strictEqual(maximumActiveWriteCount, 2);
+
+    firstWriteCompletion.resolve();
+    secondWriteCompletion.resolve();
+    await Promise.all([writeFirstFile, writeSecondFile]);
+  });
+
+  it('releases queued writes when maintenance fails', async () => {
+    const coordinator = createTestMaintenanceCoordinator();
+    const maintenance = coordinator.runMaintenance(async (): Promise<void> => {
+      throw new Error('maintenance failed');
+    });
+    const queuedWrite = coordinator.runWrite(async (): Promise<void> => {
+      // The test only verifies that the queued write resumes.
+    });
+    let maintenanceFailure: unknown;
+
+    try {
+      await maintenance;
+    } catch (error) {
+      maintenanceFailure = error;
+    }
+
+    await queuedWrite;
+
+    assert.strictEqual(maintenanceFailure instanceof Error, true);
+  });
+
+  it('serializes concurrent maintenance operations', async () => {
+    const coordinator = createTestMaintenanceCoordinator();
+    const firstMaintenanceCompletion = createDeferredCompletion();
+    let activeMaintenanceCount = 0;
+    let maximumActiveMaintenanceCount = 0;
+
+    const firstMaintenance = coordinator.runMaintenance(async (): Promise<void> => {
+      activeMaintenanceCount += 1;
+      maximumActiveMaintenanceCount = Math.max(maximumActiveMaintenanceCount, activeMaintenanceCount);
+      await firstMaintenanceCompletion.promise;
+      activeMaintenanceCount -= 1;
+    });
+    const secondMaintenance = coordinator.runMaintenance(async (): Promise<void> => {
+      activeMaintenanceCount += 1;
+      maximumActiveMaintenanceCount = Math.max(maximumActiveMaintenanceCount, activeMaintenanceCount);
+      activeMaintenanceCount -= 1;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.strictEqual(maximumActiveMaintenanceCount, 1);
+
+    firstMaintenanceCompletion.resolve();
+    await Promise.all([firstMaintenance, secondMaintenance]);
+  });
+});

--- a/electron/src/logging/logMaintenance.ts
+++ b/electron/src/logging/logMaintenance.ts
@@ -1,0 +1,142 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export type LogMaintenanceCoordinator = {
+  runMaintenance<Result>(operation: () => Promise<Result>): Promise<Result>;
+  runWrite<Result>(operation: () => Promise<Result>): Promise<Result>;
+};
+
+export type CreateLogMaintenanceCoordinatorDependencies = {
+  fireAndForget: (asyncAction: () => Promise<unknown>) => void;
+};
+
+type QueuedMaintenance = {
+  operation: () => Promise<void>;
+};
+
+type QueuedWrite = () => void;
+
+export function createLogMaintenanceCoordinator(
+  dependencies: CreateLogMaintenanceCoordinatorDependencies,
+): LogMaintenanceCoordinator {
+  let activeWriteCount = 0;
+  let maintenanceRequested = false;
+  let maintenanceRunning = false;
+  let queuedMaintenances: QueuedMaintenance[] = [];
+  let queuedWrites: QueuedWrite[] = [];
+
+  function startQueuedWrites(): void {
+    const writesToStart = queuedWrites;
+    queuedWrites = [];
+
+    for (const startWrite of writesToStart) {
+      startWrite();
+    }
+  }
+
+  function finishMaintenance(): void {
+    maintenanceRunning = false;
+
+    if (queuedMaintenances.length > 0) {
+      dependencies.fireAndForget(startNextMaintenance);
+
+      return;
+    }
+
+    maintenanceRequested = false;
+    startQueuedWrites();
+  }
+
+  function releaseWrite(): void {
+    activeWriteCount -= 1;
+    dependencies.fireAndForget(startNextMaintenance);
+  }
+
+  async function startWrite<Result>(
+    operation: () => Promise<Result>,
+    resolve: (result: Result) => void,
+    reject: (error: unknown) => void,
+  ): Promise<void> {
+    activeWriteCount += 1;
+
+    try {
+      const result = await operation();
+
+      resolve(result);
+    } catch (error) {
+      reject(error);
+    } finally {
+      releaseWrite();
+    }
+  }
+
+  async function startNextMaintenance(): Promise<void> {
+    if (maintenanceRunning || activeWriteCount !== 0 || queuedMaintenances.length === 0) {
+      return;
+    }
+
+    maintenanceRunning = true;
+    const nextMaintenance = queuedMaintenances[0];
+    queuedMaintenances = queuedMaintenances.toSpliced(0, 1);
+
+    try {
+      await nextMaintenance.operation();
+    } catch {
+      // The queued operation rejects the public maintenance promise itself.
+    } finally {
+      finishMaintenance();
+    }
+  }
+
+  function runWrite<Result>(operation: () => Promise<Result>): Promise<Result> {
+    return new Promise<Result>((resolve, reject) => {
+      const startCurrentWrite = (): void => {
+        dependencies.fireAndForget(() => startWrite(operation, resolve, reject));
+      };
+
+      if (maintenanceRequested === false && maintenanceRunning === false) {
+        startCurrentWrite();
+
+        return;
+      }
+
+      queuedWrites = [...queuedWrites, startCurrentWrite];
+    });
+  }
+
+  function runMaintenance<Result>(operation: () => Promise<Result>): Promise<Result> {
+    return new Promise<Result>((resolve, reject) => {
+      const queuedOperation = async (): Promise<void> => {
+        try {
+          const result = await operation();
+
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      };
+
+      maintenanceRequested = true;
+      queuedMaintenances = [...queuedMaintenances, {operation: queuedOperation}];
+      dependencies.fireAndForget(startNextMaintenance);
+    });
+  }
+
+  return {runMaintenance, runWrite};
+}

--- a/electron/src/logging/logStartup.test.main.ts
+++ b/electron/src/logging/logStartup.test.main.ts
@@ -1,0 +1,93 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {initializeDesktopLogLifecycle} from './logStartup';
+
+function createDeferredCompletion(): {promise: Promise<void>; resolve: () => void} {
+  let resolvePromise: () => void = () => {
+    // The resolver is replaced by the Promise constructor.
+  };
+  const promise = new Promise<void>(resolve => {
+    resolvePromise = resolve;
+  });
+
+  return {promise, resolve: resolvePromise};
+}
+
+describe('desktop log startup', () => {
+  it('completes cleanup before scheduling and initializing webview logging', async () => {
+    const events: string[] = [];
+    const cleanupCompletion = createDeferredCompletion();
+    const startup = initializeDesktopLogLifecycle({
+      async initializeWebviewLogging(): Promise<void> {
+        events.push('initialize-webview-logging');
+      },
+      reportCleanupFailure(): void {
+        events.push('cleanup-failed');
+      },
+      async runInitialCleanup(): Promise<void> {
+        events.push('cleanup-started');
+        await cleanupCompletion.promise;
+        events.push('cleanup-completed');
+      },
+      schedulePeriodicCleanup(): void {
+        events.push('schedule-cleanup');
+      },
+    });
+
+    await Promise.resolve();
+
+    assert.deepStrictEqual(events, ['cleanup-started']);
+
+    cleanupCompletion.resolve();
+    await startup;
+
+    assert.deepStrictEqual(events, [
+      'cleanup-started',
+      'cleanup-completed',
+      'schedule-cleanup',
+      'initialize-webview-logging',
+    ]);
+  });
+
+  it('reports cleanup failure and continues startup', async () => {
+    const events: string[] = [];
+    const cleanupFailure = new Error('cleanup failed');
+
+    await initializeDesktopLogLifecycle({
+      async initializeWebviewLogging(): Promise<void> {
+        events.push('initialize-webview-logging');
+      },
+      reportCleanupFailure(error: unknown): void {
+        assert.strictEqual(error, cleanupFailure);
+        events.push('cleanup-failed');
+      },
+      async runInitialCleanup(): Promise<void> {
+        throw cleanupFailure;
+      },
+      schedulePeriodicCleanup(): void {
+        events.push('schedule-cleanup');
+      },
+    });
+
+    assert.deepStrictEqual(events, ['cleanup-failed', 'schedule-cleanup', 'initialize-webview-logging']);
+  });
+});

--- a/electron/src/logging/logStartup.ts
+++ b/electron/src/logging/logStartup.ts
@@ -17,21 +17,22 @@
  *
  */
 
-export type UnrefableInterval = {
-  unref: () => void;
+export type InitializeDesktopLogLifecycleParameters = {
+  initializeWebviewLogging: () => Promise<void>;
+  reportCleanupFailure: (error: unknown) => void;
+  runInitialCleanup: () => Promise<void>;
+  schedulePeriodicCleanup: () => void;
 };
 
-export type ScheduleLogCleanupParameters = {
-  fireAndForget: (asyncAction: () => Promise<unknown>) => void;
-  intervalMilliseconds: number;
-  runCleanup: () => Promise<void>;
-  setInterval: (callback: () => void, intervalMilliseconds: number) => UnrefableInterval;
-};
+export async function initializeDesktopLogLifecycle(
+  parameters: InitializeDesktopLogLifecycleParameters,
+): Promise<void> {
+  try {
+    await parameters.runInitialCleanup();
+  } catch (error) {
+    parameters.reportCleanupFailure(error);
+  }
 
-export function scheduleLogCleanup(parameters: ScheduleLogCleanupParameters): void {
-  const cleanupInterval = parameters.setInterval(() => {
-    parameters.fireAndForget(parameters.runCleanup);
-  }, parameters.intervalMilliseconds);
-
-  cleanupInterval.unref();
+  parameters.schedulePeriodicCleanup();
+  await parameters.initializeWebviewLogging();
 }

--- a/electron/src/logging/loggerUtils.ts
+++ b/electron/src/logging/loggerUtils.ts
@@ -21,9 +21,9 @@ import * as fs from 'fs-extra';
 
 import * as path from 'path';
 
-import {getActiveLogFilePaths} from './desktopLogWriter';
+import {runDesktopLogCleanupWithinMaintenance, runDesktopLogMaintenance} from './desktopLogWriter';
 import {getLogger} from './getLogger';
-import {cleanupDesktopLogs, DESKTOP_LOG_RETENTION_POLICY} from './logCleanup';
+import {gatherLogFiles} from './logExport';
 import {getLogFilenames as getLogFilenamesFromRoot, LogFileDiscoveryOptions} from './logFiles';
 import {getLogDirectory} from './logPaths';
 
@@ -34,26 +34,20 @@ export function getLogFilenames(parameters: LogFileDiscoveryOptions): string[] {
 }
 
 export async function gatherLogs(): Promise<Record<string, Uint8Array>> {
-  const logFiles: Record<string, Uint8Array> = {};
   const logDirectory = getLogDirectory();
 
-  await cleanupDesktopLogs({
-    activeFilePaths: getActiveLogFilePaths(),
+  return gatherLogFiles({
+    cleanup: runDesktopLogCleanupWithinMaintenance,
+    discoverLogFilePaths: (): readonly string[] => {
+      return getLogFilenames({absolute: false, baseDirectory: logDirectory});
+    },
     logDirectory,
-    policy: DESKTOP_LOG_RETENTION_POLICY,
-  });
-
-  const relativeFilePaths = getLogFilenames({absolute: false, baseDirectory: logDirectory});
-
-  for (const relativeFilePath of relativeFilePaths) {
-    const resolvedPath = path.join(logDirectory, relativeFilePath);
-    try {
-      const fileContent = await fs.readFile(resolvedPath);
-      logFiles[relativeFilePath] = fileContent;
-    } catch (error) {
+    readFile: (filePath: string): Promise<Uint8Array> => {
+      return fs.readFile(filePath);
+    },
+    reportReadFailure: (_filePath: string, error: unknown): void => {
       logger.error(error);
-    }
-  }
-
-  return logFiles;
+    },
+    runMaintenance: runDesktopLogMaintenance,
+  });
 }

--- a/electron/src/mainProcess.ts
+++ b/electron/src/mainProcess.ts
@@ -53,16 +53,17 @@ import {
 import {CustomProtocolHandler} from './lib/CoreProtocol';
 import {downloadImage} from './lib/download';
 import {EVENT_TYPE} from './lib/eventType';
+import {createFireAndForgetInvoker} from './lib/fireAndForgetInvoker';
 import {forwardWrapperReloadRequest} from './lib/forwardWrapperReloadRequest';
 import {deleteAccount} from './lib/LocalAccountDeletion';
 import {getOpenGraphDataAsync} from './lib/openGraph';
 import {showErrorDialog} from './lib/showDialog';
 import * as locale from './locale';
-import {getActiveLogFilePaths, writeBoundedLogMessage} from './logging/desktopLogWriter';
+import {runDesktopLogCleanup, writeBoundedLogMessage} from './logging/desktopLogWriter';
 import {ENABLE_LOGGING, getLogger} from './logging/getLogger';
-import {cleanupDesktopLogs, DESKTOP_LOG_RETENTION_POLICY} from './logging/logCleanup';
 import {scheduleLogCleanup} from './logging/logCleanupScheduler';
 import {getLogDirectory, getMainProcessLogPath, getWebViewLogPath} from './logging/logPaths';
+import {initializeDesktopLogLifecycle} from './logging/logStartup';
 import {getManagedConfig} from './managed/ManagedConfig';
 import {developerMenu, openDevTools} from './menu/developer';
 import * as systemMenu from './menu/system';
@@ -84,15 +85,12 @@ import * as WindowUtil from './window/WindowUtil';
 const MAIN_PROCESS_LOGGER_NAME = 'main.js';
 const LOG_CLEANUP_INTERVAL_MILLISECONDS = 60 * 60 * 1_000;
 const logger = getLogger(MAIN_PROCESS_LOGGER_NAME);
+const mainProcessFireAndForgetInvoker = createFireAndForgetInvoker({
+  reportFailure(error: unknown): void {
+    logger.error('Failed to execute a main-process background operation.', error);
+  },
+});
 const configuredUserDataPath = getConfiguredPortableUserDataPath();
-
-function runDesktopLogCleanup(): Promise<void> {
-  return cleanupDesktopLogs({
-    activeFilePaths: getActiveLogFilePaths(),
-    logDirectory: getLogDirectory(),
-    policy: DESKTOP_LOG_RETENTION_POLICY,
-  });
-}
 
 type OpenLinkInNewWindowParameters = {
   accountId: Maybe<string>;
@@ -632,7 +630,7 @@ class ElectronWrapperInit {
       }
 
       this.logger.log('Opening an external window from a webview.');
-      void WindowUtil.openExternal(details.url);
+      mainProcessFireAndForgetInvoker.fireAndForget(() => WindowUtil.openExternal(details.url));
 
       return {action: 'deny'};
     };
@@ -809,13 +807,25 @@ if (lifecycle.isFirstInstance) {
   bindIpcEvents();
   handleAppEvents();
   fs.ensureFileSync(getMainProcessLogPath({date: new Date(), logDirectory: getLogDirectory()}));
-  void runDesktopLogCleanup();
-  scheduleLogCleanup({
-    intervalMilliseconds: LOG_CLEANUP_INTERVAL_MILLISECONDS,
-    runCleanup: runDesktopLogCleanup,
-    setInterval: (callback: () => void, intervalMilliseconds: number): NodeJS.Timeout => {
-      return setInterval(callback, intervalMilliseconds);
-    },
+  mainProcessFireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
+    await initializeDesktopLogLifecycle({
+      async initializeWebviewLogging(): Promise<void> {
+        await new ElectronWrapperInit().run();
+      },
+      reportCleanupFailure(error: unknown): void {
+        logger.error('Failed to complete initial desktop log cleanup.', error);
+      },
+      runInitialCleanup: runDesktopLogCleanup,
+      schedulePeriodicCleanup(): void {
+        scheduleLogCleanup({
+          fireAndForget: mainProcessFireAndForgetInvoker.fireAndForget,
+          intervalMilliseconds: LOG_CLEANUP_INTERVAL_MILLISECONDS,
+          runCleanup: runDesktopLogCleanup,
+          setInterval(callback: () => void, intervalMilliseconds: number): NodeJS.Timeout {
+            return setInterval(callback, intervalMilliseconds);
+          },
+        });
+      },
+    });
   });
-  new ElectronWrapperInit().run().catch(error => logger.error(error));
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27016" title="WPB-27016" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27016</a>  [Web] Fix desktop log rotation, retention, and directory organization
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The new bounded logging implementation still has a few concurrency and cleanup edge cases.

Startup cleanup can overlap with webview logging, cleanup relies on a snapshot of active writes, debug-log export can read while writes are still pending, and empty parent directories are not fully pruned.

Legacy account log matching is also more permissive than necessary.
