### PR TITLE
fix(windows): use actual OS build for MSI version check [WPB-5221]

### DIFF
--- a/bin/build-tools/lib/build-windows-msi.test.ts
+++ b/bin/build-tools/lib/build-windows-msi.test.ts
@@ -110,6 +110,27 @@ describe('build-windows-msi', () => {
   });
 
   describe('customizeMsiProject', () => {
+    it('regression: detects Windows 10 and later from the actual registry build number', () => {
+      const project = `<Product>
+        <Condition Message="Windows 7 and above is required"><![CDATA[Installed OR VersionNT >= 601]]></Condition>
+        <Component>
+          <File Name="Wire.exe" Id="mainExecutable">
+            <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="Wire"/>
+          </File>
+        </Component>
+      </Product>`;
+
+      const result = customizeMsiProject(project, 'wire', 'com.squirrel.wire.wire', 'Wire', 'msi-banner.bmp');
+
+      assert.match(result, /Property Id="WIRE_WINDOWS_BUILD" Secure="yes"/);
+      assert.match(
+        result,
+        /RegistrySearch Id="WireWindowsBuild" Root="HKLM" Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" Name="CurrentBuildNumber" Type="raw" Win64="yes"/,
+      );
+      assert.match(result, /Installed OR WIRE_WINDOWS_BUILD >= 10240/);
+      assert.doesNotMatch(result, /VersionNT >= 603 AND WindowsBuild >= 10240/);
+    });
+
     it('brands the assisted UI and makes the URL protocol and desktop shortcut identity MSI-owned', () => {
       const project = `
         <Product Name="Wire">
@@ -125,8 +146,6 @@ describe('build-windows-msi', () => {
 
       assert.match(result, /WixVariable Id="WixUIBannerBmp" Value="msi-banner\.bmp"/);
       assert.match(result, /Windows 10 or above is required/);
-      assert.match(result, /VersionNT >= 603 AND WindowsBuild >= 10240/);
-      assert.doesNotMatch(result, /VersionNT >= 1000/);
       assert.match(result, /ShortcutProperty Key="System\.AppUserModel\.ID" Value="com\.squirrel\.wire\.wire"/);
       assert.match(result, /RegistryKey Root="HKLM" Key="Software\\Classes\\wire"/);
       assert.match(result, /Value="&quot;\[#mainExecutable\]&quot; &quot;%1&quot;"/);

--- a/bin/build-tools/lib/build-windows-msi.ts
+++ b/bin/build-tools/lib/build-windows-msi.ts
@@ -113,6 +113,9 @@ export function customizeMsiProject(
   const banner = escapeXmlAttribute(bannerFileName);
   const msiProperties = [
     `    <WixVariable Id="WixUIBannerBmp" Value="${banner}"/>`,
+    '    <Property Id="WIRE_WINDOWS_BUILD" Secure="yes">',
+    '      <RegistrySearch Id="WireWindowsBuild" Root="HKLM" Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" Name="CurrentBuildNumber" Type="raw" Win64="yes"/>',
+    '    </Property>',
     '    <Property Id="WIRE_WEBAPP_URL" Secure="yes"/>',
     '    <Property Id="WIRE_CLEAR_WEBAPP_URL" Secure="yes"/>',
     '    <Property Id="WIRE_EXISTING_WEBAPP_URL">',
@@ -129,7 +132,9 @@ export function customizeMsiProject(
   }
   customizedProject = customizedProject.replace(
     electronBuilderOsCondition,
-    '<Condition Message="Windows 10 or above is required"><![CDATA[Installed OR (VersionNT >= 603 AND WindowsBuild >= 10240)]]></Condition>',
+    // Windows Installer can expose compatibility values for its built-in OS properties on modern Windows. Read the
+    // actual build from the registry instead; 10240 is the first public Windows 10 build.
+    '<Condition Message="Windows 10 or above is required"><![CDATA[Installed OR WIRE_WINDOWS_BUILD >= 10240]]></Condition>',
   );
 
   const escapedAppId = escapeXmlAttribute(appId);

--- a/docs/windows-msi.md
+++ b/docs/windows-msi.md
@@ -15,6 +15,8 @@ The Windows Jenkins job uses `yarn build:win:installers` to create the Squirrel 
 
 `-m` disables electron-builder's automatic signing. Jenkins uses this mode because it signs the packaged Windows executables before creating the MSI, and signs the resulting MSI separately with the managed signing service.
 
+The Windows 10 minimum-version check reads `CurrentBuildNumber` from the 64-bit Windows registry. Do not replace it with Windows Installer's built-in version properties, which can report compatibility values on modern Windows.
+
 Interactive installation uses the standard assisted Windows Installer flow with a Wire-branded banner, including welcome, installation location, readiness, progress, and completion pages. The managed deployment defaults create both desktop and Start Menu shortcuts; they are not optional features in the installer UI.
 
 The standard Wire environments have permanent MSI upgrade codes in `build-windows-msi.ts`. Never change an upgrade code after its first release. A custom-branded build must set `WIN_MSI_UPGRADE_CODE` to its own permanent GUID so that it cannot collide with a standard Wire installation. The MSI manufacturer defaults to `Wire Swiss GmbH`; an OEM build can override it with `WIN_MSI_MANUFACTURER`.


### PR DESCRIPTION
## Summary

Fixes the native MSI rejecting supported Windows 10/11 systems. The correction made during #9722 still trusted Windows Installer's `WindowsBuild` property, which can report a compatibility value; it rejected Windows 11 Pro 10.0.26200 as unsupported.

The launch condition now reads the actual `CurrentBuildNumber` from the 64-bit Windows registry and requires build 10240 or later. `Installed OR ...` preserves repair and uninstall, and missing registry data fails closed for a fresh install.

Adds a focused regression test and documentation. The Squirrel/EXE path is unchanged.

## Validation

- 33 build-tool tests, lint and Semgrep pass
- generated MSI database and payload inspected successfully
- interactive install, repair, quiet install/uninstall and `wire:` protocol registration pass on the affected Windows 11 machine

[WPB-5221](https://wearezeta.atlassian.net/browse/WPB-5221) · [Microsoft compatibility-property documentation](https://learn.microsoft.com/en-us/troubleshoot/windows-client/application-management/versionnt-value-for-windows-10-server)


[WPB-5221]: https://wearezeta.atlassian.net/browse/WPB-5221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