### PR TITLE
Use Hosted Dev for desktop smoke tests [WPB-26469]

### DIFF
--- a/jenkins/macOS.groovy
+++ b/jenkins/macOS.groovy
@@ -185,7 +185,7 @@ node("macos") {
   stage('Trigger smoke tests') {
     if (production) {
       try {
-        build job: 'Wrapper_macOS_Smoke_Tests', parameters: [run(description: '', name: 'WRAPPER_BUILD', runId: "Wrapper_macOS_Production#${BUILD_ID}"), string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-master.zinfra.io/')], wait: false
+        build job: 'Wrapper_macOS_Smoke_Tests', parameters: [run(description: '', name: 'WRAPPER_BUILD', runId: "Wrapper_macOS_Production#${BUILD_ID}"), string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-dev.zinfra.io/')], wait: false
       } catch(e) {
         wireSend secret: "${jenkinsbot_secret}", message: "🍏 **${JOB_NAME} Unable to trigger smoke tests for ${version}**\n${BUILD_URL}"
         print e

--- a/jenkins/windows.groovy
+++ b/jenkins/windows.groovy
@@ -161,7 +161,7 @@ node('windows') {
         build job: 'Wrapper_Windows_Smoke_Tests',
           parameters: [
             run   (description: '', name: 'WRAPPER_BUILD', runId: "Wrapper_Windows_Production#${BUILD_ID}"),
-            string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-master.zinfra.io/')
+            string(name: 'WEBAPP_ENV', value: 'https://wire-webapp-dev.zinfra.io/')
           ],
           wait: false
       } catch (e) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-26469" title="WPB-26469" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-26469</a>  [Web] Use a trunk-based automated release process
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
The legacy `wire-webapp-master.zinfra.io` environment is being retired.

Desktop smoke-test automation is Staging-backed, so both production wrapper smoke-test jobs should use Hosted Dev (`wire-webapp-dev.zinfra.io`) rather than the obsolete master frontend.