### PR TITLE
Increase desktop log retention size limit [WPB-27016]

### DIFF
--- a/electron/src/logging/logCleanup.test.main.ts
+++ b/electron/src/logging/logCleanup.test.main.ts
@@ -26,11 +26,14 @@ import * as path from 'path';
 import {
   createLogCleanup,
   createLogCleanupFileSystemDependencies,
+  DESKTOP_LOG_MAXIMUM_AGE_MILLISECONDS,
+  DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES,
+  DESKTOP_LOG_RETENTION_POLICY,
   LogCleanupDependencies,
   RunLogCleanupParameters,
 } from './logCleanup';
 import {LogDirectoryCleanupResult} from './logDirectoryCleanup';
-import {LogFileMetadata} from './logRetention';
+import {LogFileMetadata, LogRetentionPolicy} from './logRetention';
 
 import {withTemporaryDirectory} from '../../test/withTemporaryDirectory';
 
@@ -38,6 +41,16 @@ type CleanupTestState = {
   failures: string[];
   removedDirectories: string[];
   removedFiles: string[];
+};
+
+const testLogRetentionPolicy: LogRetentionPolicy = {
+  maximumAgeMilliseconds: 100,
+  maximumTotalSizeBytes: 100,
+};
+
+type CleanupTestOptions = {
+  activeFilePaths: ReadonlySet<string>;
+  policy?: LogRetentionPolicy;
 };
 
 function createCleanupTestDependencies(
@@ -78,15 +91,79 @@ function createCleanupTestDependencies(
   };
 }
 
