### PR TITLE
Register webview handlers before log cleanup [WPB-27016]

### DIFF
--- a/electron/src/lib/applicationBootstrap.test.main.ts
+++ b/electron/src/lib/applicationBootstrap.test.main.ts
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as assert from 'assert';
+
+import {initializeFirstInstance} from './applicationBootstrap';
+
+describe('first-instance application bootstrap', () => {
+  it('initializes Electron handlers before app events and log maintenance', () => {
+    const events: string[] = [];
+
+    initializeFirstInstance({
+      bindIpcEvents() {
+        events.push('bind-ipc-events');
+      },
+      ensureMainProcessLogFile() {
+        events.push('ensure-main-process-log-file');
+      },
+      handleAppEvents() {
+        events.push('handle-app-events');
+      },
+      initializeElectronWrapper() {
+        events.push('initialize-electron-wrapper');
+      },
+      startDesktopLogLifecycle() {
+        events.push('start-desktop-log-lifecycle');
+      },
+    });
+
+    const actualCriticalEvents = events.filter(event =>
+      ['initialize-electron-wrapper', 'handle-app-events', 'start-desktop-log-lifecycle'].includes(event),
+    );
+    const expectedCriticalEvents = ['initialize-electron-wrapper', 'handle-app-events', 'start-desktop-log-lifecycle'];
+
+    assert.deepStrictEqual(actualCriticalEvents, expectedCriticalEvents);
+  });
+});

--- a/electron/src/lib/applicationBootstrap.ts
+++ b/electron/src/lib/applicationBootstrap.ts
@@ -17,18 +17,19 @@
  *
  */
 
