### PR TITLE
feat: remove device enrollment check [WPB-28485]

### DIFF
--- a/electron/src/managed/backends/windows.ts
+++ b/electron/src/managed/backends/windows.ts
@@ -18,12 +18,7 @@
  */
 
 import {getLogger} from '../../logging/getLogger';
-import {
-  APPLOCK_OVERRIDE_KEY,
-  WINDOWS_CLOUD_DOMAIN_JOIN_KEY,
-  WINDOWS_ENROLLMENTS_KEY,
-  WINDOWS_POLICY_KEY,
-} from '../constants';
+import {APPLOCK_OVERRIDE_KEY, WINDOWS_POLICY_KEY} from '../constants';
 
 const logger = getLogger('ManagedConfig/windows');
 
@@ -62,14 +57,6 @@ function valuesOf(registry: RegistryJs, hive: number, subkey: string): RegistryV
   }
 }
 
-function subkeysOf(registry: RegistryJs, hive: number, subkey: string): string[] {
-  try {
-    return registry.enumerateKeys(hive, subkey) ?? [];
-  } catch {
-    return [];
-  }
-}
-
 // Treats `1` (REG_DWORD) and `"1"`/`"true"` (REG_SZ) as the enabled override flag.
 function isOverrideEnabled(value: RegistryValue): boolean {
   if (value.name !== APPLOCK_OVERRIDE_KEY) {
@@ -87,25 +74,10 @@ function hasWirePolicyPayload(registry: RegistryJs): boolean {
   );
 }
 
-// True when the device is MDM-enrolled or Azure AD / Entra joined.
-function isDeviceEnrolled(registry: RegistryJs): boolean {
-  const {HKEY} = registry;
-
-  const isMdmEnrolled = subkeysOf(registry, HKEY.HKEY_LOCAL_MACHINE, WINDOWS_ENROLLMENTS_KEY).some(enrollmentKey => {
-    const values = valuesOf(registry, HKEY.HKEY_LOCAL_MACHINE, `${WINDOWS_ENROLLMENTS_KEY}\\${enrollmentKey}`);
-    return values.some(({name}) => name === 'UPN' || name === 'ProviderID');
-  });
-  if (isMdmEnrolled) {
-    return true;
-  }
-
-  return subkeysOf(registry, HKEY.HKEY_LOCAL_MACHINE, WINDOWS_CLOUD_DOMAIN_JOIN_KEY).length > 0;
-}
-
 export function isDeviceManagedWindows(): boolean {
   const registry = loadRegistry();
   if (!registry) {
     return false;
   }
-  return hasWirePolicyPayload(registry) || isDeviceEnrolled(registry);
+  return hasWirePolicyPayload(registry);
 }

--- a/electron/src/managed/constants.ts
+++ b/electron/src/managed/constants.ts
@@ -34,12 +34,6 @@ export const APPLOCK_OVERRIDE_KEY = 'applockOverride';
 /** Windows: machine-wide Group Policy key. The `APPLOCK_OVERRIDE_KEY` value under it drives the override. */
 export const WINDOWS_POLICY_KEY = 'SOFTWARE\\Policies\\Wire';
 
-/** Windows: MDM enrollment registry. A subkey carrying a `UPN`/`ProviderID` means the device is enrolled. */
-export const WINDOWS_ENROLLMENTS_KEY = 'SOFTWARE\\Microsoft\\Enrollments';
-
-/** Windows: Azure AD / Entra device join. A subkey under JoinInfo means the device is joined. */
-export const WINDOWS_CLOUD_DOMAIN_JOIN_KEY = 'SYSTEM\\CurrentControlSet\\Control\\CloudDomainJoin\\JoinInfo';
-
 // macOS reads `APPLOCK_OVERRIDE_KEY` from the app's defaults domain (pushed via an MDM AppConfig profile).
 
 /** Linux: machine-wide managed config file holding the `APPLOCK_OVERRIDE_KEY` flag. */


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28485" title="WPB-28485" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28485</a>  [Windwos]PM-35 Feature works even with missing Registry Key
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description

Remove device enrollment logic to only rely on MDM config