-function createCleanupParameters(activeFilePaths: ReadonlySet<string>): RunLogCleanupParameters {
+function createCleanupOptions(options: CleanupTestOptions): RunLogCleanupParameters {
+  const retentionPolicy = options.policy ?? testLogRetentionPolicy;
+
   return {
-    activeFilePaths,
+    activeFilePaths: options.activeFilePaths,
     logDirectory: 'logs',
-    policy: {maximumAgeMilliseconds: 100, maximumTotalSizeBytes: 100},
+    policy: retentionPolicy,
   };
 }
 
 describe('desktop log cleanup', () => {
+  it('uses a seven-day age limit and a 500 MiB total size limit', () => {
+    assert.strictEqual(DESKTOP_LOG_MAXIMUM_AGE_MILLISECONDS, 7 * 24 * 60 * 60 * 1_000);
+    assert.strictEqual(DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES, 500 * 1024 * 1024);
+    assert.deepStrictEqual(DESKTOP_LOG_RETENTION_POLICY, {
+      maximumAgeMilliseconds: DESKTOP_LOG_MAXIMUM_AGE_MILLISECONDS,
+      maximumTotalSizeBytes: DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES,
+    });
+  });
+
+  it('retains recent files when total usage is below the desktop total size limit', async () => {
+    const state: CleanupTestState = {failures: [], removedDirectories: [], removedFiles: []};
+    const fileMetadata: LogFileMetadata[] = [
+      {
+        filePath: 'logs/newest.log',
+        fileSizeBytes: DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES - 2,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 999_999,
+      },
+      {
+        filePath: 'logs/second-newest.log',
+        fileSizeBytes: 1,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 999_998,
+      },
+    ];
+    const cleanup = createLogCleanup(createCleanupTestDependencies(fileMetadata, state));
+
+    await cleanup.run(createCleanupOptions({activeFilePaths: new Set(), policy: DESKTOP_LOG_RETENTION_POLICY}));
+
+    assert.deepStrictEqual(state.removedFiles, []);
+  });
+
+  it('removes the oldest eligible files when desktop total usage exceeds the limit', async () => {
+    const state: CleanupTestState = {failures: [], removedDirectories: [], removedFiles: []};
+    const fileSizeBytes = Math.floor(DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES / 2) + 1;
+    const fileMetadata: LogFileMetadata[] = [
+      {
+        filePath: 'logs/newest.log',
+        fileSizeBytes,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 3,
+      },
+      {
+        filePath: 'logs/oldest.log',
+        fileSizeBytes,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 1,
+      },
+      {
+        filePath: 'logs/middle.log',
+        fileSizeBytes,
+        isSymbolicLink: false,
+        modifiedTimeMilliseconds: 2,
+      },
+    ];
+    const cleanup = createLogCleanup(createCleanupTestDependencies(fileMetadata, state));
+
+    await cleanup.run(createCleanupOptions({activeFilePaths: new Set(), policy: DESKTOP_LOG_RETENTION_POLICY}));
+
+    assert.deepStrictEqual(state.removedFiles, ['logs/oldest.log', 'logs/middle.log']);
+  });
+
   it('removes planned files and their empty parent directories', async () => {
     const state: CleanupTestState = {failures: [], removedDirectories: [], removedFiles: []};
     const fileMetadata: LogFileMetadata[] = [
@@ -105,7 +182,7 @@ describe('desktop log cleanup', () => {
     ];
     const cleanup = createLogCleanup(createCleanupTestDependencies(fileMetadata, state));
 
-    await cleanup.run(createCleanupParameters(new Set()));
+    await cleanup.run(createCleanupOptions({activeFilePaths: new Set()}));
 
     assert.deepStrictEqual(state.removedFiles, ['logs/2026-08-20/accounts/account/console.log']);
     assert.deepStrictEqual(state.removedDirectories, [
@@ -124,7 +201,7 @@ describe('desktop log cleanup', () => {
     ];
     const cleanup = createLogCleanup(createCleanupTestDependencies(fileMetadata, state));
 
-    await cleanup.run(createCleanupParameters(new Set(['logs/active.log'])));
+    await cleanup.run(createCleanupOptions({activeFilePaths: new Set(['logs/active.log'])}));
 
     assert.deepStrictEqual(state.removedFiles, ['logs/eligible.log']);
   });
@@ -147,7 +224,7 @@ describe('desktop log cleanup', () => {
       },
     });
 
-    await cleanup.run(createCleanupParameters(new Set()));
+    await cleanup.run(createCleanupOptions({activeFilePaths: new Set()}));
 
     assert.deepStrictEqual(state.removedFiles, ['logs/second.log']);
     assert.strictEqual(state.failures.length, 1);
@@ -169,9 +246,9 @@ describe('desktop log cleanup', () => {
         return [];
       },
     });
-    const cleanupParameters = createCleanupParameters(new Set());
+    const cleanupOptions = createCleanupOptions({activeFilePaths: new Set()});
 
-    await Promise.all([cleanup.run(cleanupParameters), cleanup.run(cleanupParameters)]);
+    await Promise.all([cleanup.run(cleanupOptions), cleanup.run(cleanupOptions)]);
 
     assert.strictEqual(discoveryCount, 1);
   });

--- a/electron/src/logging/logCleanup.ts
+++ b/electron/src/logging/logCleanup.ts
@@ -30,7 +30,7 @@ import {getLogFilenames} from './logFiles';
 import {LogFileMetadata, LogRetentionPlanParameters, LogRetentionPolicy, planLogCleanup} from './logRetention';
 
 export const DESKTOP_LOG_MAXIMUM_AGE_MILLISECONDS = 7 * 24 * 60 * 60 * 1_000;
-export const DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES = 100 * 1024 * 1024;
+export const DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES = 500 * 1024 * 1024;
 export const DESKTOP_LOG_RETENTION_POLICY: LogRetentionPolicy = {
   maximumAgeMilliseconds: DESKTOP_LOG_MAXIMUM_AGE_MILLISECONDS,
   maximumTotalSizeBytes: DESKTOP_LOG_MAXIMUM_TOTAL_SIZE_BYTES,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27016" title="WPB-27016" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27016</a>  [Web] Fix desktop log rotation, retention, and directory organization
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The initial desktop log retention policy capped total retained logs at 100 MiB.

With real WireInternal usage, we observed roughly 40–60 MiB of logs per day. At that rate, the size limit would start removing logs after around two days, even though the intended normal retention period is seven days.

The size limit should protect against excessive log growth, not routinely shorten the retention period.

---

```sh
[ 160]  .
├── [ 128]  2026-09-02
│   ├── [  96]  accounts
│   │   └── [ 192]  my-account-uuid
│   │       ├── [9.5M]  console.log
│   │       ├── [ 10M]  console.log.1788343593091-0.old
│   │       ├── [ 10M]  console.log.1788344922391-0.old
│   │       └── [ 10M]  console.log.1788355328826-0.old
│   └── [223K]  electron.log
├── [ 128]  2026-09-03
│   ├── [  96]  accounts
│   │   └── [ 256]  my-account-uuid
│   │       ├── [6.4M]  console.log
│   │       ├── [ 10M]  console.log.1788424323833-0.old
│   │       ├── [ 10M]  console.log.1788425495643-0.old
│   │       ├── [ 10M]  console.log.1788437520892-0.old
│   │       ├── [ 10M]  console.log.1788438786888-0.old
│   │       └── [ 10M]  console.log.1788440034416-0.old
│   └── [135K]  electron.log
└── [ 128]  2026-09-04
    ├── [  96]  accounts
    │   └── [  96]  my-account-uuid
    │       └── [361K]  console.log
    └── [4.9K]  electron.log

10 directories, 14 files
```

Which already has a size of 98 MB