-export type InitializeDesktopLogLifecycleOptions = {
-  reportCleanupFailure: (error: unknown) => void;
-  runInitialCleanup: () => Promise<void>;
-  schedulePeriodicCleanup: () => void;
+export type InitializeFirstInstanceOptions = {
+  bindIpcEvents: () => void;
+  ensureMainProcessLogFile: () => void;
+  handleAppEvents: () => void;
+  initializeElectronWrapper: () => void;
+  startDesktopLogLifecycle: () => void;
 };
 
-export async function initializeDesktopLogLifecycle(options: InitializeDesktopLogLifecycleOptions): Promise<void> {
-  try {
-    await options.runInitialCleanup();
-  } catch (error) {
-    options.reportCleanupFailure(error);
-  }
-
-  options.schedulePeriodicCleanup();
+export function initializeFirstInstance(options: InitializeFirstInstanceOptions): void {
+  options.bindIpcEvents();
+  options.ensureMainProcessLogFile();
+  // Electron does not replay web-contents-created, so handlers must be registered before app events can create windows.
+  options.initializeElectronWrapper();
+  options.handleAppEvents();
+  options.startDesktopLogLifecycle();
 }

--- a/electron/src/logging/logStartup.test.main.ts
+++ b/electron/src/logging/logStartup.test.main.ts
@@ -33,22 +33,19 @@ function createDeferredCompletion(): {promise: Promise<void>; resolve: () => voi
 }
 
 describe('desktop log startup', () => {
-  it('completes cleanup before scheduling and initializing webview logging', async () => {
+  it('completes initial cleanup before scheduling periodic cleanup', async () => {
     const events: string[] = [];
     const cleanupCompletion = createDeferredCompletion();
     const startup = initializeDesktopLogLifecycle({
-      async initializeWebviewLogging(): Promise<void> {
-        events.push('initialize-webview-logging');
-      },
-      reportCleanupFailure(): void {
+      reportCleanupFailure() {
         events.push('cleanup-failed');
       },
-      async runInitialCleanup(): Promise<void> {
+      async runInitialCleanup() {
         events.push('cleanup-started');
         await cleanupCompletion.promise;
         events.push('cleanup-completed');
       },
-      schedulePeriodicCleanup(): void {
+      schedulePeriodicCleanup() {
         events.push('schedule-cleanup');
       },
     });
@@ -60,12 +57,7 @@ describe('desktop log startup', () => {
     cleanupCompletion.resolve();
     await startup;
 
-    assert.deepStrictEqual(events, [
-      'cleanup-started',
-      'cleanup-completed',
-      'schedule-cleanup',
-      'initialize-webview-logging',
-    ]);
+    assert.deepStrictEqual(events, ['cleanup-started', 'cleanup-completed', 'schedule-cleanup']);
   });
 
   it('reports cleanup failure and continues startup', async () => {
@@ -73,21 +65,18 @@ describe('desktop log startup', () => {
     const cleanupFailure = new Error('cleanup failed');
 
     await initializeDesktopLogLifecycle({
-      async initializeWebviewLogging(): Promise<void> {
-        events.push('initialize-webview-logging');
-      },
-      reportCleanupFailure(error: unknown): void {
+      reportCleanupFailure(error: unknown) {
         assert.strictEqual(error, cleanupFailure);
         events.push('cleanup-failed');
       },
-      async runInitialCleanup(): Promise<void> {
+      async runInitialCleanup() {
         throw cleanupFailure;
       },
-      schedulePeriodicCleanup(): void {
+      schedulePeriodicCleanup() {
         events.push('schedule-cleanup');
       },
     });
 
-    assert.deepStrictEqual(events, ['cleanup-failed', 'schedule-cleanup', 'initialize-webview-logging']);
+    assert.deepStrictEqual(events, ['cleanup-failed', 'schedule-cleanup']);
   });
 });

--- a/electron/src/mainProcess.ts
+++ b/electron/src/mainProcess.ts
@@ -47,6 +47,7 @@ import {WebAppEvents} from '@wireapp/webapp-events';
 
 import * as ProxyAuth from './auth/ProxyAuth';
 import {getPictureInPictureCallWindowOptions, isPictureInPictureCallWindow} from './calling/PictureInPictureCall';
+import {initializeFirstInstance} from './lib/applicationBootstrap';
 import {
   attachTo as attachCertificateVerifyProcManagerTo,
   setCertificateVerifyProc,
@@ -595,7 +596,7 @@ class ElectronWrapperInit {
     ipcMain.on(WebAppEvents.LIFECYCLE.SSO_WINDOW_FOCUS, this.focusSSOWindow);
   }
 
-  async run(): Promise<void> {
+  run(): void {
     this.logger.log('webviewProtection init');
     this.webviewProtection();
   }
@@ -813,28 +814,38 @@ lifecycle.addRelaunchListeners(async () => {
 // Stop further execution on update to prevent second tray icon
 if (lifecycle.isFirstInstance) {
   addLinuxWorkarounds();
-  bindIpcEvents();
-  handleAppEvents();
-  fs.ensureFileSync(getMainProcessLogPath({date: new Date(), logDirectory: getLogDirectory()}));
-  mainProcessFireAndForgetInvoker.fireAndForget(async (): Promise<void> => {
-    await initializeDesktopLogLifecycle({
-      async initializeWebviewLogging(): Promise<void> {
-        await new ElectronWrapperInit().run();
-      },
-      reportCleanupFailure(error: unknown): void {
-        logger.error('Failed to complete initial desktop log cleanup.', error);
-      },
-      runInitialCleanup: runDesktopLogCleanup,
-      schedulePeriodicCleanup(): void {
-        scheduleLogCleanup({
-          fireAndForget: mainProcessFireAndForgetInvoker.fireAndForget,
-          intervalMilliseconds: LOG_CLEANUP_INTERVAL_MILLISECONDS,
-          runCleanup: runDesktopLogCleanup,
-          setInterval(callback: () => void, intervalMilliseconds: number): NodeJS.Timeout {
-            return setInterval(callback, intervalMilliseconds);
+  initializeFirstInstance({
+    bindIpcEvents,
+    ensureMainProcessLogFile() {
+      fs.ensureFileSync(getMainProcessLogPath({date: new Date(), logDirectory: getLogDirectory()}));
+    },
+    handleAppEvents,
+    initializeElectronWrapper() {
+      try {
+        new ElectronWrapperInit().run();
+      } catch (error) {
+        logger.error(error);
+      }
+    },
+    startDesktopLogLifecycle() {
+      mainProcessFireAndForgetInvoker.fireAndForget(async () => {
+        await initializeDesktopLogLifecycle({
+          reportCleanupFailure(error: unknown) {
+            logger.error('Failed to complete initial desktop log cleanup.', error);
+          },
+          runInitialCleanup: runDesktopLogCleanup,
+          schedulePeriodicCleanup() {
+            scheduleLogCleanup({
+              fireAndForget: mainProcessFireAndForgetInvoker.fireAndForget,
+              intervalMilliseconds: LOG_CLEANUP_INTERVAL_MILLISECONDS,
+              runCleanup: runDesktopLogCleanup,
+              setInterval(callback: () => void, intervalMilliseconds: number): NodeJS.Timeout {
+                return setInterval(callback, intervalMilliseconds);
+              },
+            });
           },
         });
-      },
-    });
+      });
+    },
   });
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27016" title="WPB-27016" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27016</a>  [Web] Fix desktop log rotation, retention, and directory organization
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Registers the Electron/WebView handlers synchronously during application startup instead of waiting for the initial desktop log cleanup to complete.

The previous startup ordering introduced in the logging lifecycle changes could delay `ElectronWrapperInit` until after the main `BrowserWindow` had already been created. Because Electron does not replay `web-contents-created`, this could prevent the corresponding `will-attach-webview` handler from being installed for that window.

That handler configures the WebView preload used for Desktop/WebApp communication. Missing it can therefore affect application startup and functionality such as reporting the WebApp and AVS versions.

Initial log cleanup remains asynchronous. Concurrent startup log writes continue to be coordinated through the existing log maintenance coordinator, which queues writes while maintenance is running and waits for active writes before cleanup.